### PR TITLE
Fix hydrogenic phixs tables being scaled in energy as well as cross section

### DIFF
--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -991,9 +991,10 @@ def match_hydrogenic_phixs(atomic_number: int, energy_levels, ionization_energy_
 
         n = get_n(level["levelname"])
         effective_charge_squared = threshold_ev * 2 * (n**2) / alpha_squared / mc_squared
-        phixstables[lowerlevelid] = (
-            readhillierdata.get_hydrogenic_n_phixstable(lambda_angstrom=lambda_angstrom, n=n) / effective_charge_squared
-        )
+        # scale the cross sections but not the energy grid
+        phixstable = readhillierdata.get_hydrogenic_n_phixstable(lambda_angstrom=lambda_angstrom, n=n)
+        phixstable[:, 1] /= effective_charge_squared
+        phixstables[lowerlevelid] = phixstable
         photoionization_targetfractions[lowerlevelid] = [(1, 1.0)]
 
     reduced_phixs_dict = reduce_phixs_tables(

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -608,9 +608,10 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                             scale, n = fitcoefficients
                             n = int(n)
                             lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
-                            phixstables[filenum][lowerlevelname] = scale * get_hydrogenic_n_phixstable(
-                                lambda_angstrom, n
-                            )
+                            # scale the cross sections but not the energy grid
+                            phixstable = get_hydrogenic_n_phixstable(lambda_angstrom, n)
+                            phixstable[:, 1] *= scale
+                            phixstables[filenum][lowerlevelname] = phixstable
 
                             numpointsexpected = len(phixstables[filenum][lowerlevelname])
                             # artisatomic.log_and_print(flog, 'Using Hydrogenic pure n formula values for level {0}'.format(lowerlevelname))


### PR DESCRIPTION
## Summary

`get_hydrogenic_n_phixstable()` returns an (N, 2) array of (energy, cross section) rows, and two call sites applied a scalar to the **whole array**, scaling the energy grid along with the cross sections:

- the CMFGEN type-3 cross-section handler in `readhillierdata.read_phixs_tables()`: `scale * get_hydrogenic_n_phixstable(...)`
- `match_hydrogenic_phixs()` in `__init__.py`: `get_hydrogenic_n_phixstable(...) / effective_charge_squared`

The energy grid already starts at the correct threshold derived from the level's wavelength, so scaling it is wrong. The downsampler (`reduce_phixs_tables_worker`) normalises to the first grid point, so the *shape* of the output survived, but the absolute frequencies entering the `exp(-hν/k_BT)` recombination-rate weighting were off by the scale factor, subtly skewing the downsampled cross sections.

Both call sites now scale only the cross-section column (`phixstable[:, 1]`).

## Impact on outputs

None for the CI test configurations:

- None of the nine phot files used by the tested CMFGEN ions (Fe I–V, Co II–IV, Ni II–V) contain type-3 cross sections (verified by grep), and the cmfgen pipeline was rerun after the fix — physics outputs still match the committed checksums.
- `match_hydrogenic_phixs()` only runs with `--use_hydrogenic_for_unknown_phixs`, which no CI test uses. That path was exercised manually with the kurucz test data (Sr and Y) after the fix: clean run with sensible non-zero cross sections (0.33 Mb at the 5.69 eV Sr II threshold).

Outputs **will** change for any non-CI configuration that uses type-3 CMFGEN cross sections or the hydrogenic fallback flag — that is the point of the fix.

Independent of #52 (no overlapping hunks; can merge in either order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)