### PR TITLE
Pass threshold instead of level energy to photoionisation formula fits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   cache: pip
-                  python-version: '3.11'
+                  python-version-file: .python-version
 
             - name: Install dependencies
               run: |

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -859,7 +859,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                 photoionization_targetconfig_fractions[levelid] = phixs_targetconfigfractions_of_levelname[levelname_b]
 
                 # photoionization_thresholds_ev[levelid] = energy_level.thresholdenergyev
-                photoionization_thresholds_ev[levelid] = hc_in_ev_angstrom / float(energy_level.lambdaangstrom)
+                photoionization_thresholds_ev[levelid] = float(energy_level.thresholdenergyev)
 
     return photoionization_crosssections, photoionization_targetconfig_fractions, photoionization_thresholds_ev
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1301,7 +1301,7 @@ def read_hyd_phixsdata():
                 continue
 
             n, num_points = (int(x) for x in line.split())
-            e_threshold_ev = hc_in_ev_angstrom / float(hillier_energy_levels[n].thresholdenergyev)
+            e_threshold_ev = float(hillier_energy_levels[n].thresholdenergyev)
 
             gaunt_values = []
             for line in fhyd:

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -21,7 +21,7 @@ hillier_rowformat_a = (
 hillier_rowformat_b = (
     "levelname g energyabovegsinpercm freqtentothe15hz thresholdenergyev lambdaangstrom hillierlevelid arad c4 c6"
 )
-hillier_rowformat_c = "levelname g energyabovegsinpercm freqtentothe15hz lambdaangstrom hillierlevelid"
+hillier_rowformat_c = "levelname g energyabovegsinpercm thresholdenergyev lambdaangstrom hillierlevelid"
 hillier_rowformat_d = (
     "levelname g energyabovegsinpercm thresholdenergyev freqtentothe15hz lambdaangstrom hillierlevelid"
 )
@@ -568,7 +568,8 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                     if len(row) == 1 and row_is_all_floats and numpointsexpected > 0:
                         fitcoefficients.append(float(row[0].replace("D", "E")))
                         if len(fitcoefficients) == 3:
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = hc_in_ev_angstrom / float(energy_levels[lowerlevelid].thresholdenergyev)
+                            assert lambda_angstrom > 0
                             phixstables[filenum][lowerlevelname] = get_seaton_phixstable(  # type: ignore
                                 lambda_angstrom, *fitcoefficients
                             )
@@ -585,7 +586,10 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                                     flog, "ERROR: can't have l_end = {} > n - 1 = {}".format(l_end, n - 1)
                                 )
                             else:
-                                lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                                lambda_angstrom = hc_in_ev_angstrom / float(
+                                    energy_levels[lowerlevelid].thresholdenergyev
+                                )
+                                assert lambda_angstrom > 0
                                 phixstables[filenum][lowerlevelname] = get_hydrogenic_nl_phixstable(
                                     lambda_angstrom, n, l_start, l_end
                                 )
@@ -598,7 +602,8 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                         if len(fitcoefficients) == 2:
                             scale, n = fitcoefficients
                             n = int(n)
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = hc_in_ev_angstrom / float(energy_levels[lowerlevelid].thresholdenergyev)
+                            assert lambda_angstrom > 0
                             phixstables[filenum][lowerlevelname] = scale * get_hydrogenic_n_phixstable(
                                 lambda_angstrom, n
                             )
@@ -613,7 +618,8 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                     if len(row) == 1 and row_is_all_floats and numpointsexpected > 0:
                         fitcoefficients.append(float(row[0].replace("D", "E")))
                         if len(fitcoefficients) == 5:
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = hc_in_ev_angstrom / float(energy_levels[lowerlevelid].thresholdenergyev)
+                            assert lambda_angstrom > 0
                             phixstables[filenum][lowerlevelname] = get_opproject_phixstable(
                                 lambda_angstrom, *fitcoefficients
                             )
@@ -625,7 +631,8 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                     if len(row) == 1 and row_is_all_floats and numpointsexpected > 0:
                         fitcoefficients.append(float(row[0].replace("D", "E")))
                         if len(fitcoefficients) == 8:
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = hc_in_ev_angstrom / float(energy_levels[lowerlevelid].thresholdenergyev)
+                            assert lambda_angstrom > 0
                             phixstables[filenum][lowerlevelname] = get_hummer_phixstable(
                                 lambda_angstrom, *fitcoefficients
                             )
@@ -642,7 +649,8 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                     if len(row) == 1 and row_is_all_floats and numpointsexpected > 0:
                         fitcoefficients.append(float(row[0].replace("D", "E")))
                         if len(fitcoefficients) == 4:
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = hc_in_ev_angstrom / float(energy_levels[lowerlevelid].thresholdenergyev)
+                            assert lambda_angstrom > 0
                             phixstables[filenum][lowerlevelname] = get_seaton_phixstable(
                                 lambda_angstrom, *fitcoefficients
                             )
@@ -663,12 +671,19 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                             if l_end > n - 1:
                                 artisatomic.log_and_print(flog, f"ERROR: can't have l_end = {l_end} > n - 1 = {n - 1}")
                             else:
-                                lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
-                                phixstables[filenum][lowerlevelname] = get_hydrogenic_nl_phixstable(
-                                    lambda_angstrom, n, l_start, l_end, nu_o=nu_o
+                                lambda_angstrom = hc_in_ev_angstrom / float(
+                                    energy_levels[lowerlevelid].thresholdenergyev
                                 )
-                                # log_and_print(flog, 'Using offset Hydrogenic split l formula values for level {0}'.format(lowerlevelname))
-                                numpointsexpected = len(phixstables[filenum][lowerlevelname])
+                                if not lambda_angstrom > 0:
+                                    print(
+                                        f"ERROR: lambda_angstrom = {lambda_angstrom:.3f} is not > 0 for {lowerlevelname}"
+                                    )
+                                else:
+                                    phixstables[filenum][lowerlevelname] = get_hydrogenic_nl_phixstable(
+                                        lambda_angstrom, n, l_start, l_end, nu_o=nu_o
+                                    )
+                                    # log_and_print(flog, 'Using offset Hydrogenic split l formula values for level {0}'.format(lowerlevelname))
+                                    numpointsexpected = len(phixstables[filenum][lowerlevelname])
 
                 elif crosssectiontype == 9:
                     if len(row) == 8 and numpointsexpected > 0:
@@ -677,7 +692,8 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                         )
 
                         if len(fitcoefficients) * 8 == numpointsexpected:
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = hc_in_ev_angstrom / float(energy_levels[lowerlevelid].thresholdenergyev)
+                            assert lambda_angstrom > 0
                             phixstables[filenum][lowerlevelname] = get_vy95_phixstable(lambda_angstrom, fitcoefficients)
                             numpointsexpected = len(phixstables[filenum][lowerlevelname])
                             # artisatomic.log_and_print(flog, 'Using Verner & Yakolev 1995 formula values for level {0}'.format(lowerlevelname))
@@ -687,8 +703,9 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                         if lowerlevelname not in phixstables[filenum]:
                             phixstables[filenum][lowerlevelname] = np.zeros((numpointsexpected, 2))
 
-                        lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
-                        thresholdenergyryd = hc_in_ev_angstrom / lambda_angstrom / ryd_to_ev
+                        thresholdenergyev = float(energy_levels[lowerlevelid].thresholdenergyev)
+                        assert thresholdenergyev > 0
+                        thresholdenergyryd = thresholdenergyev / ryd_to_ev
                         enryd = float(row[0].replace("D", "E"))
 
                         if crosssectiontype in [
@@ -1284,7 +1301,7 @@ def read_hyd_phixsdata():
                 continue
 
             n, num_points = (int(x) for x in line.split())
-            e_threshold_ev = hc_in_ev_angstrom / float(hillier_energy_levels[n].lambdaangstrom)
+            e_threshold_ev = hc_in_ev_angstrom / float(hillier_energy_levels[n].thresholdenergyev)
 
             gaunt_values = []
             for line in fhyd:

--- a/tests/cmfgen/checksums.txt
+++ b/tests/cmfgen/checksums.txt
@@ -1,4 +1,4 @@
 b8f6bc739894a563cb55ee83a9a81f8c  adata.txt
 2e3bd7a2e27ee823afa9977e1b4dc2a5  compositiondata.txt
-1c9b987f4eebc22003050a168d0c091d  phixsdata_v2.txt
+732bc44a0cbdf5d146f08926e315614a  phixsdata_v2.txt
 77c382be3756cf6bd7475daffbe2060a  transitiondata.txt


### PR DESCRIPTION
Pass the threshold energy to CMFGEN formula fits, instead of incorrectly passing the level energy. EDIT: Actually the lambda_angstrom does contain the threshold wavelength, so there was not a real bug there.

For tables of cross section samples (type 20, 21, 22), the incorrect threshold gets divided back out again when interpolating on the energy / energy_threshold grid, so these are not affected.