### PR TITLE
Enable hydrogen for Hillier data

### DIFF
--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -89,7 +89,7 @@ def get_listelements() -> list[tuple[int, list[int | tuple[int, str]]]]:
     # ]
 
     # include everything we have data for
-    # listelements = readhillierdata.extend_ion_list(listelements, maxionstage=5)
+    # listelements = readhillierdata.extend_ion_list(listelements, maxionstage=5, include_hydrogen=False)
     # listelements = readcarsusdata.extend_ion_list(listelements)
     # listelements = readdreamdata.extend_ion_list(listelements)
     # listelements = readfacdata.extend_ion_list(listelements)

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1306,11 +1306,13 @@ def read_hyd_phixsdata():
 
 
 def extend_ion_list(
-    listelements: list[tuple[int, list[Union[int, tuple[int, str]]]]], maxionstage: Optional[int] = None
+    listelements: list[tuple[int, list[Union[int, tuple[int, str]]]]], maxionstage: Optional[int] = None, include_hydrogen: Optional[bool] = False
 ):
     for atomic_number, ion_stage in ions_data:
-        if atomic_number == 1 or (maxionstage is not None and ion_stage > maxionstage):
+        if (maxionstage is not None and ion_stage > maxionstage):
             continue  # skip
+        if not include_hydrogen and atomic_number == 1:
+            continue # skip
         found_element = False
         for tmp_atomic_number, list_ions_handlers in listelements:
             if tmp_atomic_number == atomic_number:


### PR DESCRIPTION
Enables the optional inclusion of hydrogen data from the Hillier date when using the ``extend_ion_list`` function.