### PR TITLE
Fix bugs found in codebase review, vectorize hot loops, and refactor per-ion data handling

### DIFF
--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -311,8 +311,6 @@ def get_default_handler(atomic_number: int, ion_stage: int) -> str:
     #     return "hillier_nahar"  # Hillier/Nahar hybrid
     if atomic_number <= 28 or atomic_number == 56:  # Hillier data only
         return "cmfgen"
-    if atomic_number >= 57:  # DREAM database of Z > 57
-        return "dream"
     if (
         (atomic_number == 38 and ion_stage in [1, 2, 3, 4, 5])
         or (atomic_number == 39 and ion_stage in [2, 3])
@@ -322,7 +320,10 @@ def get_default_handler(atomic_number: int, ion_stage: int) -> str:
         or (atomic_number == 78 and ion_stage in [1, 2, 3])
         or (atomic_number == 79 and ion_stage in [1, 2, 3])
     ):
+        # QUB calculations take precedence over DREAM for W, Pt, and Au
         return "qub_data"
+    if atomic_number >= 57:  # DREAM database of Z > 57
+        return "dream"
     return "kurucz"
 
 
@@ -437,8 +438,9 @@ def read_ion_data(
                 nahar_core_states,
                 nahar_level_index_of_state,
                 nahar_configurations,
-                ionization_energy_ev,
+                nahar_ionization_potential_rydberg,
             ) = readnahardata.read_nahar_energy_level_file(path_nahar_energy_file, atomic_number, ion_stage, flog)
+            ionization_energy_ev = nahar_ionization_potential_rydberg * ryd_to_ev
 
             # keys are (2S+1, L, parity, indexinsymmetry), values are lists of
             # (energy in Rydberg, cross section in Mb) tuples
@@ -468,8 +470,6 @@ def read_ion_data(
                 flog,
                 useallnaharlevels=True,
             )
-
-            print(energy_levels[:3])
 
         elif handler == "hillier_nahar":  # Hillier/Nahar hybrid
             (

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -130,27 +130,29 @@ def drop_handlers(list_ions: list[int | tuple[int, str]]) -> list[int]:
 def add_handler_if_not_set(
     ion_handlers: list[tuple[int, list[int | tuple[int, str]]]], atomic_number: int, ion_stage: int, handler: str
 ) -> list[tuple[int, list[int | tuple[int, str]]]]:
-    ion_handlers_out = ion_handlers.copy()
+    """Return a new ion_handlers list with (ion_stage, handler) added unless the ion is already present.
+
+    The input list is not modified, so the return value must be used.
+    """
+
+    def get_ion_stage(entry: int | tuple[int, str]) -> int:
+        return entry if isinstance(entry, int) else entry[0]
+
+    ion_handlers_out: list[tuple[int, list[int | tuple[int, str]]]] = []
     found_element = False
     for tmp_atomic_number, list_ions_handlers in ion_handlers:
+        list_ions_handlers_out: list[int | tuple[int, str]] = list(list_ions_handlers)
         if tmp_atomic_number == atomic_number:
             found_element = True
-            if ion_stage not in [
-                x[0] if not isinstance(x, int) and hasattr(x, "__getitem__") else x for x in list_ions_handlers
-            ]:
+            if ion_stage not in [get_ion_stage(x) for x in list_ions_handlers_out]:
                 # add an ion that is not present in the element's list
-                list_ions_handlers.append((ion_stage, handler))
-                list_ions_handlers.sort(
-                    key=lambda x: x[0] if not isinstance(x, int) and hasattr(x, "__getitem__") else x
-                )
+                list_ions_handlers_out.append((ion_stage, handler))
+                list_ions_handlers_out.sort(key=get_ion_stage)
+        ion_handlers_out.append((tmp_atomic_number, list_ions_handlers_out))
 
     if not found_element:
-        ion_handlers_out.append(
-            (
-                atomic_number,
-                [(ion_stage, handler)],
-            )
-        )
+        new_element_ions: list[int | tuple[int, str]] = [(ion_stage, handler)]
+        ion_handlers_out.append((atomic_number, new_element_ions))
 
     ion_handlers_out.sort(key=lambda x: x[0])
 
@@ -187,10 +189,6 @@ def leveltuples_to_pldataframe(energy_levels) -> pl.DataFrame:
 
 def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None = None, **kwargs: t.Any) -> None:
     if args is None:
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-            description="Plot estimated spectra from bound-bound transitions.",
-        )
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
             description="Produce an ARTIS atomic database by combining Hillier and Nahar data sets.",
@@ -272,364 +270,316 @@ def clear_files(args: argparse.Namespace) -> None:
 
 
 def process_files(ion_handlers: list[tuple[int, list[int | tuple[int, str]]]], args: argparse.Namespace) -> None:
-    for elementindex, (atomic_number, listions) in enumerate(ion_handlers):
+    for atomic_number, listions in ion_handlers:
         if not listions:
             continue
 
-        nahar_core_states: list[list[readnahardata.NaharCoreState | None]] = [[None] for _ in listions]
-        hillier_photoion_targetconfigs: list = [[] for _ in listions]
+        iondatalist = [
+            read_ion_data(atomic_number, ion_stage_entry, is_top_ion=(i == len(listions) - 1), args=args)
+            for i, ion_stage_entry in enumerate(listions)
+        ]
 
-        # keys are (2S+1, L, parity), values are strings of electron configuration
-        nahar_configurations: list[dict[tuple, str]] = [{} for _ in listions]
+        write_output_files(atomic_number, iondatalist, args)
 
-        # keys are (2S+1, L, parity, indexinsymmetry), values are lists of (energy
-        # in Rydberg, cross section in Mb) tuples
-        nahar_phixs_tables: list[dict[tuple, list[tuple]]] = [{} for _ in listions]
 
-        ionization_energy_ev = [0.0 for _ in listions]
-        thresholds_ev_dict: list[dict] = [{} for _ in listions]
+class IonData(t.NamedTuple):
+    """Levels, transitions, and photoionisation data for a single ion, read from one of the source datasets."""
 
-        # list of named tuples (hillier_transition_row)
-        transitions: list = [[] for _ in listions]
-        transition_count_of_level_name: list[dict] = [{} for _ in listions]
-        upsilondicts: list[dict] = [{} for _ in listions]
+    ion_stage: int
+    handler: str
+    ionization_energy_ev: float
+    dfenergylevels: pl.DataFrame
+    dftransitions: pl.DataFrame
+    transition_count_of_level_name: dict
+    upsilondict: dict
+    # list of readnahardata.NaharCoreState with a dummy None at index zero ([None] if unavailable)
+    nahar_core_states: list
+    # keys are (2S+1, L, parity), values are strings of electron configuration
+    nahar_configurations: dict
+    hillier_photoion_targetconfigs: list | None
+    photoionization_crosssections: t.Any  # cross sections in Mb, indexed by levelid
+    photoionization_targetfractions: list
+    photoionization_thresholds_ev: t.Any  # indexed by levelid
 
-        energy_levels: list = [[] for _ in listions]
-        dfenergylevels_allions: list = [pl.DataFrame() for _ in listions]
-        # index matches level id
-        photoionization_thresholds_ev: list = [[] for _ in listions]
-        photoionization_crosssections: list = [[] for _ in listions]  # list of cross section in Mb
-        photoionization_targetfractions: list = [[] for _ in listions]
 
-        for i, ion_stage in enumerate(listions):
-            handler = None
+def get_default_handler(atomic_number: int, ion_stage: int) -> str:
+    if atomic_number == 2 and ion_stage == 3:
+        return "boyle"
+    if USE_QUB_COBALT and atomic_number == 27:
+        return "qub_cobalt"
+    # if atomic_number in [8, 26] and os.path.isfile(path_nahar_energy_file):
+    #     return "hillier_nahar"  # Hillier/Nahar hybrid
+    if atomic_number <= 28 or atomic_number == 56:  # Hillier data only
+        return "cmfgen"
+    if atomic_number >= 57:  # DREAM database of Z > 57
+        return "dream"
+    if (
+        (atomic_number == 38 and ion_stage in [1, 2, 3, 4, 5])
+        or (atomic_number == 39 and ion_stage in [2, 3])
+        or (atomic_number == 40 and ion_stage in [1, 2, 3])
+        or (atomic_number == 74 and ion_stage in [1, 2, 3])
+        or (atomic_number == 52 and ion_stage in [1, 2, 3, 4, 5])
+        or (atomic_number == 78 and ion_stage in [1, 2, 3])
+        or (atomic_number == 79 and ion_stage in [1, 2, 3])
+    ):
+        return "qub_data"
+    return "kurucz"
 
-            if not isinstance(ion_stage, int):
-                ion_stage, handler = ion_stage
 
-            if handler is None:
-                if atomic_number == 2 and ion_stage == 3:
-                    handler = "boyle"
-                elif USE_QUB_COBALT and atomic_number == 27:
-                    handler = "qub_cobalt"
-                elif False:  # Nahar only, usually just for testing purposes
-                    handler = "nahar"
-                # elif atomic_number in [
-                #     26,
-                # ]:  # atomic_number in [8, 26] and os.path.isfile(path_nahar_energy_file):  # Hillier/Nahar hybrid
-                #     handler = "hiller_nahar"
-                elif atomic_number <= 28 or atomic_number == 56:  # Hillier data only
-                    handler = "cmfgen"
-                elif atomic_number >= 57:  # DREAM database of Z > 57
-                    handler = "dream"
-                elif (
-                    (atomic_number == 38 and ion_stage in [1, 2, 3, 4, 5])
-                    or (atomic_number == 39 and ion_stage in [2, 3])
-                    or (atomic_number == 40 and ion_stage in [1, 2, 3])
-                    or (atomic_number == 74 and ion_stage in [1, 2, 3])
-                    or (atomic_number == 52 and ion_stage in [1, 2, 3, 4, 5])
-                    or (atomic_number == 78 and ion_stage in [1, 2, 3])
-                    or (atomic_number == 79 and ion_stage in [1, 2, 3])
-                ):
-                    handler = "qub_data"
-                else:
-                    handler = "kurucz"
+# handlers whose readers share a common call signature and return
+# (ionization_energy_ev, energy_levels, transitions, transition_count_of_level_name)
+# with an additional upsilondict for qub_data
+simple_handler_readers: dict[str, Callable[..., tuple]] = {
+    "boyle": lambda atomic_number, ion_stage, _flog: readboyledata.read_levels_and_transitions(
+        atomic_number, ion_stage
+    ),
+    "kurucz": readkuruczdata.read_levels_and_transitions,
+    "dream": readdreamdata.read_levels_and_transitions,  # DREAM database of Z >= 57
+    # "lisbon": readlisbondata.read_levels_and_transitions,
+    "floers25calib": lambda atomic_number, ion_stage, flog: readfloers25data.read_levels_and_transitions(
+        atomic_number, ion_stage, flog, calibrated=True
+    ),
+    "floers25uncalib": lambda atomic_number, ion_stage, flog: readfloers25data.read_levels_and_transitions(
+        atomic_number, ion_stage, flog, calibrated=False
+    ),
+    "fac": readfacdata.read_levels_and_transitions,  # early version of floers25 calib data
+    "tanakajplt": readtanakajpltdata.read_levels_and_transitions,  # Tanaka Japan-Lithuania database of 26 <= Z <= 88
+    "gsnist": groundstatesonlynist.read_ground_levels,  # ground states taken from NIST
+    "qub_data": readqubdata.read_qub_levels_and_transitions,  # also returns an upsilondict
+}
 
-            logfilepath = Path(
-                args.output_folder, args.output_folder_logs, f"{elsymbols[atomic_number].lower()}{ion_stage:d}.txt"
-            )
-            with logfilepath.open("w") as flog:
-                log_and_print(
-                    flog,
-                    f"\n===========> Z={atomic_number} {elsymbols[atomic_number]} {roman_numerals[ion_stage]} input:",
-                )
-                log_and_print(flog, f"Source handler: {handler}")
 
-                path_nahar_energy_file = f"atomic-data-nahar/{elsymbols[atomic_number].lower()}{ion_stage:d}.en.ls.txt"
-                path_nahar_px_file = f"atomic-data-nahar/{elsymbols[atomic_number].lower()}{ion_stage:d}.ptpx.txt"
+def read_ion_data(
+    atomic_number: int, ion_stage_entry: int | tuple[int, str], is_top_ion: bool, args: argparse.Namespace
+) -> IonData:
+    """Read a single ion's data from its source dataset."""
+    if isinstance(ion_stage_entry, int):
+        ion_stage = ion_stage_entry
+        handler = get_default_handler(atomic_number, ion_stage)
+    else:
+        ion_stage, handler = ion_stage_entry
 
-                # upsilondatafilenames = {(26, 2): 'fe_ii_upsilon-data.txt', (26, 3): 'fe_iii_upsilon-data.txt'}
-                # if (atomic_number, ion_stage) in upsilondatafilenames:
-                #     upsilonfilename = os.path.join('atomic-data-tiptopbase',
-                #                                    upsilondatafilenames[(atomic_number, ion_stage)])
-                #     log_and_print(flog, f'Reading effective collision strengths from {upsilonfilename}')
-                #     upsilondatadf = pd.read_csv(upsilonfilename,
-                #                                 names=["Z", "ion_stage", "lower", "upper", "upsilon"],
-                #                                 index_col=False, header=None, sep=" ")
-                #     if len(upsilondatadf) > 0:
-                #         for _, row in upsilondatadf.iterrows():
-                #             lower = int(row['lower'])
-                #             upper = int(row['upper'])
-                #             if upper < lower:
-                #                 print(f'Problem in {upsilondatafilenames[(atomic_number, ion_stage)]}, lower {lower} upper {upper}. Swapping lower and upper')
-                #                 old_lower = lower
-                #                 lower = upper
-                #                 upper = old_lower
-                #             if (lower, upper) not in upsilondicts[i]:
-                #                 upsilondicts[i][(lower, upper)] = row['upsilon']
-                #             else:
-                #                 log_and_print(flog, f"Duplicate upsilon value for transition {lower:d} to {upper:d} keeping {upsilondicts[i][(lower, upper)]:5.2e} instead of using {row['upsilon']:5.2e}")
+    ionization_energy_ev = 0.0
+    transition_count_of_level_name: dict = {}
+    upsilondict: dict = {}
+    nahar_core_states: list = [None]
+    nahar_configurations: dict = {}
+    hillier_photoion_targetconfigs = None
+    photoionization_crosssections: t.Any = []  # list of cross section in Mb
+    photoionization_targetfractions: list = []
+    photoionization_thresholds_ev: t.Any = []
 
-                # if False:
-                #     pass
-                hillier_photoion_targetconfigs[i] = None
-
-                # Call readHedata for He III
-                if handler == "boyle":
-                    (
-                        ionization_energy_ev[i],
-                        energy_levels[i],
-                        transitions[i],
-                        transition_count_of_level_name[i],
-                    ) = readboyledata.read_levels_and_transitions(atomic_number, ion_stage)
-
-                elif handler == "qub_cobalt":
-                    if ion_stage in [3, 4]:  # QUB levels and transitions, or single-level Co IV
-                        (
-                            ionization_energy_ev[i],
-                            energy_levels[i],
-                            transitions[i],
-                            transition_count_of_level_name[i],
-                            upsilondicts[i],
-                        ) = readqubdata.read_qub_levels_and_transitions(atomic_number, ion_stage, flog)
-                    else:  # hillier levels and transitions
-                        # if ion_stage == 2:
-                        #     upsilondicts[i] = read_storey_2016_upsilondata(flog)
-                        (
-                            ionization_energy_ev[i],
-                            energy_levels[i],
-                            transitions[i],
-                            transition_count_of_level_name[i],
-                            hillier_levelnamesnoJ_matching_term,
-                        ) = readhillierdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
-
-                    if i < len(listions) - 1 and not args.nophixs:  # don't get cross sections for top ion
-                        (
-                            photoionization_crosssections[i],
-                            photoionization_targetfractions[i],
-                            photoionization_thresholds_ev[i],
-                        ) = readqubdata.read_qub_photoionizations(
-                            atomic_number, ion_stage, energy_levels[i], args, flog
-                        )
-
-                elif handler == "nahar":
-                    (
-                        nahar_energy_levels,
-                        nahar_core_states[i],
-                        nahar_level_index_of_state,
-                        nahar_configurations[i],
-                        ionization_energy_ev[i],
-                    ) = readnahardata.read_nahar_energy_level_file(
-                        path_nahar_energy_file, atomic_number, ion_stage, flog
-                    )
-
-                    if i < len(listions) - 1:  # don't get cross sections for top ion
-                        log_and_print(flog, f"Reading {path_nahar_px_file}")
-                        nahar_phixs_tables[i], thresholds_ev_dict[i] = readnahardata.read_nahar_phixs_tables(
-                            path_nahar_px_file, atomic_number, ion_stage, args
-                        )
-
-                    hillier_levelnamesnoJ_matching_term = defaultdict(list)
-                    hillier_transitions: list = []
-                    hillier_energy_levels = [None]
-                    (
-                        energy_levels[i],
-                        transitions[i],
-                        photoionization_crosssections[i],
-                        photoionization_thresholds_ev[i],
-                    ) = combine_hillier_nahar(
-                        hillier_energy_levels,
-                        hillier_levelnamesnoJ_matching_term,
-                        hillier_transitions,
-                        nahar_energy_levels,
-                        nahar_level_index_of_state,
-                        nahar_configurations[i],
-                        nahar_phixs_tables[i],
-                        thresholds_ev_dict[i],
-                        args,
-                        flog,
-                        useallnaharlevels=True,
-                    )
-
-                    print(energy_levels[i][:3])
-
-                elif handler == "hillier_nahar":  # Hillier/Nahar hybrid
-                    (
-                        nahar_energy_levels,
-                        nahar_core_states[i],
-                        nahar_level_index_of_state,
-                        nahar_configurations[i],
-                        _nahar_ionization_potential_rydberg,
-                    ) = readnahardata.read_nahar_energy_level_file(
-                        path_nahar_energy_file, atomic_number, ion_stage, flog
-                    )
-
-                    (
-                        ionization_energy_ev[i],
-                        hillier_energy_levels,
-                        hillier_transitions,
-                        transition_count_of_level_name[i],
-                        hillier_levelnamesnoJ_matching_term,
-                    ) = readhillierdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
-
-                    if i < len(listions) - 1:  # don't get cross sections for top ion
-                        log_and_print(flog, f"Reading {path_nahar_px_file}")
-                        nahar_phixs_tables[i], thresholds_ev_dict[i] = readnahardata.read_nahar_phixs_tables(
-                            path_nahar_px_file, atomic_number, ion_stage, args
-                        )
-
-                    (
-                        energy_levels[i],
-                        transitions[i],
-                        photoionization_crosssections[i],
-                        photoionization_thresholds_ev[i],
-                    ) = combine_hillier_nahar(
-                        hillier_energy_levels,
-                        hillier_levelnamesnoJ_matching_term,
-                        hillier_transitions,
-                        nahar_energy_levels,
-                        nahar_level_index_of_state,
-                        nahar_configurations[i],
-                        nahar_phixs_tables[i],
-                        thresholds_ev_dict[i],
-                        args,
-                        flog,
-                    )
-                    # reading the collision data (in terms of level names) must be done after the data sets have
-                    # been combined so that the level numbers are correct
-                    if len(upsilondicts[i]) == 0:
-                        upsilondicts[i] = readhillierdata.read_coldata(
-                            atomic_number, ion_stage, energy_levels[i], flog, args
-                        )
-
-                elif handler == "cmfgen":  # Hillier CMFGEN data only
-                    (
-                        ionization_energy_ev[i],
-                        energy_levels[i],
-                        transitions[i],
-                        transition_count_of_level_name[i],
-                        hillier_levelnamesnoJ_matching_term,
-                    ) = readhillierdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
-
-                    if len(upsilondicts[i]) == 0:
-                        upsilondicts[i] = readhillierdata.read_coldata(
-                            atomic_number, ion_stage, energy_levels[i], flog, args
-                        )
-
-                    if i < len(listions) - 1 and not args.nophixs:  # don't get cross sections for top ion
-                        (
-                            photoionization_crosssections[i],
-                            hillier_photoion_targetconfigs[i],
-                            photoionization_thresholds_ev[i],
-                        ) = readhillierdata.read_phixs_tables(atomic_number, ion_stage, energy_levels[i], args, flog)
-                    else:
-                        hillier_photoion_targetconfigs[i] = None
-
-                elif handler == "kurucz":
-                    (
-                        ionization_energy_ev[i],
-                        energy_levels[i],
-                        transitions[i],
-                        transition_count_of_level_name[i],
-                    ) = readkuruczdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
-
-                elif handler == "dream":  # DREAM database of Z >= 57
-                    (
-                        ionization_energy_ev[i],
-                        energy_levels[i],
-                        transitions[i],
-                        transition_count_of_level_name[i],
-                    ) = readdreamdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
-
-                # elif handler == "lisbon":
-                #     (
-                #         ionization_energy_ev[i],
-                #         energy_levels[i],
-                #         transitions[i],
-                #         transition_count_of_level_name[i],
-                #     ) = readlisbondata.read_levels_and_transitions(atomic_number, ion_stage, flog)
-
-                elif handler in {"floers25calib", "floers25uncalib"}:
-                    (
-                        ionization_energy_ev[i],
-                        energy_levels[i],
-                        transitions[i],
-                        transition_count_of_level_name[i],
-                    ) = readfloers25data.read_levels_and_transitions(
-                        atomic_number, ion_stage, flog, calibrated=(handler == "floers25calib")
-                    )
-
-                elif handler == "fac":
-                    # early version of floers25 calib data
-                    (
-                        ionization_energy_ev[i],
-                        energy_levels[i],
-                        transitions[i],
-                        transition_count_of_level_name[i],
-                    ) = readfacdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
-
-                elif handler == "tanakajplt":  # Tanaka Japan-Lithuania database of 26 <= Z <= 88
-                    (
-                        ionization_energy_ev[i],
-                        energy_levels[i],
-                        transitions[i],
-                        transition_count_of_level_name[i],
-                    ) = readtanakajpltdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
-
-                elif handler == "gsnist":  # ground states taken from NIST
-                    (
-                        ionization_energy_ev[i],
-                        energy_levels[i],
-                        transitions[i],
-                        transition_count_of_level_name[i],
-                    ) = groundstatesonlynist.read_ground_levels(atomic_number, ion_stage, flog)
-
-                elif handler == "qub_data":
-                    (
-                        ionization_energy_ev[i],
-                        energy_levels[i],
-                        transitions[i],
-                        transition_count_of_level_name[i],
-                        upsilondicts[i],
-                    ) = readqubdata.read_qub_levels_and_transitions(atomic_number, ion_stage, flog)
-
-                else:
-                    raise ValueError(f"Unknown handler: {handler}")
-
-            dfenergylevels_allions[i] = leveltuples_to_pldataframe(energy_levels[i])
-
-            if (
-                i < len(listions) - 1
-                and not args.nophixs
-                and len(photoionization_crosssections[i]) == 0
-                and args.use_hydrogenic_for_unknown_phixs
-            ):  # don't get cross sections for top ion
-                (
-                    photoionization_crosssections[i],
-                    photoionization_targetfractions[i],
-                    photoionization_thresholds_ev[i],
-                ) = match_hydrogenic_phixs(
-                    atomic_number, dfenergylevels_allions[i], ionization_energy_ev[i], handler, args
-                )
-
-        dftransitions_allions = [t if isinstance(t, pl.DataFrame) else pl.DataFrame(t) for t in transitions]
-
-        write_output_files(
-            elementindex,
-            dfenergylevels_allions,
-            dftransitions_allions,
-            upsilondicts,
-            ionization_energy_ev,
-            transition_count_of_level_name,
-            nahar_core_states,
-            nahar_configurations,
-            hillier_photoion_targetconfigs,
-            photoionization_thresholds_ev,
-            photoionization_targetfractions,
-            photoionization_crosssections,
-            ion_handlers,
-            args,
+    logfilepath = Path(
+        args.output_folder, args.output_folder_logs, f"{elsymbols[atomic_number].lower()}{ion_stage:d}.txt"
+    )
+    with logfilepath.open("w") as flog:
+        log_and_print(
+            flog,
+            f"\n===========> Z={atomic_number} {elsymbols[atomic_number]} {roman_numerals[ion_stage]} input:",
         )
+        log_and_print(flog, f"Source handler: {handler}")
+
+        path_nahar_energy_file = f"atomic-data-nahar/{elsymbols[atomic_number].lower()}{ion_stage:d}.en.ls.txt"
+        path_nahar_px_file = f"atomic-data-nahar/{elsymbols[atomic_number].lower()}{ion_stage:d}.ptpx.txt"
+
+        # upsilondatafilenames = {(26, 2): 'fe_ii_upsilon-data.txt', (26, 3): 'fe_iii_upsilon-data.txt'}
+        # if (atomic_number, ion_stage) in upsilondatafilenames:
+        #     upsilonfilename = os.path.join('atomic-data-tiptopbase',
+        #                                    upsilondatafilenames[(atomic_number, ion_stage)])
+        #     log_and_print(flog, f'Reading effective collision strengths from {upsilonfilename}')
+        #     upsilondatadf = pd.read_csv(upsilonfilename,
+        #                                 names=["Z", "ion_stage", "lower", "upper", "upsilon"],
+        #                                 index_col=False, header=None, sep=" ")
+        #     if len(upsilondatadf) > 0:
+        #         for _, row in upsilondatadf.iterrows():
+        #             lower = int(row['lower'])
+        #             upper = int(row['upper'])
+        #             if upper < lower:
+        #                 print(f'Problem in {upsilondatafilenames[(atomic_number, ion_stage)]}, lower {lower} upper {upper}. Swapping lower and upper')
+        #                 old_lower = lower
+        #                 lower = upper
+        #                 upper = old_lower
+        #             if (lower, upper) not in upsilondict:
+        #                 upsilondict[(lower, upper)] = row['upsilon']
+        #             else:
+        #                 log_and_print(flog, f"Duplicate upsilon value for transition {lower:d} to {upper:d} keeping {upsilondict[(lower, upper)]:5.2e} instead of using {row['upsilon']:5.2e}")
+
+        if handler == "qub_cobalt":
+            if ion_stage in [3, 4]:  # QUB levels and transitions, or single-level Co IV
+                (
+                    ionization_energy_ev,
+                    energy_levels,
+                    transitions,
+                    transition_count_of_level_name,
+                    upsilondict,
+                ) = readqubdata.read_qub_levels_and_transitions(atomic_number, ion_stage, flog)
+            else:  # hillier levels and transitions
+                # if ion_stage == 2:
+                #     upsilondict = read_storey_2016_upsilondata(flog)
+                (
+                    ionization_energy_ev,
+                    energy_levels,
+                    transitions,
+                    transition_count_of_level_name,
+                    hillier_levelnamesnoJ_matching_term,
+                ) = readhillierdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
+
+            if not is_top_ion and not args.nophixs:  # don't get cross sections for top ion
+                (
+                    photoionization_crosssections,
+                    photoionization_targetfractions,
+                    photoionization_thresholds_ev,
+                ) = readqubdata.read_qub_photoionizations(atomic_number, ion_stage, energy_levels, args, flog)
+
+        elif handler == "nahar":  # Nahar only, usually just for testing purposes
+            (
+                nahar_energy_levels,
+                nahar_core_states,
+                nahar_level_index_of_state,
+                nahar_configurations,
+                ionization_energy_ev,
+            ) = readnahardata.read_nahar_energy_level_file(path_nahar_energy_file, atomic_number, ion_stage, flog)
+
+            # keys are (2S+1, L, parity, indexinsymmetry), values are lists of
+            # (energy in Rydberg, cross section in Mb) tuples
+            nahar_phixs_tables: dict = {}
+            thresholds_ev_dict: dict = {}
+            if not is_top_ion:  # don't get cross sections for top ion
+                log_and_print(flog, f"Reading {path_nahar_px_file}")
+                nahar_phixs_tables, thresholds_ev_dict = readnahardata.read_nahar_phixs_tables(
+                    path_nahar_px_file, atomic_number, ion_stage, args
+                )
+
+            (
+                energy_levels,
+                transitions,
+                photoionization_crosssections,
+                photoionization_thresholds_ev,
+            ) = combine_hillier_nahar(
+                [None],
+                defaultdict(list),
+                [],
+                nahar_energy_levels,
+                nahar_level_index_of_state,
+                nahar_configurations,
+                nahar_phixs_tables,
+                thresholds_ev_dict,
+                args,
+                flog,
+                useallnaharlevels=True,
+            )
+
+            print(energy_levels[:3])
+
+        elif handler == "hillier_nahar":  # Hillier/Nahar hybrid
+            (
+                nahar_energy_levels,
+                nahar_core_states,
+                nahar_level_index_of_state,
+                nahar_configurations,
+                _nahar_ionization_potential_rydberg,
+            ) = readnahardata.read_nahar_energy_level_file(path_nahar_energy_file, atomic_number, ion_stage, flog)
+
+            (
+                ionization_energy_ev,
+                hillier_energy_levels,
+                hillier_transitions,
+                transition_count_of_level_name,
+                hillier_levelnamesnoJ_matching_term,
+            ) = readhillierdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
+
+            nahar_phixs_tables = {}
+            thresholds_ev_dict = {}
+            if not is_top_ion:  # don't get cross sections for top ion
+                log_and_print(flog, f"Reading {path_nahar_px_file}")
+                nahar_phixs_tables, thresholds_ev_dict = readnahardata.read_nahar_phixs_tables(
+                    path_nahar_px_file, atomic_number, ion_stage, args
+                )
+
+            (
+                energy_levels,
+                transitions,
+                photoionization_crosssections,
+                photoionization_thresholds_ev,
+            ) = combine_hillier_nahar(
+                hillier_energy_levels,
+                hillier_levelnamesnoJ_matching_term,
+                hillier_transitions,
+                nahar_energy_levels,
+                nahar_level_index_of_state,
+                nahar_configurations,
+                nahar_phixs_tables,
+                thresholds_ev_dict,
+                args,
+                flog,
+            )
+            # reading the collision data (in terms of level names) must be done after the data sets have
+            # been combined so that the level numbers are correct
+            if len(upsilondict) == 0:
+                upsilondict = readhillierdata.read_coldata(atomic_number, ion_stage, energy_levels, flog, args)
+
+        elif handler == "cmfgen":  # Hillier CMFGEN data only
+            (
+                ionization_energy_ev,
+                energy_levels,
+                transitions,
+                transition_count_of_level_name,
+                hillier_levelnamesnoJ_matching_term,
+            ) = readhillierdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
+
+            if len(upsilondict) == 0:
+                upsilondict = readhillierdata.read_coldata(atomic_number, ion_stage, energy_levels, flog, args)
+
+            if not is_top_ion and not args.nophixs:  # don't get cross sections for top ion
+                (
+                    photoionization_crosssections,
+                    hillier_photoion_targetconfigs,
+                    photoionization_thresholds_ev,
+                ) = readhillierdata.read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog)
+            else:
+                hillier_photoion_targetconfigs = None
+
+        elif handler in simple_handler_readers:
+            result = simple_handler_readers[handler](atomic_number, ion_stage, flog)
+            if len(result) == 5:
+                (ionization_energy_ev, energy_levels, transitions, transition_count_of_level_name, upsilondict) = result
+            else:
+                (ionization_energy_ev, energy_levels, transitions, transition_count_of_level_name) = result
+
+        else:
+            raise ValueError(f"Unknown handler: {handler}")
+
+    dfenergylevels = leveltuples_to_pldataframe(energy_levels)
+
+    if (
+        not is_top_ion
+        and not args.nophixs
+        and len(photoionization_crosssections) == 0
+        and args.use_hydrogenic_for_unknown_phixs
+    ):  # don't get cross sections for top ion
+        (
+            photoionization_crosssections,
+            photoionization_targetfractions,
+            photoionization_thresholds_ev,
+        ) = match_hydrogenic_phixs(atomic_number, dfenergylevels, ionization_energy_ev, handler, args)
+
+    dftransitions = transitions if isinstance(transitions, pl.DataFrame) else pl.DataFrame(transitions)
+
+    return IonData(
+        ion_stage=ion_stage,
+        handler=handler,
+        ionization_energy_ev=ionization_energy_ev,
+        dfenergylevels=dfenergylevels,
+        dftransitions=dftransitions,
+        transition_count_of_level_name=transition_count_of_level_name,
+        upsilondict=upsilondict,
+        nahar_core_states=nahar_core_states,
+        nahar_configurations=nahar_configurations,
+        hillier_photoion_targetconfigs=hillier_photoion_targetconfigs,
+        photoionization_crosssections=photoionization_crosssections,
+        photoionization_targetfractions=photoionization_targetfractions,
+        photoionization_thresholds_ev=photoionization_thresholds_ev,
+    )
 
 
 def read_storey_2016_upsilondata(flog) -> dict[tuple[int, int], float]:
@@ -704,9 +654,9 @@ def combine_hillier_nahar(
             if state_tuple in nahar_level_index_of_state:
                 nahar_energy_level = nahar_energy_levels[nahar_level_index_of_state[state_tuple]]
                 nahar_energyabovegsinev = hc_in_ev_cm * nahar_energy_level.energyabovegsinpercm
-            # else:
-            # nahar_energy_level = None
-            # nahar_energyabovegsinev = 999999.
+            else:
+                nahar_energy_level = None
+                nahar_energyabovegsinev = 999999.0
 
             nahar_configuration_this_state = "_CONFIG NOT FOUND_"
             flog.write("\n")
@@ -749,7 +699,7 @@ def combine_hillier_nahar(
                     best_match_score = level_match_scores[0][1]
                     if best_match_score > 0:
                         best_levelname = level_match_scores[0][0]
-                        core_state_id = nahar_energy_levels[nahar_level_index_of_state[state_tuple]].corestateid
+                        core_state_id = nahar_energy_level.corestateid if nahar_energy_level is not None else 0
 
                         confignote = nahar_configurations[state_tuple]
 
@@ -804,8 +754,6 @@ def combine_hillier_nahar(
                 else:
                     flog.write(" (and no matching entry in Nahar energy table, so can't be added)\n")
             else:  # there are Hillier levels matched to this state
-                nahar_energy_level = nahar_energy_levels[nahar_level_index_of_state[state_tuple]]
-                nahar_energyabovegsinev = hc_in_ev_cm * nahar_energy_level.energyabovegsinpercm
                 # avghillierthreshold = weightedavgthresholdinev(
                 #    hillier_energy_levels, hillier_level_ids_matching_this_nahar_state)
                 # strhilliermatchesthreshold = '[' + ', '.join(
@@ -813,15 +761,19 @@ def combine_hillier_nahar(
                 #                                hc_in_ev_angstrom / float(hillier_energy_levels[k].lambdaangstrom))
                 #      for k in hillier_level_ids_matching_this_nahar_state]) + ']'
 
+                str_nahar_energy_g = (
+                    f"E = {nahar_energyabovegsinev:.3f} eV, g = {nahar_energy_level.g:.1f}"
+                    if nahar_energy_level is not None
+                    else "not in Nahar energy table"
+                )
                 flog.write(
-                    "Matched Nahar phixs for {:d}{}{} index {:d} '{}' (E = {:.3f} eV, g = {:.1f}) to \n".format(
+                    "Matched Nahar phixs for {:d}{}{} index {:d} '{}' ({}) to \n".format(
                         twosplusone,
                         lchars[l],
                         ["e", "o"][parity],
                         indexinsymmetry,
                         nahar_configuration_this_state,
-                        nahar_energyabovegsinev,
-                        nahar_energy_level.g,
+                        str_nahar_energy_g,
                     )
                 )
 
@@ -1186,11 +1138,8 @@ def reduce_phixs_tables_worker(
         elif integralwithsigma == 0:
             arr_sigma_out[i] = 0.0
         else:
-            print("Math error: ", i, nsamples, arr_sigma_megabarns[i], integralwithsigma, integralnosigma)
+            print("Math error: ", i, nsamples, integralwithsigma, integralnosigma)
             print(samples_in_interval)
-            print(arr_sigma_out[i - 1])
-            print(arr_sigma_out[i])
-            print(arr_sigma_out[i + 1])
             arr_sigma_out[i] = 0.0
             # sys.exit()
 
@@ -1269,7 +1218,7 @@ def get_term_as_tuple(config: str) -> tuple[int, int, int]:
             l = -1
             parity = -1
     #        sys.exit()
-    except ValueError:
+    except (IndexError, ValueError):
         twosplusone = -1
         l = -1
         parity = -1
@@ -1369,11 +1318,13 @@ def interpret_configuration(instr_orig: str) -> tuple[list[str], int, int, int, 
             print("Warning: Check QUB file formatting")
             break
 
-    if str.isdigit(instr[-1]):
+    if instr and str.isdigit(instr[-1]):
         term_twosplusone = int(instr[-1])
         instr = instr[:-1]
 
-    if instr[-1] == "_":
+    if not instr:
+        pass
+    elif instr[-1] == "_":
         instr = instr[:-1]
     elif instr[-1] in alphabets and (
         (len(instr) < 2 or not str.isdigit(instr[-2])) or (len(instr) < 3 or instr[-3] in lchars.lower())
@@ -1402,7 +1353,7 @@ def interpret_configuration(instr_orig: str) -> tuple[list[str], int, int, int, 
                 electron_config.insert(0, str_parent_term)
                 instr = instr[:left_bracket_pos]
             elif str.isdigit(instr[-1]):  # probably the number of electrons in an orbital
-                if instr[-2].upper() in lchars:
+                if len(instr) >= 2 and instr[-2].upper() in lchars:
                     startpos = -4 if len(instr) >= 4 and str.isdigit(instr[-4]) and int(instr[-4:-2]) < max_n else -3
                     electron_config.insert(0, instr[-3:])
                     instr = instr[:-3]
@@ -1571,29 +1522,11 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
     return dftransitions_ion
 
 
-def write_output_files(
-    elementindex,
-    dfenergylevels_allions,
-    dftransitions_allions: list[pl.DataFrame],
-    upsilondicts,
-    ionization_energies,
-    transition_count_of_level_name,
-    nahar_core_states,
-    nahar_configurations,
-    hillier_photoion_targetconfigs,
-    photoionization_thresholds_ev,
-    photoionization_targetfractions,
-    photoionization_crosssections,
-    ion_handlers,
-    args,
-):
-    atomic_number, listions = ion_handlers[elementindex]
-
-    for i, ion_stage in enumerate(listions):
-        with contextlib.suppress(TypeError):
-            if len(ion_stage) > 1:
-                ion_stage = ion_stage[0]
-        upsilondict = upsilondicts[i]
+def write_output_files(atomic_number: int, iondatalist: list[IonData], args: argparse.Namespace) -> None:
+    for i, iondata in enumerate(iondatalist):
+        ion_stage = iondata.ion_stage
+        upsilondict = iondata.upsilondict
+        transition_count_of_level_name = iondata.transition_count_of_level_name
         ionstr = f"{elsymbols[atomic_number]} {roman_numerals[ion_stage]}"
 
         flog = open(
@@ -1605,14 +1538,14 @@ def write_output_files(
 
         log_and_print(flog, f"\n===========> Z={atomic_number} {ionstr} output:")
 
-        dfenergylevels_ion = dfenergylevels_allions[i]
-        dftransitions_ion = dftransitions_allions[i]
+        dfenergylevels_ion = iondata.dfenergylevels
+        dftransitions_ion = iondata.dftransitions
 
         if dftransitions_ion.is_empty():
             unused_upsilon_transitions = set()
         else:
             dftransitions_ion = add_level_ids_forbidden(dfenergylevels_ion, dftransitions_ion)
-            unused_upsilon_transitions = set(upsilondicts[i].keys()).difference(
+            unused_upsilon_transitions = set(upsilondict.keys()).difference(
                 dftransitions_ion[["lowerlevel", "upperlevel"]].iter_rows(named=False)
             )
 
@@ -1628,8 +1561,8 @@ def write_output_files(
                 namefrom = dfenergylevels_ion["levelname"][id_upper]
                 nameto = dfenergylevels_ion["levelname"][id_lower]
 
-                transition_count_of_level_name[i][namefrom] += 1
-                transition_count_of_level_name[i][nameto] += 1
+                transition_count_of_level_name[namefrom] += 1
+                transition_count_of_level_name[nameto] += 1
 
             dfupsilon_only_transitions = add_level_ids_forbidden(dfenergylevels_ion, dfupsilon_only_transitions)
             dftransitions_ion = pl.concat([dftransitions_ion, dfupsilon_only_transitions], how="diagonal_relaxed")
@@ -1652,9 +1585,9 @@ def write_output_files(
                 fatommodels,
                 atomic_number,
                 ion_stage,
-                dfenergylevels_allions[i],
-                ionization_energies[i],
-                transition_count_of_level_name[i],
+                dfenergylevels_ion,
+                iondata.ionization_energy_ev,
+                transition_count_of_level_name,
                 flog,
             )
 
@@ -1672,19 +1605,20 @@ def write_output_files(
                 flog,
             )
 
-        if i < len(listions) - 1 and not args.nophixs:  # ignore the top ion
-            if len(photoionization_targetfractions[i]) < 1:
-                if len(nahar_core_states[i]) > 1:
-                    photoionization_targetfractions[i] = readnahardata.get_photoiontargetfractions(
-                        dfenergylevels_allions[i],
-                        dfenergylevels_allions[i + 1],
-                        nahar_core_states[i],
-                        nahar_configurations[i + 1],
+        if i < len(iondatalist) - 1 and not args.nophixs:  # ignore the top ion
+            photoionization_targetfractions = iondata.photoionization_targetfractions
+            if len(photoionization_targetfractions) < 1:
+                if len(iondata.nahar_core_states) > 1:
+                    photoionization_targetfractions = readnahardata.get_photoiontargetfractions(
+                        dfenergylevels_ion,
+                        iondatalist[i + 1].dfenergylevels,
+                        iondata.nahar_core_states,
+                        iondatalist[i + 1].nahar_configurations,
                         flog,
                     )
                 else:
-                    photoionization_targetfractions[i] = readhillierdata.get_photoiontargetfractions(
-                        dfenergylevels_allions[i], dfenergylevels_allions[i + 1], hillier_photoion_targetconfigs[i]
+                    photoionization_targetfractions = readhillierdata.get_photoiontargetfractions(
+                        dfenergylevels_ion, iondatalist[i + 1].dfenergylevels, iondata.hillier_photoion_targetconfigs
                     )
 
             with open(os.path.join(args.output_folder, "phixsdata_v2.txt"), "a") as fphixs:
@@ -1692,9 +1626,9 @@ def write_output_files(
                     fphixs,
                     atomic_number,
                     ion_stage,
-                    photoionization_crosssections[i],
-                    photoionization_targetfractions[i],
-                    photoionization_thresholds_ev[i],
+                    iondata.photoionization_crosssections,
+                    photoionization_targetfractions,
+                    iondata.photoionization_thresholds_ev,
                     args,
                     flog,
                 )

--- a/artisatomic/readboyledata.py
+++ b/artisatomic/readboyledata.py
@@ -86,8 +86,9 @@ def read_lines_data(atomic_number, ion_stage):
         if int(atomic_num) != atomic_number or int(ion_number) != ion_stage - 1:
             continue
         # print(line)
-        transition_count_of_level_name[level_number_lower] += 1
-        transition_count_of_level_name[level_number_upper] += 1
+        # must match the levelname format used in read_levels_data
+        transition_count_of_level_name[f"level{int(level_number_lower):05d}"] += 1
+        transition_count_of_level_name[f"level{int(level_number_upper):05d}"] += 1
 
         transitions.append(line)
 

--- a/artisatomic/readdreamdata.py
+++ b/artisatomic/readdreamdata.py
@@ -17,6 +17,8 @@ hc_in_ev_cm = 0.0001239841984332003
 
 def init_dreamdata():
     global dreamdata
+    if dreamdata is not None:
+        return
     hdfdata = pd.read_hdf(dreamdatapath)
     assert isinstance(hdfdata, pd.DataFrame)
     dreamdata = hdfdata
@@ -28,7 +30,7 @@ def extend_ion_list(ion_handlers):
     assert dreamdata is not None
     for atomic_number, charge in dreamdata.index.unique():  # ty:ignore[possibly-missing-attribute]
         ion_stage = charge + 1
-        artisatomic.add_handler_if_not_set(ion_handlers, atomic_number, ion_stage, "dream")
+        ion_handlers = artisatomic.add_handler_if_not_set(ion_handlers, atomic_number, ion_stage, "dream")
 
     return ion_handlers
 

--- a/artisatomic/readfloers25data.py
+++ b/artisatomic/readfloers25data.py
@@ -95,12 +95,10 @@ def read_levels_and_transitions(atomic_number: int, ion_stage: int, flog, calibr
 
     artisatomic.log_and_print(flog, f"Read {dftransitions.height} transitions")
 
+    counts_lower: dict[str, int] = dict(dftransitions["Config_Lower"].value_counts().iter_rows())
+    counts_upper: dict[str, int] = dict(dftransitions["Config_Upper"].value_counts().iter_rows())
     transition_count_of_level_name = {
-        config: (
-            dftransitions.filter(pl.col("Config_Lower") == config).height
-            + dftransitions.filter(pl.col("Config_Upper") == config).height
-        )
-        for config in dflevels["Configuration"]
+        config: counts_lower.get(config, 0) + counts_upper.get(config, 0) for config in dflevels["Configuration"]
     }
 
     # use standard artisatomic column names and convert to 1-indexed levels

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -498,7 +498,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
         with artisatomic.xopen_check_extension(filename) as fhillierphot:
             lowerlevelid = -1
             lowerlevelname = ""
-            # upperlevelname = ''
+            targetlevelname = ""
             numpointsexpected = 0
             crosssectiontype = -1
             fitcoefficients = []
@@ -536,7 +536,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                 ) == "!Configuration name [*]":
                     lowerlevelname = row[0]
                     if "[" in lowerlevelname:
-                        lowerlevelname.split("[")[0]
+                        lowerlevelname = lowerlevelname.split("[")[0]
                     fitcoefficients = []
                     numpointsexpected = 0
                     lowerlevelid = 1
@@ -1045,6 +1045,7 @@ def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
     )
     artisatomic.log_and_print(flog, f"Reading {filename}")
     coll_lines_in = 0
+    number_expected_transitions = -1
     with artisatomic.xopen_check_extension(filename) as fcoldata:
         header_row = []
         temperature_index = -1
@@ -1156,7 +1157,9 @@ def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
                         f" {nameto}{unlisted_to_message}",
                     )
 
-    if coll_lines_in < number_expected_transitions:
+    if number_expected_transitions < 0:
+        artisatomic.log_and_print(flog, "WARNING: no '!Number of transitions' line found in collision data file")
+    elif coll_lines_in < number_expected_transitions:
         print(
             f"ERROR: file specified {number_expected_transitions:d} transitions, but only {coll_lines_in:d} were found"
         )
@@ -1174,16 +1177,19 @@ def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
 
 
 def get_photoiontargetfractions(
-    dfenergy_levels, dfenergy_levels_upperion, hillier_photoion_targetconfigs: dict[int, list[tuple[str, float]]]
+    dfenergy_levels,
+    dfenergy_levels_upperion,
+    hillier_photoion_targetconfigs: list[list[tuple[str, float]] | None] | None,
 ) -> list[list[tuple[int, float]]]:
     targetlist: list[list[tuple[int, float]]] = [[] for _ in range(dfenergy_levels.height)]
     targetlist_of_targetconfig: defaultdict[str, list[tuple[int, float]]] = defaultdict(list)
 
+    if hillier_photoion_targetconfigs is None:
+        return targetlist
+
     for energy_level in dfenergy_levels[1:].iter_rows(named=True):
         lowerlevelid = energy_level["levelid"]
-        if hillier_photoion_targetconfigs is None:
-            continue
-        if lowerlevelid in hillier_photoion_targetconfigs and hillier_photoion_targetconfigs[lowerlevelid] is None:
+        if hillier_photoion_targetconfigs[lowerlevelid] is None:
             continue  # photoionisation flagged as not available
 
         for targetconfig, targetconfig_fraction in hillier_photoion_targetconfigs[lowerlevelid]:
@@ -1223,7 +1229,7 @@ def read_hyd_phixsdata():
         _transitions,
         _transition_count_of_level_name,
         _hillier_level_ids_matching_term,
-    ) = read_levels_and_transitions(1, 1, open("/dev/null", "w"))
+    ) = read_levels_and_transitions(1, 1, open(os.devnull, "w"))
 
     hyd_filename = hillier_ion_folder(1, 1) + "/5dec96/hyd_l_data.dat"
     print(f"Reading hydrogen photoionization cross sections from {hyd_filename}")

--- a/artisatomic/readkuruczdata.py
+++ b/artisatomic/readkuruczdata.py
@@ -242,10 +242,11 @@ def read_levels_and_transitions(
         .collect()
     )
 
+    transition_count_of_levelid: dict[int, int] = dict(
+        pl.concat([transitions["lowerlevel"], transitions["upperlevel"]]).value_counts().iter_rows()
+    )
     transition_count_of_level_name: dict[str, int] = {
-        levelname: (
-            transitions.select(((pl.col("lowerlevel") == levelid) | (pl.col("upperlevel") == levelid)).sum()).item()
-        )
+        levelname: transition_count_of_levelid.get(levelid, 0)
         for levelid, levelname in dflevels.select("levelid", "levelname").iter_rows(named=False)
     }
     artisatomic.log_and_print(flog, f"Read {len(transitions):d} transitions")

--- a/artisatomic/readnahardata.py
+++ b/artisatomic/readnahardata.py
@@ -45,6 +45,7 @@ def read_nahar_energy_level_file(path_nahar_energy_file, atomic_number, ion_stag
     nahar_energy_levels: list[NaharEnergyLevel | None] = [None]
     nahar_level_index_of_state = {}
     nahar_core_states: list[NaharCoreState | None] = []
+    nahar_ionization_potential_rydberg = -1.0
 
     if not os.path.isfile(path_nahar_energy_file):
         artisatomic.log_and_print(flog, f"{path_nahar_energy_file} does not exist")
@@ -239,7 +240,7 @@ def read_nahar_phixs_tables(path_nahar_px_file, atomic_number, ion_stage, args):
 
             number_of_points = int(fenlist.readline().split()[1])
             binding_energy_ryd = float(fenlist.readline().split()[0])
-            thresholds_ev_dict[(twosplusone, l, parity, indexinsymmetry)] = binding_energy_ryd * 13.605698065
+            thresholds_ev_dict[(twosplusone, l, parity, indexinsymmetry)] = binding_energy_ryd * ryd_to_ev
 
             if not args.nophixs:
                 phixsarray = np.array([list(map(float, fenlist.readline().split())) for _ in range(number_of_points)])
@@ -255,6 +256,7 @@ def read_nahar_phixs_tables(path_nahar_px_file, atomic_number, ion_stage, args):
 
 def read_nahar_configurations(fenlist, flog):
     nahar_configurations = {}
+    nahar_ionization_potential_rydberg = -1.0
     while True:
         line = fenlist.readline()
         if not line:
@@ -380,7 +382,7 @@ def get_naharphotoion_upperlevelids(
 def get_photoiontargetfractions(
     dfenergy_levels, dfenergy_levels_upperion, nahar_core_states, nahar_configurations_upperion, flog
 ):
-    targetlist = [() for _ in range(dfenergy_levels.height)]
+    targetlist: list[list[tuple[int, float]]] = [[] for _ in range(dfenergy_levels.height)]
     upper_level_ids_of_core_state_id = defaultdict(list)
     for energy_level in dfenergy_levels[1:].iter_rows(named=True):
         lowerlevelid = energy_level["levelid"]

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -305,6 +305,10 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
                         )
                         qub_transitions.append(transition)
 
+    else:
+        msg = f"No QUB data available for Z={atomic_number} ion_stage {ion_stage}"
+        raise ValueError(msg)
+
     artisatomic.log_and_print(flog, f"Read {len(qub_transitions):d} transitions")
 
     return ionization_energy_ev, qub_energylevels, qub_transitions, transition_count_of_level_name, upsilondict

--- a/artisatomic/readtanakajpltdata.py
+++ b/artisatomic/readtanakajpltdata.py
@@ -86,19 +86,25 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
             pl.col("g_u_times_A").cast(pl.Float64),
         )
 
+    transition_count_of_levelid: dict[int, int] = dict(
+        pl.concat([dftransitions["lowerlevel"], dftransitions["upperlevel"]]).value_counts().iter_rows()
+    )
     transition_count_of_level_name = {
-        dflevels["levelname"][levelid]: (
-            dftransitions.filter(pl.col("lowerlevel") == levelid).height
-            + dftransitions.filter(pl.col("upperlevel") == levelid).height
-        )
+        dflevels["levelname"][levelid]: transition_count_of_levelid.get(levelid, 0)
         for levelid in dflevels["levelid"][1:]
     }
     assert dftransitions.height == transitioncount
 
-    dftransitions = dftransitions.with_columns(
-        g_u=pl.col("upperlevel").map_elements(lambda upperlevel: dflevels["g"][upperlevel], return_dtype=pl.Float64)
-    ).with_columns(A=pl.col("g_u_times_A") / pl.col("g_u"))
-    dftransitions = dftransitions.select(["lowerlevel", "upperlevel", "A"])
+    dftransitions = (
+        dftransitions.join(
+            dflevels.select(g_u=pl.col("g"), upperlevel=pl.col("levelid")),
+            on="upperlevel",
+            how="left",
+            maintain_order="left",
+        )
+        .with_columns(A=pl.col("g_u_times_A") / pl.col("g_u"))
+        .select(["lowerlevel", "upperlevel", "A"])
+    )
     dftransitions_filtered = dftransitions.filter(pl.col("lowerlevel") != pl.col("upperlevel"))
     if dftransitions.height != dftransitions_filtered.height:
         artisatomic.log_and_print(flog, "WARNING: dropped rows where upper and lower levels are equal")

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -1,10 +1,24 @@
 #!/usr/bin/env python3
-import numpy as np
+import io
+import typing as t
 
+import numpy as np
+import polars as pl
+
+from artisatomic import add_handler_if_not_set
 from artisatomic import get_term_as_tuple
 from artisatomic import interpret_configuration
 from artisatomic import interpret_parent_term
+from artisatomic import PYDIR
+from artisatomic import readfacdata
+from artisatomic import readfloers25data
+from artisatomic import readhillierdata
+from artisatomic import readkuruczdata
+from artisatomic import readnahardata
+from artisatomic import readqubdata
+from artisatomic import readtanakajpltdata
 from artisatomic import reduce_configuration
+from artisatomic import reduce_phixs_tables_worker
 from artisatomic import score_config_match
 
 
@@ -13,7 +27,7 @@ def test_reduce_configuration():
     assert reduce_configuration("3d6_3P2e") == "3d6_3Pe"
 
 
-def text_interpret_term():
+def test_interpret_term():
     assert get_term_as_tuple("3d5(6S)4s(7S)4d6De") == (6, 2, 0)
     assert get_term_as_tuple("3d6_3P2e") == (3, 1, 0)
 
@@ -95,3 +109,138 @@ def test_hydrogenic_phixs():
 
     phixstable_n = rhd.get_hydrogenic_n_phixstable(oneryd_lambda_angstrom, 5)
     assert np.allclose(expected_n5, phixstable_n[:10], rtol=1e-3)
+
+
+def test_add_handler_if_not_set():
+    ion_handlers: list[tuple[int, list[int | tuple[int, str]]]] = [(26, [1, 2])]
+
+    # adding an ion for a new element must not modify the input list
+    result = add_handler_if_not_set(ion_handlers, 58, 1, "dream")
+    assert ion_handlers == [(26, [1, 2])]
+    assert result == [(26, [1, 2]), (58, [(1, "dream")])]
+
+    # add an ion to an existing element
+    result = add_handler_if_not_set(ion_handlers, 26, 3, "dream")
+    assert ion_handlers == [(26, [1, 2])]
+    assert result == [(26, [1, 2, (3, "dream")])]
+
+    # an already-present ion stage is not replaced or duplicated
+    result = add_handler_if_not_set(ion_handlers, 26, 2, "dream")
+    assert result == [(26, [1, 2])]
+
+    # ion stages with handlers can be given as tuples or lists (e.g. loaded from JSON)
+    ion_handlers_json = t.cast("list[tuple[int, list[int | tuple[int, str]]]]", [(26, [[1, "cmfgen"]])])
+    result = add_handler_if_not_set(ion_handlers_json, 26, 1, "dream")
+    assert result == [(26, [[1, "cmfgen"]])]
+
+
+def test_hillier_extend_ion_list():
+    result = readhillierdata.extend_ion_list([], maxionstage=1, include_hydrogen=False)
+    assert (2, [(1, "cmfgen")]) in result
+    assert (26, [(1, "cmfgen")]) in result
+    assert all(atomic_number != 1 for atomic_number, _ in result)
+    assert all(entry == (1, "cmfgen") for _, listions in result for entry in listions)
+
+
+def test_reduce_phixs_tables_worker():
+    nphixspoints = 100
+    phixsnuincrement = 0.03
+    temperature = 6000.0
+    sigma_0 = 4.0
+
+    # dense input table with a hydrogenic-like sigma_0 * (E_threshold / E)**3 cross section
+    energyryd = np.linspace(1.0, 1.0 + phixsnuincrement * (nphixspoints + 1) * 2, 5000)
+    tablein = np.column_stack([energyryd, sigma_0 * (energyryd[0] / energyryd) ** 3])
+
+    reduced = reduce_phixs_tables_worker(temperature, nphixspoints, phixsnuincrement, tablein)
+    assert len(reduced) == nphixspoints
+    assert abs(reduced[0] / sigma_0 - 1) < 0.05  # first point close to the threshold cross section
+    assert np.all(np.diff(reduced) < 0)  # monotonically decreasing
+
+    # a constant cross section must be preserved exactly
+    tablein_const = np.column_stack([energyryd, np.full_like(energyryd, 2.5)])
+    reduced_const = reduce_phixs_tables_worker(temperature, nphixspoints, phixsnuincrement, tablein_const)
+    assert np.allclose(reduced_const, 2.5, rtol=1e-6)
+
+    # the downsampling must preserve the recombination-rate integral
+    # sigma(nu) * nu**2 * exp(-h*nu / (k_B * T)) at the optimisation temperature
+    ryd_to_hz = 3289841960250880.5
+    h_over_kb_in_k_sec = 4.799243073366221e-11
+
+    def recomb_integral(en_ryd, sigmas):
+        nu = np.asarray(en_ryd) * ryd_to_hz
+        return np.trapezoid(sigmas * nu**2 * np.exp(-h_over_kb_in_k_sec * nu / temperature), nu)
+
+    # reconstruct the reduced table as piecewise-constant over the output grid intervals
+    xgrid = np.linspace(1.0, 1.0 + phixsnuincrement * (nphixspoints + 1), num=nphixspoints + 1, endpoint=False)
+    interval_edges = [xgrid[0], *(0.5 * (xgrid[i] + xgrid[i + 1]) for i in range(nphixspoints))]
+    dense_en: list[float] = []
+    dense_sigma: list[float] = []
+    for i in range(nphixspoints):
+        segment = np.linspace(interval_edges[i], interval_edges[i + 1], 200)
+        dense_en.extend(segment)
+        dense_sigma.extend([reduced[i]] * len(segment))
+
+    integral_reduced = recomb_integral(dense_en, np.array(dense_sigma))
+    selection = (energyryd >= interval_edges[0]) & (energyryd <= interval_edges[-1])
+    integral_input = recomb_integral(energyryd[selection], tablein[selection, 1])
+    assert abs(integral_reduced / integral_input - 1) < 0.01
+
+
+def test_read_adf04():
+    flog = io.StringIO()
+    ionization_energy_ev, energylevels, upsilondict = readqubdata.read_adf04(
+        (PYDIR / ".." / "atomic-data-qub" / "co_tyndall_test_sample" / "adf04_v1").resolve(), 27, 3, flog
+    )
+    assert abs(ionization_energy_ev - 40.964007) < 1e-5
+    assert len(energylevels) - 1 == 262
+    assert len(upsilondict) == 235
+    level1 = energylevels[1]
+    assert level1 is not None
+    assert level1.levelname == "3s23p63d7(4F)_4Fe[9/2]_id=1"
+    assert level1.energyabovegsinpercm == 0.0
+    assert level1.g == 10.0
+    assert level1.parity == 0
+
+
+def test_read_nahar_energy_level_file_missing():
+    # a missing file should be logged and returned as empty data, not crash
+    flog = io.StringIO()
+    (
+        nahar_energy_levels,
+        nahar_core_states,
+        nahar_level_index_of_state,
+        nahar_configurations,
+        nahar_ionization_potential_rydberg,
+    ) = readnahardata.read_nahar_energy_level_file("does/not/exist.en.ls.txt", 26, 2, flog)
+    assert nahar_energy_levels == [None]
+    assert nahar_core_states == []
+    assert nahar_level_index_of_state == {}
+    assert nahar_configurations == {}
+    assert nahar_ionization_potential_rydberg == -1.0
+    assert "does not exist" in flog.getvalue()
+
+
+def test_nahar_get_photoiontargetfractions():
+    dflower = pl.DataFrame(
+        {"levelid": [0, 1], "energyabovegsinpercm": [None, 0.0], "g": [None, 9.0], "levelname": [None, "gs"]}
+    )
+    dfupper = pl.DataFrame(
+        {"levelid": [0, 1], "energyabovegsinpercm": [None, 0.0], "g": [None, 10.0], "levelname": [None, "gs2"]}
+    )
+    nahar_core_states = [None, readnahardata.NaharCoreState(1, "3d6", "5De", 0.0)]
+    targetlist = readnahardata.get_photoiontargetfractions(dflower, dfupper, nahar_core_states, {}, io.StringIO())
+    assert targetlist[1] == [(1, 1.0)]
+
+
+def test_get_level_valence_n():
+    # each handler has its own level-name format and parser
+    assert readkuruczdata.get_level_valence_n("s5p  3P,enpercm=14276.381,j=0.0") == 5
+    assert readtanakajpltdata.get_level_valence_n("2,even,{  4d- 3  4d+ 1  5s+ 1 }") == 5
+    assert readfloers25data.get_level_valence_n("4f10") == 4
+    assert readfloers25data.get_level_valence_n("4f9.6s") == 6
+    assert readfloers25data.get_level_valence_n("5s2.5p5") == 5
+    assert readfacdata.get_level_valence_n("4f9 6s1") == 6
+    assert readfacdata.get_level_valence_n("4f10") == 4
+    assert readqubdata.get_level_valence_n("3d7_4Fe[9/2]_id=1") == 3
+    assert readqubdata.get_level_valence_n("5s2_1Se[0/2]_id=1") == 5

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -6,6 +6,7 @@ import numpy as np
 import polars as pl
 
 from artisatomic import add_handler_if_not_set
+from artisatomic import get_default_handler
 from artisatomic import get_term_as_tuple
 from artisatomic import interpret_configuration
 from artisatomic import interpret_parent_term
@@ -132,6 +133,20 @@ def test_add_handler_if_not_set():
     ion_handlers_json = t.cast("list[tuple[int, list[int | tuple[int, str]]]]", [(26, [[1, "cmfgen"]])])
     result = add_handler_if_not_set(ion_handlers_json, 26, 1, "dream")
     assert result == [(26, [[1, "cmfgen"]])]
+
+
+def test_get_default_handler():
+    assert get_default_handler(2, 3) == "boyle"
+    assert get_default_handler(26, 1) == "cmfgen"
+    assert get_default_handler(56, 2) == "cmfgen"
+    assert get_default_handler(38, 1) == "qub_data"
+    # QUB calculations take precedence over DREAM for W, Pt, and Au ion stages 1-3
+    assert get_default_handler(74, 1) == "qub_data"
+    assert get_default_handler(78, 3) == "qub_data"
+    assert get_default_handler(79, 2) == "qub_data"
+    assert get_default_handler(74, 4) == "dream"
+    assert get_default_handler(60, 2) == "dream"
+    assert get_default_handler(45, 1) == "kurucz"
 
 
 def test_hillier_extend_ion_list():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pyarrow>=18.1.0",
     "requests>=2.34.0",
     "scipy>=1.15.3",
+    "tables>=3.11.1",
     "tqdm>=4.67.3",
     "xopen>=2.1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,28 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -35,6 +57,7 @@ dependencies = [
     { name = "pyarrow" },
     { name = "requests" },
     { name = "scipy" },
+    { name = "tables" },
     { name = "tqdm" },
     { name = "xopen" },
 ]
@@ -66,6 +89,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=18.1.0" },
     { name = "requests", specifier = ">=2.34.0" },
     { name = "scipy", specifier = ">=1.15.3" },
+    { name = "tables", specifier = ">=3.11.1" },
     { name = "tqdm", specifier = ">=4.67.3" },
     { name = "xopen", specifier = ">=2.1.0" },
 ]
@@ -217,6 +241,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/4b/c1f4e211e50389304d6af32b9280e026a7133e3ad59bbdf8f7a3250f8bee/basedpyright-1.39.9.tar.gz", hash = "sha256:32cbea5fc8273e89df3db20daea56cb7286e419ccdfdc479c64759d2dc071901", size = 24412216, upload-time = "2026-06-27T02:19:49.834Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/d4/e1fa108710d0498a18c77b1e13897f31eab47c69aa8cfe2d2a4df746541e/basedpyright-1.39.9-py3-none-any.whl", hash = "sha256:6b0837b9eba972c71895167ab9b127e6afdbc17abc92312e3f8d15ca82a5611c", size = 13374276, upload-time = "2026-06-27T02:19:54.431Z" },
+]
+
+[[package]]
+name = "blosc2"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "msgpack" },
+    { name = "ndindex" },
+    { name = "numexpr", marker = "platform_machine != 'wasm32'" },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "threadpoolctl", marker = "platform_machine != 'wasm32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/e9/7a352079e1ccc51c4f6d828fca9454b08b76f064d8f3a0ef9f01900f0b73/blosc2-4.9.1.tar.gz", hash = "sha256:0e7ee7579b6e7ba4a8d11c55da7f5a17ed3743973c1dca65f10828bbf473fc55", size = 6079075, upload-time = "2026-07-17T12:20:47.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/57/919a7df027bd3931fd620d2b5f0d11e3d8b368bcbdaf9eb0749811bd58bc/blosc2-4.9.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cf8e32e6e52799c841193ccc3f005fbeb5f1ca205c5ffcdc7b2ec8550bf70731", size = 6170953, upload-time = "2026-07-17T12:20:02.794Z" },
+    { url = "https://files.pythonhosted.org/packages/04/41/e0fb67b09fd77efd5238077296e096a8344076f2918f6fa6c3e1d1e9988a/blosc2-4.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e9dac961f1e65fd33d3dccee998b34ac569dbb60c5715c0f63cb9afc0e17af89", size = 5402763, upload-time = "2026-07-17T12:20:04.605Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/1eb89562cc1c0d463d657cacb119053ddc585b1d229fba57e8bfd6894700/blosc2-4.9.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9fc283350e6310899c13e1ecda249c04dc7f58dee00a0b01f5aaedd6e38b4ddf", size = 6773698, upload-time = "2026-07-17T12:20:06.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/98/e447ddc243614165b2e70ff235f0a98e663946efd809792feb863dfb88cb/blosc2-4.9.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9e53a7346c3c6ff91302553297d5ce68b8af535a6b0c5d95f33aa4eb79b4d92", size = 7280802, upload-time = "2026-07-17T12:20:09.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2f/2b6c5dde045f273122004f91dc7d0a2b93cd20087f5906a335355fd3150c/blosc2-4.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:93e3950106e0235ca074a32eca210319595c6f9122b657db21a4fb6238d8699d", size = 4391074, upload-time = "2026-07-17T12:20:11.035Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/43/bd2f0a262a47c49c086a29fc3289b26e4305a9c1b1db57d1af647cb09575/blosc2-4.9.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8a40f2b3fbb46d1415ba79f80d973f3e82e24a27e2a4baf226f82dfc443c4093", size = 6168563, upload-time = "2026-07-17T12:20:13.076Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/98/dc7333655cdbb3d5f3b7f3a8c94472ff5d3531d262d62e30580a12dcec0b/blosc2-4.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:04692e016d42e909be2e30e2530280e90119c690495328f180551fb5d41f97e0", size = 5401031, upload-time = "2026-07-17T12:20:15.249Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7b/03bc7afd8b5db05cabccff8d4f354d1067e7db02363c767c2bafc60cc2a7/blosc2-4.9.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59ee059f6cc193a970b3681cb5d4d0306edbfefd3e812ceede8778ab4e5fc361", size = 6775808, upload-time = "2026-07-17T12:20:17.373Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/a4/927a6a1b0ed6235ec8065df37270dec3afc5031c0c6d3220370ac45d6b39/blosc2-4.9.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:720c391aa5df09a556adff4d7621862f9a785804d6bd7b944e35e222ebc1c16c", size = 7283336, upload-time = "2026-07-17T12:20:19.467Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/fefe8a02cddc0bf00d49c5d122d4aaf0a6385776294527cc2d3bce02c0e0/blosc2-4.9.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:fc3d906c94f0947b0a0c894db3bd46c432bb855dccc528332aed8230387066a8", size = 2351837, upload-time = "2026-07-17T12:20:21.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/a7/79d34e6bb965cc69368dd1f0fdc440cdb0d22fefe7ce9f6ea8280887ed25/blosc2-4.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:57eed46e77439a5628120b1d09dcdae39f93941a70f194e4efcbc30f79db655c", size = 4391138, upload-time = "2026-07-17T12:20:23.01Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/98/eeb86b236a9125507c94320ea8dd82c75518b19896bb0f22de9d33947e84/blosc2-4.9.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9613a5af7498da27b1229db27c0b795f01e654eabe440ade911a1e2b93d275b3", size = 6171085, upload-time = "2026-07-17T12:20:25.1Z" },
+    { url = "https://files.pythonhosted.org/packages/65/8e/9bb1c8c4279c36e1dc96dbfdc44563040026c401227f48ffc1c7f97fa944/blosc2-4.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fe59688b404599ec9d7fa78f5c8f58db8553c56531b97672d462606c4bc3513", size = 5404897, upload-time = "2026-07-17T12:20:27.05Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/8301136c66db5bfe239ed6ea9d3beff7f62328a9aafb2afeef9907d3d16a/blosc2-4.9.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9b5725f62a90274bbafb609a464b49e7efe5cb2b45aeb6ff1b917983c33b1fc", size = 6792627, upload-time = "2026-07-17T12:20:29.093Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c6/30c20e83357e84ef12aa076980f5bc5bd5afb7d58b074fe8fbd0fb58bca9/blosc2-4.9.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80357f8252999c0f90942ef949533c09960bc1e577607173ff78c6c7b6effc74", size = 7287039, upload-time = "2026-07-17T12:20:31.264Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2d/5474dd754f68f55ba18caf82f5782549b9dea16c0d5f09a5f71f6c198d07/blosc2-4.9.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:4c15885b862afece043edaa50179e4317123b60f3fc5a4fa1bc41422ac58b5a7", size = 2349508, upload-time = "2026-07-17T12:20:32.856Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/65/b42de2683d1d7f486a2921f2050732975b85150408f2345bc03fa8a3936c/blosc2-4.9.1-cp314-cp314-win_amd64.whl", hash = "sha256:1e547697222ae9d2908dfa816852e78b41a79d967f1ad27ed94b0b48bfcbe73b", size = 4477720, upload-time = "2026-07-17T12:20:34.363Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/37/0103ee46fbe64e8f44dc4b8609007fca4d309d98e78aae18b4de9a719102/blosc2-4.9.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:53d5c056c5d0783fdf8944f8e767d5cf95b1f2cb36f9d8e7c2e852a7755ac82c", size = 6212245, upload-time = "2026-07-17T12:20:36.214Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/35/10be1df0cd635f333928d6b8ce964f6969597ec56a33b0cf58e5dafa41a0/blosc2-4.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:dd13564c61cd477556e99f179895a5b06491080ea5eac638a300dc410c85a660", size = 5445532, upload-time = "2026-07-17T12:20:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/75/7b0e759014bb854b6afebd91cc78c9e97054cd3648a6c6203792f45d30df/blosc2-4.9.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:db575a6c817050ce6b4255a756afad049a7e7cac5ec60dde3c16033f41769b94", size = 6741201, upload-time = "2026-07-17T12:20:40.082Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/71/afe45439af30ee4a7617b18cff2b23dad18e8d83535f4aa9e873dc7a1f8e/blosc2-4.9.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7cfbbd64992dcfb5d2ecf891f233c89e3a88b4e1aa7863738ed669f761fe8c04", size = 7259103, upload-time = "2026-07-17T12:20:42.159Z" },
+    { url = "https://files.pythonhosted.org/packages/94/05/124cfb9a0fba6a19bbb7ed09a086144e2028acb531b0ccb3eae8fdda3587/blosc2-4.9.1-cp314-cp314t-win_amd64.whl", hash = "sha256:0f01fe713789bf1ebfe7daee53525df9a4687e8ef4fcfefff807969b6cd9cd6d", size = 4539582, upload-time = "2026-07-17T12:20:45.517Z" },
 ]
 
 [[package]]
@@ -467,6 +531,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/d4/a7d6fb3f58be99d65cbf2d3f766896217a2921d0f3ab10711c45dc1519ee/h2-4.4.0.tar.gz", hash = "sha256:46b551bdcdc7e83cf5c04d0bf93badb8a939bd2287d9fee1abb23a445b9e0580", size = 2156691, upload-time = "2026-07-23T19:14:19.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/df/5b14a118322d6097cb9bb30ec6bacad268e546a8ecfcb1f6d0de618dac2f/h2-4.4.0-py3-none-any.whl", hash = "sha256:6acffe1aeab79098d7eb0f8385c1add11f2c7a94815f6fa2b7060eeddee3d87c", size = 62368, upload-time = "2026-07-23T19:14:16.143Z" },
+]
+
+[[package]]
 name = "h5py"
 version = "3.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -507,6 +593,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/8c/bbe98f813722b4873818a8db3e15aa3e625b59278566905ac439725e8070/h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725", size = 5300253, upload-time = "2026-03-06T13:49:02.033Z" },
     { url = "https://files.pythonhosted.org/packages/32/9e/87e6705b4d6890e7cecdf876e2a7d3e40654a2ae37482d79a6f1b87f7b92/h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e", size = 3381671, upload-time = "2026-03-06T13:49:04.351Z" },
     { url = "https://files.pythonhosted.org/packages/96/91/9fad90cfc5f9b2489c7c26ad897157bce82f0e9534a986a221b99760b23b/h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1", size = 2740706, upload-time = "2026-03-06T13:49:06.347Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -785,6 +922,58 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -838,6 +1027,54 @@ wheels = [
 ]
 
 [[package]]
+name = "ndindex"
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/92/4b9d2f4e0f3eabcfc7b02b48261f6e5ad36a3e2c1bbdcc4e3b7b6c768fa6/ndindex-1.10.1.tar.gz", hash = "sha256:0f6113c1f031248f8818cbee1aa92aa3c9472b7701debcce9fddebcd2f610f11", size = 271395, upload-time = "2025-11-19T20:40:08.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/90/774ddd08b2a1b41faa56da111f0fbfeb4f17ee537214c938ef41d61af949/ndindex-1.10.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:87f83e8c35a7f49a68cd3a3054c406e6c22f8c1315f3905f7a778c657669187e", size = 177348, upload-time = "2025-11-19T20:38:41.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ee/a423e857f5b45da3adc8ddbcfbfd4a0e9a047edce3915d3e3d6e189b6bd9/ndindex-1.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cf9e05986b2eb8c5993bce0f911d6cedd15bda30b5e35dd354b1ad1f4cc3599d", size = 176561, upload-time = "2025-11-19T20:38:43.06Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/40/139b6b050ba2b2a0bb40e0381a352b1eb6551302dcb8f86fb4c97dd34e92/ndindex-1.10.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:046c1e88d46b2bd2fd3483e06d27b4e85132b55bc693f2fca2db0bb56eea1e78", size = 542901, upload-time = "2025-11-19T20:38:44.43Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ae/defd665dbbeb2fffa077491365ed160acaec49274ce8d4b979f55db71f18/ndindex-1.10.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03cf1e6cdac876bd8fc92d3b65bb223496b1581d10eab3ba113f7c195121a959", size = 546875, upload-time = "2025-11-19T20:38:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/59/43/6d54d48e8eaee25cdab70d3e4c4f579ddb0255e4f1660040d5ad55e029c6/ndindex-1.10.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:752e78a5e87911ded117c57a7246596f26c9c6da066de3c2b533b3db694949bb", size = 1510036, upload-time = "2025-11-19T20:38:47.444Z" },
+    { url = "https://files.pythonhosted.org/packages/09/61/e28ba3b98eacd18193176526526b34d7d70d2a6f9fd2b4d8309ab5692678/ndindex-1.10.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c9dd58d91220b1c1fe516324bfcf4114566c98e84b1cbbe416abe345c75bd557", size = 1571849, upload-time = "2025-11-19T20:38:48.951Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/63/83fff78a3712cb9f478dd84a19ec389acf6f8c7b01dc347a65ae74e6123d/ndindex-1.10.1-cp312-cp312-win32.whl", hash = "sha256:3b0d9ce2c8488444499ab6d40e92e09867bf4413f5cf04c01635de923f44aa67", size = 149792, upload-time = "2025-11-19T20:38:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/52/fd/a5e3c8c043d0dddea6cd4567bfaea568f022ac197301882b3d85d9c1e9b3/ndindex-1.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c026dbbf2455d97ce6456d8a50b349aee8fefa11027d020638c89e9be2c9c4c", size = 158164, upload-time = "2025-11-19T20:38:52.242Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ea/03676266cb38cc671679a9d258cc59bfc58c69726db87b0d6eeafb308895/ndindex-1.10.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:157b5c34a1b779f5d27b790d9bd7e7b156d284e76be83c591a3ba003984f4956", size = 176323, upload-time = "2025-11-19T20:38:53.528Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f4/2d350439031b108b0bb8897cad315390c5ad88c14d87419a54c2ffa95c80/ndindex-1.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f99b3e89220da3244d03c9c5473669c7107d361c129fd9b064622744dee1ce15", size = 175584, upload-time = "2025-11-19T20:38:57.968Z" },
+    { url = "https://files.pythonhosted.org/packages/77/34/a51b7c6f7159718a6a0a694fc1058b94d793c416d9a4fd649f1924cce5f8/ndindex-1.10.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6928e47fb008903f2e41309b7ff1e59b16abbcd59e2e945454571c28b2433c9e", size = 524127, upload-time = "2025-11-19T20:38:59.412Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/d8f19f0b8fc9c5585b50fda44c05415da0bdc5fa9c9c69011015dac27880/ndindex-1.10.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69a2cb1ac7be955c3c77f1def83f410775a81525c9ce2d4c0a3f2a61589ed47", size = 528213, upload-time = "2025-11-19T20:39:00.882Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a9/77d9d037e871a3faa8579b354ca2dd09cc5bbf3e085d9e3c67f786d55ee3/ndindex-1.10.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cb76e0f3f235d8b1c768b17e771de48775d281713795c3aa045e8114ad61bdda", size = 1492172, upload-time = "2025-11-19T20:39:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/29/ad13676fc9312e0aa1a80a7c04bcb0b502b877ed4956136117ad663eced0/ndindex-1.10.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7da34a78410c14341d5fff73be5ce924bd36500bf7f640fc59b8607d3a0df95e", size = 1552614, upload-time = "2025-11-19T20:39:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/63/34/e6e6fd81423810c07ae623c4d36e099f42a812994977e8e3bfa182c02472/ndindex-1.10.1-cp313-cp313-win32.whl", hash = "sha256:9599fcb7411ffe601c367f0a5d4bc0ed588e3e7d9dc7604bdb32c8f669456b9e", size = 149330, upload-time = "2025-11-19T20:39:05.727Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d3/830a20626e2ec0e31a926be90e67068a029930f99e6cfebf2f9768e7b7b1/ndindex-1.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:ef3ef22390a892d16286505083ee5b326317b21c255a0c7f744b1290a0b964a6", size = 157309, upload-time = "2025-11-19T20:39:07.394Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/73/3bdeecd1f6ec0ad81478a53d96da4ba9be74ed297c95f2b4fbe2b80843e1/ndindex-1.10.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:72af787dcee3661f36fff9d144d989aacefe32e2c8b51ceef9babd46afb93a18", size = 181022, upload-time = "2025-11-19T20:39:10.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b1/0d97ba134b5aa71b5ed638fac193a7ec4d987e091e2f4e4162ebdaacbda1/ndindex-1.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa60637dfae1ee3fc057e420a52cc4ace38cf2c0d1a0451af2a3cba84d281842", size = 181289, upload-time = "2025-11-19T20:39:11.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d7/1df02df24880ce3f3c8137b6f3ca5a901a58d9079dcfd8c818419277ff87/ndindex-1.10.1-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d0ebdba2fade3f6916fe21fd49e2a0935af4f58c56100a60f3f2eb26e20baee7", size = 632517, upload-time = "2025-11-19T20:39:13.259Z" },
+    { url = "https://files.pythonhosted.org/packages/34/96/b509c2b14e9b10710fe6ab6ba8bda1ee6ce36ab16397ff2f5bbb33bbbba3/ndindex-1.10.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:346a4bf09f5771548665c8206e81daadb6b9925d409746e709894bdd98adc701", size = 616179, upload-time = "2025-11-19T20:39:14.757Z" },
+    { url = "https://files.pythonhosted.org/packages/38/e3/f89d60cf351c33a484bf1a4546a5dee6f4e7a6a973613ffa12bd316b14ad/ndindex-1.10.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:23d35696f802548143b5cc199bf2f171efb0061aa7934959251dd3bae56d038c", size = 1588373, upload-time = "2025-11-19T20:39:16.62Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/19/002fc1e6a4abeef8d92e9aa2e43aea4d462f6b170090f7752ea8887f4897/ndindex-1.10.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a91e1a0398120233d5c3b23ccb2d4b78e970d66136f1a7221fa9a53873c3d5c5", size = 1636436, upload-time = "2025-11-19T20:39:18.266Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/28b1ad78c787ac8fafd6e26419a80366617784b1779e3857fa687492f6bc/ndindex-1.10.1-cp313-cp313t-win32.whl", hash = "sha256:78bfe25941d2dac406391ddd9baf0b0fce163807b98ecc2c47a3030ee8466319", size = 158780, upload-time = "2025-11-19T20:39:20.454Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/56/b81060607a19865bb8be8d705b1b3e8aefb8747c0fbd383e38b4cae4bd71/ndindex-1.10.1-cp313-cp313t-win_amd64.whl", hash = "sha256:08bfdc1f7a0b408d15b3ce61d141ebbebdb47a25341967e425e104c5bd512a5c", size = 167485, upload-time = "2025-11-19T20:39:21.733Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9b/aac1131e9f3a5635ba7b0312c3bfa610511ab4108f85c0d914a32887aa00/ndindex-1.10.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9b5297f207ebc068c7cdf9e3cd7b95aa5c9ec04295d0a7e56b529f66787d4685", size = 176478, upload-time = "2025-11-19T20:39:23.747Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/05/a0d8ca0432c84550bc17af6d6479a803936895b8b8403a1216c5a55475fb/ndindex-1.10.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c5e9762452b163e33cfb6e821f86e45ba0b53bdfcd23ab5d57b48a8f566898cb", size = 175480, upload-time = "2025-11-19T20:39:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/09/4a/028ab78a9f29fd2a7e86a90337cde4658eaa77b425c63045d83a1d2e4f26/ndindex-1.10.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf80241b40adffdc3276b2c9fb63a96c6c98b4a9d941892738de8add65083962", size = 528125, upload-time = "2025-11-19T20:39:26.798Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a9/bd823b345fb06c83ade6ef1c1933521d4357cd04490e684d4fa30126926c/ndindex-1.10.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf5855881884b8467dfcf45764ccf2e4279075be14b155b89c96994bb08d2e6f", size = 527328, upload-time = "2025-11-19T20:39:28.292Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/40b9c15588cbf9dde43c4fb88a31dd1f636a913fa29649f18f8e3ebca36a/ndindex-1.10.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e81a9bd36fe054b6c9fcc53d26bc9a28cf15d1ab52a0f5b854f894116f3a54e1", size = 1497508, upload-time = "2025-11-19T20:39:30.735Z" },
+    { url = "https://files.pythonhosted.org/packages/24/8f/b8048f7837d2e9dff0af507b398307fa84a2aa9ea3db71b4aa800b21da4a/ndindex-1.10.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:588e8875d836a93b3cd9af482c8074bb02288ae1aff92cf277e1f02d9ae0f992", size = 1552625, upload-time = "2025-11-19T20:39:32.404Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/0ecb53c7e690a44769f2f92a843723ccb1d0ce080d93ba1ea811304cca12/ndindex-1.10.1-cp314-cp314-win32.whl", hash = "sha256:28741daca5926adff402247cd406f453ed5bb6042e82d6855938f805190e5ce9", size = 151237, upload-time = "2025-11-19T20:39:34.847Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/4e/197982fa8b4e6e6b9d15c38505c41076d1c552921f09f4d35acbbbbc0b70/ndindex-1.10.1-cp314-cp314-win_amd64.whl", hash = "sha256:59a3222befc0f7cdc85fb9b90a567ae890f70a864bdeb660517e9ebcb36bf1bc", size = 158925, upload-time = "2025-11-19T20:39:37.149Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ad/116b6154046a69fc04e2d4490905801d3839a3f21290c0b4d49b1044e251/ndindex-1.10.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967b87b88dadb62555ec1039695c347254eccb8ca3d124c0e5dbe084c525fa93", size = 181724, upload-time = "2025-11-19T20:39:38.635Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/00/3ce4351366c890bcc87a5e9f1f90102547962eef356ac7c799bfdd0dddce/ndindex-1.10.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c67dde588c0fb89d872931a4ed5f9b4d21c1c70a3d92fdf0812a1de154239816", size = 181653, upload-time = "2025-11-19T20:39:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/05/a6fda696a2f02a3f8dd2ee9d816cb2edff6423bf0110a4876cc3b1259732/ndindex-1.10.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c65ca639a7abf72d79f22424f4abd18dece1f289a2b7b028a0ca455edd2168d4", size = 630898, upload-time = "2025-11-19T20:39:41.495Z" },
+    { url = "https://files.pythonhosted.org/packages/73/78/eb2e5d067d4c054451e33eaece74cbdcb58236dc60516e73d783dae34c7e/ndindex-1.10.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c3634a8df43e7928122225a3d64d850c8957bd1edf2e403907deacb478af27b", size = 614419, upload-time = "2025-11-19T20:39:43.254Z" },
+    { url = "https://files.pythonhosted.org/packages/78/51/261bfb49eb7920c2a7314cacba5821930a529911dce48c7c6cd786096a5a/ndindex-1.10.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9d581f931e61f182478f18bdf5edd3955899df5da4892ed0d5de547a4cfd5b6f", size = 1587517, upload-time = "2025-11-19T20:39:44.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/37/084a332ecdf8b0049151bd78001a7baf2daf7f500d043beb8a1f95d0f4e3/ndindex-1.10.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:78ce45106ebf67aeba99714818c721d8fd5fb9534daebd2565665a2d64b50fc9", size = 1635372, upload-time = "2025-11-19T20:39:47.231Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f4/716580fbb03018ab1daa86ed12c1925c67e79689db5fee82393e840758a2/ndindex-1.10.1-cp314-cp314t-win32.whl", hash = "sha256:fe5341e24dc992b09c258456ac90a09a6d25efdc2cb86dcc91d32c8891e1df9a", size = 162186, upload-time = "2025-11-19T20:39:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/20/28f669c09a470e7f523b0cc10b94336664d9648594015e3f2a1ec29047b1/ndindex-1.10.1-cp314-cp314t-win_amd64.whl", hash = "sha256:37f87f0e7690ae0324334740e0661d6297f2e62c9bf925127d249fb7eddd0ad8", size = 171077, upload-time = "2025-11-19T20:39:50.108Z" },
+]
+
+[[package]]
 name = "nodejs-wheel-binaries"
 version = "24.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -851,6 +1088,53 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/d931255cf9d11a84d6b54d882dba7434646467d568ccf070ea3418638df3/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f1a3d8f7b4491cbbd023ba3fc4e901fcca2d9fb80d57f24ba3890de8b1dbac03", size = 62841759, upload-time = "2026-05-30T16:51:59.407Z" },
     { url = "https://files.pythonhosted.org/packages/a2/7b/8b7a3f41bc255411be30b6d7d288aab8ffd9ea2055db8555ced3548007b9/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_amd64.whl", hash = "sha256:bb136be9944f0662dcf1120f45193a6b75b13fac378971a95cc42c9f879a81aa", size = 42027734, upload-time = "2026-05-30T16:52:03.348Z" },
     { url = "https://files.pythonhosted.org/packages/17/66/1ed71f1f529b8ca727d42c7ceb9db0bef145ce4a13dfc86fb50aa44f3be6/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_arm64.whl", hash = "sha256:8308940b5edd0a50dc5267ea36ba21c9f668e83fe0d9f293937174d3a7e31c36", size = 39714528, upload-time = "2026-05-30T16:52:06.421Z" },
+]
+
+[[package]]
+name = "numexpr"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/c4/27ea7849eb4a7e3b51db446b0414254326dba8c6bdee09b9f2abf963e55d/numexpr-2.14.2.tar.gz", hash = "sha256:e7144e83ea9e581f2273e0304f15836736c4e470e2bd2e378ce617662a1ca278", size = 121744, upload-time = "2026-07-18T10:52:43.185Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/fd/3e7ca4328c22b28717cfe05cd23ca35ffd84e4ca36c3da004323528e9e20/numexpr-2.14.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:606ceaf5722e295ef965ca591736fc26d9e5f13ad950a479e64cead1947f8a3d", size = 164757, upload-time = "2026-07-18T10:51:49.05Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5c/9780d48c4d5effcf55fc7ab7c5651ed82b43250ac8410cce4ef1e97583ed/numexpr-2.14.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:790da022539fe7c37dc893acf530a91c2ca6964d7ba11f464131383729d058f3", size = 153507, upload-time = "2026-07-18T10:51:50.273Z" },
+    { url = "https://files.pythonhosted.org/packages/41/13/ed5efda74ace9a7e2e933476b85bba6d00f2ebf6b833ef59a796ec9af88c/numexpr-2.14.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:327be9ee62251c173236dc620147ff2d0e732a32f5bad918d78a10082f502f63", size = 455373, upload-time = "2026-07-18T10:51:51.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/11/e8953226d658ae67e3e002abaa60a101c693f9c57d74974001729afab5ef/numexpr-2.14.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6a5d8fc7016bf6f6e1808b011510aa7c3bd75ec1407f7650874ec591db59f5e", size = 445187, upload-time = "2026-07-18T10:51:52.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f7/f51b7e10c312bd9617df829e063c87a6d443fd97af54688282ba2b11b1fd/numexpr-2.14.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4b1ff261c3e69c4c59578d3a9ca6132603619d38ae1abe73325563bed3b9bbaf", size = 1420426, upload-time = "2026-07-18T10:51:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bf/21b4e362039ba52f9033a3f57d68160c0829c9c8d66fa7b443b82491322c/numexpr-2.14.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8b8384592c49cb15a91caa54e2cd84d1ce18edb7af030bb76cd29b52e5dc155d", size = 1467554, upload-time = "2026-07-18T10:51:55.391Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/75/0856b1add4e5a7741b80b615f3faace8e3cfffe11e22b6a940ebf25443aa/numexpr-2.14.2-cp312-cp312-win32.whl", hash = "sha256:41cdeacf1b4e51c1143983ea61fcee68139ca47222b55a9265b4fa73826c4260", size = 161441, upload-time = "2026-07-18T10:51:56.503Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/78/c87a88b8e63b5f78c67d555afebefafe81f6e3d98640b4bc1c125d76c9d3/numexpr-2.14.2-cp312-cp312-win_amd64.whl", hash = "sha256:8fc55d14bcf17b3fe69213bea14f999451892b4690717008c66f2edfd6a085ce", size = 157563, upload-time = "2026-07-18T10:51:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/eea56d5ed1ae5252447f45bb461930eab66338eeab32e533aceb080db0bb/numexpr-2.14.2-cp312-cp312-win_arm64.whl", hash = "sha256:806a4471310fe20aa7cb1b2816a6f5e508073a1ad1c2e18041b83e57066fad6a", size = 148820, upload-time = "2026-07-18T10:51:58.536Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/7c/feb19571eb92d70c9952c94deb20092682e7657dc23b3e6c3a22503c9a97/numexpr-2.14.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0741efbd75c284e709b0fd430c85c31982b44c9962922ba8a9cbbea1bf413321", size = 164763, upload-time = "2026-07-18T10:51:59.709Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8a/c4c1f171e101dbfe8b31d8d9f91369ff1bc49b1b4c9a4dc04bb9ed6e4155/numexpr-2.14.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:92b00c78664070e3af155c6be713a0a5d75d598647ce32a5609adb79a8f961d3", size = 153509, upload-time = "2026-07-18T10:52:00.641Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/fb/c27f10ca2e85511a1b0fd3248b1ab5454ea22d932f8fa84836d4bb5c7949/numexpr-2.14.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:149ab5744a5222f07b1d60455c4021c754d395e44938944ac7c7c2495f7feb54", size = 458652, upload-time = "2026-07-18T10:52:01.639Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/1003cc9cc35aad4d56a68f5ffeb26baa4a235b8eb6c0d1ce9b143bece462/numexpr-2.14.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd2f5882a66a7792aa6614c68831aa20085b499d41422aedd001080624ebb14c", size = 448200, upload-time = "2026-07-18T10:52:02.872Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c7/c66fe3a137bb1dc7229adadde22299a156f730016ac70348dcaac4f7b1ef/numexpr-2.14.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:375d8bee15be42dab22100a0a3de05fe6689a2de853eca012858768a9a7e02ab", size = 1420290, upload-time = "2026-07-18T10:52:04.055Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/87/913bb467d71df80dbccaa7fc37402ba681fd6656d5a79652393f40bd5571/numexpr-2.14.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c1ffaf805d8636c3f95d0996517ecf9684c9ac62d768030ca78d1d00af2b3504", size = 1467495, upload-time = "2026-07-18T10:52:05.288Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/24/bf7b467570cd3264c2ab7cf02d7b1806c7dd6b2835b63a4f34e0ad0742d3/numexpr-2.14.2-cp313-cp313-win32.whl", hash = "sha256:449a57fb9d38de136e742b1fc429572b42f29778f1d695c3fe50ffec9d3c9a71", size = 161440, upload-time = "2026-07-18T10:52:06.504Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/59/bdebacebdd073b7ec316c5c3ed95f2e88e8bfc9bcd41af50ee2e0d53a3b2/numexpr-2.14.2-cp313-cp313-win_amd64.whl", hash = "sha256:dd905922d7dce457947d54b84c7ac345cef37332b724445e159a5a1a2080ce2b", size = 157565, upload-time = "2026-07-18T10:52:07.595Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9c/efcb3dc3a5723149842546ca7475549276bd023fe5fafb996e10b88927a0/numexpr-2.14.2-cp313-cp313-win_arm64.whl", hash = "sha256:b02738853b9b5b8a995f6c680f8f6ef33e8f419395b8fa380e38690495fdb911", size = 148823, upload-time = "2026-07-18T10:52:08.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c2/2430700212c749983ea3126e5f6900d02b64d72a95a88193c194783ad7ce/numexpr-2.14.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:76e87c7bd70d721ce4d418e81f4fb7ecf9e7e67d7cea8102527b07fd3d3facf9", size = 164781, upload-time = "2026-07-18T10:52:09.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/42/ce7f08f9ce509dd324afdc97b74c578a4847702e5f49ed32f7910a54cfcf/numexpr-2.14.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:939c89f613b814e64bb568859397dc9f99b219c3ef681a72fb99a86e435262f9", size = 153539, upload-time = "2026-07-18T10:52:10.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/29/2e3a7ad419ec0b4b70ac7e09e4cbb811ccec0ea50976fe657427ec2113b7/numexpr-2.14.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b20c1c55aba7812ff2f2c6a50006425d02282fabb1eaf8d75fe638ffcf6deb02", size = 458710, upload-time = "2026-07-18T10:52:11.7Z" },
+    { url = "https://files.pythonhosted.org/packages/22/79/ce34593e425b5ac1c4aba69306c8811017bea34a4e9f966f6947514e8acb/numexpr-2.14.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bac00898930f962f360c3d763a8e2273fc931f65a1759ff1bf64b3cf13d65aee", size = 448255, upload-time = "2026-07-18T10:52:12.81Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ac/dab6fb4c66713b7676c2ea133a213dcc95a1359ebe52dacb4eeaa7c0f2b3/numexpr-2.14.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:022e61a3d5dbf5807746264b62126d1c2c24057ad90052478a4d4482ab2555c2", size = 1420432, upload-time = "2026-07-18T10:52:14.193Z" },
+    { url = "https://files.pythonhosted.org/packages/12/bc/6131d1ab0166e982542c6034b516a94d6f006fb394b2deffb97e6c07688a/numexpr-2.14.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1d4593e2c6fa060cd7441e8b6ef25c16321a6be2144b3c82d1e00885f1fb6e94", size = 1467525, upload-time = "2026-07-18T10:52:15.474Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b1/23eadd1c0a880ee7c035681837960bd4ae295895ce52e917f152fc3d7995/numexpr-2.14.2-cp314-cp314-win32.whl", hash = "sha256:66f3b125b1104241322811de87918724d6709bf082dc0703722d0cecb7b29e82", size = 163695, upload-time = "2026-07-18T10:52:16.976Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/30/d605eddf0825bfd0ca64219cfa493bc87dee598d919d4c7d30bf9d4b7e49/numexpr-2.14.2-cp314-cp314-win_amd64.whl", hash = "sha256:ef576a1cded27ba2f3129bc3c42df452a1c498072680d560793f98b0024cd7e6", size = 160100, upload-time = "2026-07-18T10:52:18.159Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/48/00c82bd49202d27d9c6072fa3b20ac04bb45c8ee4ffdede67d026a591f0c/numexpr-2.14.2-cp314-cp314-win_arm64.whl", hash = "sha256:8274c51ae1842948f3ae7fe6951a23dcf4ddcbeeaff3737e978e7740b754662d", size = 150953, upload-time = "2026-07-18T10:52:19.183Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3d/0731d84de115f134631142284d636027e0e7702f88838533cff3c449fce0/numexpr-2.14.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f3526699350f94c6277fb16863773a1af9defd95a6f78bbd69b1f0338fd94756", size = 165453, upload-time = "2026-07-18T10:52:20.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/1e/349cf53bba707856f4186a831421727bdc9a352210bea5750ef22fb04212/numexpr-2.14.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:91e7928435f14fcb351c0157000bce65122b897cc8b0df6bcc48251f25850a6d", size = 154091, upload-time = "2026-07-18T10:52:21.172Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/f35e5096006ee89f5e5f65482c5e4a4512faf387e395c7578e5efd4ccaf8/numexpr-2.14.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c66925deb968f0b5280f723e2bb5918c11e6be2ca60e9e1530006286ab44031d", size = 469560, upload-time = "2026-07-18T10:52:22.402Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/00/698b6bdd95403af044928af9fc1dcf7c2b0909146ca5ae26882ebf22dfca/numexpr-2.14.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a404c9a55902572eec810068d06b79a7c99e96f0400f5a7d73f39dff5ec5e371", size = 459233, upload-time = "2026-07-18T10:52:23.687Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/87e160de8cba2779a82f7b9a3c93e39feb4ae50e397f676f96e979ecd92b/numexpr-2.14.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:44dc6b1dfa9abcbfc9917297f0d2af7c87c16b6ecd45747a8e70f54399a3a2f9", size = 1430032, upload-time = "2026-07-18T10:52:25.076Z" },
+    { url = "https://files.pythonhosted.org/packages/00/91/bef92d9f6fb5ce18a3baf96451e1feed99e85b035fc142436e5d7b31bb55/numexpr-2.14.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:93233040f4bed3bce5abb0c2d20aeb1074511f29cbaa9c14828f86bcfa44d321", size = 1476032, upload-time = "2026-07-18T10:52:26.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b0/241550ecad5984bb816e1cc39125a2a9eccf92b85811125a58d10b0eadb7/numexpr-2.14.2-cp314-cp314t-win32.whl", hash = "sha256:2aceefa08f8f86317fa6e8fe9f6dc20d24ab8365d715be4a26306acf406d2dbe", size = 164124, upload-time = "2026-07-18T10:52:27.56Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ad/c5933948b275db2eb5bc3d90c4dff0f53b65622a97dd80aedd99416f3d6d/numexpr-2.14.2-cp314-cp314t-win_amd64.whl", hash = "sha256:cd684ac9daa539fcdac3437678834797b29d7780cfaad71111745132d466d51f", size = 160459, upload-time = "2026-07-18T10:52:28.57Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/df/d7a61d34c48d79f8c72c2dfe0339f4249cfec68a6ebf49be269ac7971ac1/numexpr-2.14.2-cp314-cp314t-win_arm64.whl", hash = "sha256:2ef72de3d3dd466cb0c435cae7141c99b0f8091b1eae9d03dcb38690f56c3f79", size = 151337, upload-time = "2026-07-18T10:52:29.701Z" },
 ]
 
 [[package]]
@@ -1131,6 +1415,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1171,6 +1464,96 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
     { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
     { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
 ]
 
 [[package]]
@@ -1398,6 +1781,40 @@ wheels = [
 ]
 
 [[package]]
+name = "tables"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blosc2" },
+    { name = "numexpr" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "py-cpuinfo" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/a3/d213ebe7376d48055bd55a29cd9f99061afa0dcece608f94a5025d797b0a/tables-3.11.1.tar.gz", hash = "sha256:78abcf413091bc7c1e4e8c10fbbb438d1ac0b5a87436c5b972c3e8253871b6fb", size = 4790533, upload-time = "2026-03-01T11:43:36.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/bb/4a9cde6628563388db26fa86c64adb0f2475a757e72af0ec185fd520b72f/tables-3.11.1-cp311-abi3-macosx_10_9_x86_64.whl", hash = "sha256:eb30684c42a77bbecdef2b9c763c4372b0ddc9cc5bd8b2a2055f2042eee67217", size = 7045977, upload-time = "2026-03-01T11:42:48.605Z" },
+    { url = "https://files.pythonhosted.org/packages/78/74/6568c8d3aabf9982ab89fe3e378afbd7aad4894bde4570991a3246169ef4/tables-3.11.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0367d2e3df0f10ea63ccf4279f3fe58e32ec481767320301a483e2b3cd83efc", size = 6264947, upload-time = "2026-03-01T11:42:53.192Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a3/ec228901fca4c996306b17f5c60a4105144df0bbd07b3a4a816f91f37b4a/tables-3.11.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56bf6fb9132ead989b7e76695d7613d6d08f071a8019038d6565ba90c66b9f3e", size = 6903733, upload-time = "2026-03-01T11:42:58.349Z" },
+    { url = "https://files.pythonhosted.org/packages/99/29/c2dc674ea70fa9a4819417289a9c0d3e4780835beeed573eb66964cfb763/tables-3.11.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e78fe190fdeb4afe430b79651bae2a4f341904eb85aa8dbafe5f1caee1c7f67", size = 7241357, upload-time = "2026-03-01T11:43:03.938Z" },
+    { url = "https://files.pythonhosted.org/packages/60/b5/a59b62af4127790c618eb11c06c106706e07509a3fb9e346b2a3ffa74419/tables-3.11.1-cp311-abi3-win_amd64.whl", hash = "sha256:7fa6cb03f6fe55ae4f85e89ec5450e5c40cc4c52d8c3b60eb157a445c2219e89", size = 6526565, upload-time = "2026-03-01T11:43:08.58Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ce/561c82496e7c8c15ebf19b53b12c0ef91b322a66869db762db9711102764/tables-3.11.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a4bbd95036a4d0cc5c86c1f87fbb490b4c53cd70982f1c01b3ed6dcb3085cbb9", size = 7111409, upload-time = "2026-03-01T11:43:13.424Z" },
+    { url = "https://files.pythonhosted.org/packages/84/18/bac920aee8239b572c506459607c6dd8742bc6275a43d51d2dd6ae1a1541/tables-3.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e3cfe79484351f7216eb8f3767bfa1217bfd271b04428f79cfa7ef6d7491919d", size = 6380142, upload-time = "2026-03-01T11:43:17.213Z" },
+    { url = "https://files.pythonhosted.org/packages/59/3c/f4a694aa744d2b14d536e172c28dd70c84445f4787083a82d6d44a39e39f/tables-3.11.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a9c35f87fcb6a48c79fbc4e3ab15ca8f6053c4ce13063d6ca2ec36cbb58f40f", size = 7014135, upload-time = "2026-03-01T11:43:22.359Z" },
+    { url = "https://files.pythonhosted.org/packages/45/82/94d4320d6c0fe5bd55230eec90cd142d58cda37b7cce00a318ac2a6abd93/tables-3.11.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4cf3218b76ba78d156d6ee75c19fb757d50682f6c7b4905370441afbfc9d77f3", size = 7349293, upload-time = "2026-03-01T11:43:27.569Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/02/a0f61a602ce2f2be8cc2e6146cc51acdaa8a1bb9b823b3863e70d3e0505d/tables-3.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a6f7a3b82dbf0ae0f30de635ca88bb42dd87938b0950369d0ee4289c52ae6de2", size = 6854713, upload-time = "2026-03-01T11:43:31.934Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.68.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1437,6 +1854,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Full-codebase review fixes plus follow-up performance and structure work. Every change was verified to leave the five CI test pipelines (cmfgen, kurucz, qub, floers25, jplt) **byte-identical** (including log files) against a pristine-main baseline run, with physics outputs matching the committed checksums.

### Bug fixes

- **`add_handler_if_not_set` is now pure** (never mutates its input). Previously it mutated the shared inner list for existing elements but returned appended *new* elements only in a copy — so `readdreamdata.extend_ion_list()`, which discarded the return value, silently dropped every element not already in the ion list. DREAM extension now actually adds the lanthanides.
- **`readnahardata.get_photoiontargetfractions`** appended to tuples instead of lists → guaranteed `AttributeError` whenever Nahar core states were present.
- **`readnahardata`**: missing energy file / missing ionization-potential header degrade gracefully instead of raising `NameError`; phixs threshold conversion now uses the same Rydberg constant (13.605693122994232) as the rest of the codebase instead of a stale 13.605698065.
- **`combine_hillier_nahar`**: restored the commented-out `else` branch so `nahar_energyabovegsinev` can no longer carry a stale value from the previous loop iteration; removed two latent `KeyError`s for phixs states absent from the energy table.
- **`readhillierdata`**: fixed the no-op `lowerlevelname.split("[")[0]` so J values are actually stripped from phot-file configuration names (no tested phot file contains bracketed names, so outputs are unchanged); initialized `targetlevelname`; guarded `read_coldata` against a missing transition-count header; corrected the `get_photoiontargetfractions` parameter annotation (it receives a levelid-indexed list, not a dict) and its dead membership check.
- **`readqubdata`**: unsupported ions now raise a clear `ValueError` instead of `NameError` from unbound locals.
- **`readboyledata`**: transition counts keyed by level name, so He III levels no longer always write 0 transitions in adata.txt.
- **`get_term_as_tuple`/`interpret_configuration`**: no longer crash with `IndexError` on short configuration strings.
- **`reduce_phixs_tables_worker`**: error path no longer indexes out of bounds.
- **Test typo**: `text_interpret_term` → `test_interpret_term` (now collected by pytest, passes).
- **Missing dependency**: added `tables` (pytables), required by `pd.read_hdf` for the DREAM handler — the default for Z ≥ 57 — with `uv.lock` updated. Removed the duplicate `ArgumentParser` in `main()`.

### Performance

- `readkuruczdata`/`readtanakajpltdata`/`readfloers25data`: transition counts built from a single `value_counts()` pass instead of scanning the full transition table once per level (previously O(levels × transitions) — dominant for large JPLT ions).
- `readtanakajpltdata`: order-preserving join for `g_u` instead of a per-row `map_elements` lambda.
- `readdreamdata`: the HDF5 file is read once instead of once per ion.

### Refactoring (functional style, no class hierarchies)

- The 15 parallel per-ion lists in `process_files` are replaced by an `IonData` NamedTuple returned from a new `read_ion_data()`; `write_output_files` takes the record list instead of 14 separate parameters.
- Default handler selection moved into `get_default_handler()`, and the nine uniform-signature readers dispatch through a `simple_handler_readers` dict; the four complex handlers (cmfgen, qub_cobalt, nahar, hillier_nahar) keep explicit branches.

### Tests (6 → 13)

- `reduce_phixs_tables_worker` property test: output length, threshold value, monotone decay, exact preservation of a constant cross section, and preservation of the recombination-rate integral at the optimisation temperature (measured deviation 0.05%).
- `add_handler_if_not_set` purity and add/no-duplicate behavior (regression test for the DREAM bug).
- `read_adf04` on the checked-in QUB Co III test sample (262 levels, 235 upsilons, pinned ground-level fields).
- `readnahardata` missing-file handling and `get_photoiontargetfractions` (regression tests for the crashes above).
- Per-handler `get_level_valence_n` examples using real level names from each source's format (kept as separate per-handler parsers by design).
- `readhillierdata.extend_ion_list`.

## Verification

- All five pipeline outputs regenerated locally and diffed byte-for-byte against a pristine-main baseline: identical, including logs. Physics outputs (adata.txt, transitiondata.txt, phixsdata_v2.txt, compositiondata.txt) match the committed CI checksums.
- pytest: 13/13 pass. ruff check, ruff format, pyrefly, basedpyright, and all pre-commit hooks (including ty) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)