### PR TITLE
Fix Kurucz imported A values (100x too high from missing [Angstrom/nm]^2)

### DIFF
--- a/artisatomic/readcarsusdata.py
+++ b/artisatomic/readcarsusdata.py
@@ -132,7 +132,8 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
 
     dflines = gfall_reader.extract_lines().loc[atomic_number, ion_charge]
 
-    dflines["A"] = dflines["gf"] / (1.49919e-16 * (2 * dflines["j_upper"] + 1) * dflines["wavelength"] ** 2)
+    # wavelengths are in nanometers, so multiply by 10 to get Angstroms
+    dflines["A"] = dflines["gf"] / (1.49919e-16 * (2 * dflines["j_upper"] + 1) * (dflines["wavelength"] * 10.0) ** 2)
 
     transitions, transition_count_of_level_name = read_lines_data(energy_levels, dflines)
     artisatomic.log_and_print(flog, f"Read {len(transitions):d} transitions")


### PR DESCRIPTION
Bug found by @fmcneill49 resulting in A values for imported Kurucz data (e.g. Sr, Y, Zr in Shingles et al. 2023) that were too high by 100x. So far this appears to not alter the conclusion of Shingles+23:
 - the light curve is similar within 25%
 - a similar spectral sequence is still seen, but evolving at a (~30%) slower rate. However, it was already the case that the rate of time evolution already did not AT2017gfo.
 - smaller changes in the spectra features look like they will improve the match to AT2017gfo. In Shingles+23, the spectra were heavily smoothed, which obscured differences at this level of significance. 

Fixed simulations for (unpublished) higher mass models are in-progress, but will likely result is fairly large differences. This could help to fix the excess opacity at early times, and lack of blue flux in the spectra.