### PR TITLE
Use zero-based level ids in memory, converting to the output format's 1-based numbering only when writing

### DIFF
--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -1836,7 +1836,17 @@ def write_phixs_data(
     args,
     flog,
 ) -> None:
-    log_and_print(flog, f"Writing {len(photoionization_crosssections)} phixs tables to 'phixsdata2.txt'")
+    # a level gets a table only if it has photoionisation targets and a threshold energy. The
+    # threshold arrays start as zeros and are only filled in for levels that got a cross-section
+    # table, so a threshold of exactly zero means "no data for this level". (A negative threshold
+    # is a deliberate sentinel used by readqubdata, so keep those.)
+    levelids_with_targets = [
+        levelid for levelid, targetlist in enumerate(photoionization_targetfractions) if targetlist
+    ]
+    levelids_to_write = [levelid for levelid in levelids_with_targets if photoionization_thresholds_ev[levelid] != 0.0]
+    skipped_zero_threshold = len(levelids_with_targets) - len(levelids_to_write)
+
+    log_and_print(flog, f"Writing {len(levelids_to_write)} phixs tables to 'phixsdata2.txt'")
     flog.write(
         f"Downsampling cross sections assuming T={args.optimaltemperature} Kelvin, "
         f"nphixspoints={args.nphixspoints}, phixsnuincrement={args.phixsnuincrement}\n"
@@ -1846,19 +1856,11 @@ def write_phixs_data(
         log_and_print(flog, "ERROR: ground state has zero photoionization cross section")
         sys.exit()
 
-    skipped_zero_threshold = 0
     # level ids (of this ion and of the upper ion's photoionisation targets) are zero-based in
     # memory, but the output format numbers them from one
-    for lowerlevelid, targetlist in enumerate(photoionization_targetfractions):
-        if not targetlist:
-            continue
+    for lowerlevelid in levelids_to_write:
+        targetlist = photoionization_targetfractions[lowerlevelid]
         threshold_ev = photoionization_thresholds_ev[lowerlevelid]
-        if threshold_ev == 0.0:
-            # the threshold arrays start as zeros and are only filled in for levels that got a
-            # cross-section table, so a threshold of exactly zero means "no data for this level".
-            # (A negative threshold is a deliberate sentinel used by readqubdata, so keep those.)
-            skipped_zero_threshold += 1
-            continue
         if len(targetlist) == 1 and targetlist[0][1] > 0.99:
             upperionlevelid = targetlist[0][0]
 

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import argcomplete
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import polars as pl
 from scipy import integrate
@@ -318,16 +319,17 @@ class IonData(t.NamedTuple):
     ionization_energy_ev: float
     dfenergylevels: pl.DataFrame
     dftransitions: pl.DataFrame
-    transition_count_of_level_name: dict
-    upsilondict: dict
-    # list of readnahardata.NaharCoreState, where core state id n is at index n - 1 ([] if unavailable)
-    nahar_core_states: list
-    # keys are (2S+1, L, parity), values are strings of electron configuration
-    nahar_configurations: dict
-    hillier_photoion_targetconfigs: list | None
-    photoionization_crosssections: t.Any  # cross sections in Mb, level id n at index n - 1
-    photoionization_targetfractions: list
-    photoionization_thresholds_ev: t.Any  # level id n at index n - 1
+    transition_count_of_level_name: dict[str, int]
+    upsilondict: dict[tuple[int, int], float]
+    # core state id n is at index n - 1 ([] if unavailable)
+    nahar_core_states: list[readnahardata.NaharCoreState]
+    # keys are (2S+1, L, parity, index in symmetry), values are strings of electron configuration
+    nahar_configurations: dict[tuple[int, int, int, int], str]
+    # None where a level has no photoionisation data (and None entirely if none was read)
+    hillier_photoion_targetconfigs: list[list[tuple[str, float]] | None] | None
+    photoionization_crosssections: npt.NDArray[np.float64]  # cross sections in Mb, indexed by level id
+    photoionization_targetfractions: list[list[tuple[int, float]]]  # indexed by level id
+    photoionization_thresholds_ev: npt.NDArray[np.float64]  # indexed by level id
 
 
 def get_default_handler(atomic_number: int, ion_stage: int) -> str:
@@ -389,14 +391,15 @@ def read_ion_data(
         ion_stage, handler = ion_stage_entry
 
     ionization_energy_ev = 0.0
-    transition_count_of_level_name: dict = {}
-    upsilondict: dict = {}
-    nahar_core_states: list = []
-    nahar_configurations: dict = {}
-    hillier_photoion_targetconfigs = None
-    photoionization_crosssections: t.Any = []  # list of cross section in Mb
-    photoionization_targetfractions: list = []
-    photoionization_thresholds_ev: t.Any = []
+    transition_count_of_level_name: dict[str, int] = {}
+    upsilondict: dict[tuple[int, int], float] = {}
+    nahar_core_states: list[readnahardata.NaharCoreState] = []
+    nahar_configurations: dict[tuple[int, int, int, int], str] = {}
+    hillier_photoion_targetconfigs: list[list[tuple[str, float]] | None] | None = None
+    # empty until a handler below reads photoionisation data (and left empty for the top ion)
+    photoionization_crosssections: npt.NDArray[np.float64] = np.empty((0, args.nphixspoints))  # in Mb
+    photoionization_targetfractions: list[list[tuple[int, float]]] = []
+    photoionization_thresholds_ev: npt.NDArray[np.float64] = np.empty(0)
 
     logfilepath = Path(
         args.output_folder, args.output_folder_logs, f"{elsymbols[atomic_number].lower()}{ion_stage:d}.txt"
@@ -655,8 +658,9 @@ def combine_hillier_nahar(
     useallnaharlevels=False,
 ):
     added_nahar_levels = []
-    photoionization_crosssections = []
-    photoionization_thresholds_ev = []
+    # stay empty unless there are Nahar phixs tables to attach to the combined level list
+    photoionization_crosssections: npt.NDArray[np.float64] = np.empty((0, args.nphixspoints))
+    photoionization_thresholds_ev: npt.NDArray[np.float64] = np.empty(0)
     levelids_of_levelnamenoJ = defaultdict(list)
 
     if useallnaharlevels:
@@ -946,7 +950,9 @@ def get_nist_ionization_energies_ev() -> dict[tuple[int, int], float]:
     return dictioniz
 
 
-def match_hydrogenic_phixs(atomic_number: int, energy_levels, ionization_energy_ev: float, ion_handler: str, args):
+def match_hydrogenic_phixs(
+    atomic_number: int, energy_levels: pl.DataFrame, ionization_energy_ev: float, ion_handler: str, args
+) -> tuple[npt.NDArray[np.float64], list[list[tuple[int, float]]], npt.NDArray[np.float64]]:
     dict_get_n_func = {
         "tanakajplt": readtanakajpltdata.get_level_valence_n,
         "kurucz": readkuruczdata.get_level_valence_n,
@@ -959,13 +965,13 @@ def match_hydrogenic_phixs(atomic_number: int, energy_levels, ionization_energy_
         print(
             f"WARNING: Can't assign hydrogenic photoionization cross sections because I don't know how to find principle quantum numbers for {ion_handler} levels"
         )
-        return [], [], []
+        return np.empty((0, args.nphixspoints)), [], np.empty(0)
 
     get_n = dict_get_n_func[ion_handler]
     print(f"using hydrogenic photoionization cross sections for Z={atomic_number} {elsymbols[atomic_number]}")
 
     photoionization_crosssections = np.zeros((energy_levels.height, args.nphixspoints))
-    photoionization_targetfractions: list = [[] for _ in range(energy_levels.height)]
+    photoionization_targetfractions: list[list[tuple[int, float]]] = [[] for _ in range(energy_levels.height)]
     photoionization_thresholds_ev = np.zeros(energy_levels.height)
     phixstables = {}
     for levelindex, level in enumerate(energy_levels.iter_rows(named=True)):
@@ -1812,9 +1818,9 @@ def write_phixs_data(
     fphixs,
     atomic_number: int,
     ion_stage: int,
-    photoionization_crosssections,
-    photoionization_targetfractions,
-    photoionization_thresholds_ev,
+    photoionization_crosssections: npt.NDArray[np.float64],
+    photoionization_targetfractions: list[list[tuple[int, float]]],
+    photoionization_thresholds_ev: npt.NDArray[np.float64],
     args,
     flog,
 ) -> None:

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -191,32 +191,23 @@ def add_handler_if_not_set(
     return ion_handlers_out
 
 
-def add_dummy_zero_level(dflevels: pl.DataFrame) -> pl.DataFrame:
-    # keep the zero index as null since we use 1-index level indicies
-    anycolname = dflevels.columns[0]
-    return pl.concat(
-        [
-            pl.DataFrame({anycolname: [None]}, schema={anycolname: dflevels.schema[anycolname]}),
-            dflevels,
-        ],
-        how="diagonal",
-    )
-
-
 def leveltuples_to_pldataframe(energy_levels) -> pl.DataFrame:
-    if isinstance(energy_levels, pl.DataFrame):
-        dflevels = energy_levels
-        assert energy_levels["energyabovegsinpercm"].item(0) is None
-
-    else:
-        dflevels = add_dummy_zero_level(
-            pl.DataFrame(energy_levels[1:]),
-        )
+    """Convert a zero-indexed list of level tuples (or a DataFrame) into a DataFrame with 1-based levelid values."""
+    dflevels = energy_levels if isinstance(energy_levels, pl.DataFrame) else pl.DataFrame(energy_levels)
 
     if "levelid" not in dflevels.columns:
-        dflevels = dflevels.with_row_index(name="levelid")
+        dflevels = dflevels.with_row_index(name="levelid", offset=1)
 
-    return dflevels.with_columns(pl.col("levelid").cast(pl.Int64))
+    dflevels = dflevels.with_columns(pl.col("levelid").cast(pl.Int64))
+
+    # positional lookups throughout assume level id n is at row n - 1, so a reader-supplied
+    # levelid column (e.g. from the tanakajplt data files) must be contiguous and start at 1.
+    # A raise rather than an assert: this can be validating an input file's id column.
+    if not dflevels["levelid"].equals(pl.int_range(1, dflevels.height + 1, dtype=pl.Int64, eager=True)):
+        msg = "level ids must be contiguous and start at 1"
+        raise ValueError(msg)
+
+    return dflevels
 
 
 def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None = None, **kwargs: t.Any) -> None:
@@ -325,14 +316,14 @@ class IonData(t.NamedTuple):
     dftransitions: pl.DataFrame
     transition_count_of_level_name: dict
     upsilondict: dict
-    # list of readnahardata.NaharCoreState with a dummy None at index zero ([None] if unavailable)
+    # list of readnahardata.NaharCoreState, where core state id n is at index n - 1 ([] if unavailable)
     nahar_core_states: list
     # keys are (2S+1, L, parity), values are strings of electron configuration
     nahar_configurations: dict
     hillier_photoion_targetconfigs: list | None
-    photoionization_crosssections: t.Any  # cross sections in Mb, indexed by levelid
+    photoionization_crosssections: t.Any  # cross sections in Mb, level id n at index n - 1
     photoionization_targetfractions: list
-    photoionization_thresholds_ev: t.Any  # indexed by levelid
+    photoionization_thresholds_ev: t.Any  # level id n at index n - 1
 
 
 def get_default_handler(atomic_number: int, ion_stage: int) -> str:
@@ -396,7 +387,7 @@ def read_ion_data(
     ionization_energy_ev = 0.0
     transition_count_of_level_name: dict = {}
     upsilondict: dict = {}
-    nahar_core_states: list = [None]
+    nahar_core_states: list = []
     nahar_configurations: dict = {}
     hillier_photoion_targetconfigs = None
     photoionization_crosssections: t.Any = []  # list of cross section in Mb
@@ -491,7 +482,7 @@ def read_ion_data(
                 photoionization_crosssections,
                 photoionization_thresholds_ev,
             ) = combine_hillier_nahar(
-                [None],
+                [],
                 defaultdict(list),
                 [],
                 nahar_energy_levels,
@@ -665,11 +656,12 @@ def combine_hillier_nahar(
     levelids_of_levelnamenoJ = defaultdict(list)
 
     if useallnaharlevels:
-        added_nahar_levels = nahar_energy_levels[1:]
+        added_nahar_levels = list(nahar_energy_levels)
     else:
-        for levelid, energy_level in enumerate(hillier_energy_levels[1:], 1):
+        # values are zero-based indices into hillier_energy_levels
+        for levelindex, energy_level in enumerate(hillier_energy_levels):
             levelnamenoJ = energy_level.levelname.split("[")[0]
-            levelids_of_levelnamenoJ[levelnamenoJ].append(levelid)
+            levelids_of_levelnamenoJ[levelnamenoJ].append(levelindex)
 
         # match up Nahar states given in phixs data with Hillier levels, adding
         # missing levels as necessary
@@ -834,13 +826,13 @@ def combine_hillier_nahar(
 
     log_and_print(
         flog,
-        f"Included {len(hillier_energy_levels) - 1} levels from Hillier dataset and added"
-        f" {len(added_nahar_levels)} levels from Nahar phixs tables for a total of {len(energy_levels) - 1} levels",
+        f"Included {len(hillier_energy_levels)} levels from Hillier dataset and added"
+        f" {len(added_nahar_levels)} levels from Nahar phixs tables for a total of {len(energy_levels)} levels",
     )
 
     # sort the concatenated energy level list by energy
     print("Sorting levels by energy...")
-    energy_levels.sort(key=lambda x: float(getattr(x, "energyabovegsinpercm", "-inf")))
+    energy_levels.sort(key=lambda x: float(x.energyabovegsinpercm))
 
     if len(nahar_phixs_tables.keys()) > 0:
         photoionization_crosssections = np.zeros(
@@ -860,15 +852,15 @@ def combine_hillier_nahar(
 
             for (twosplusone, l, parity, indexinsymmetry), phixstable in reduced_phixs_dict.items():
                 foundamatch = False
-                for levelid, energylevel in enumerate(energy_levels[1:], 1):
+                for levelindex, energylevel in enumerate(energy_levels):
                     if (
                         int(energylevel.twosplusone) == twosplusone
                         and int(energylevel.l) == l
                         and int(energylevel.parity) == parity
                         and int(energylevel.indexinsymmetry) == indexinsymmetry
                     ):
-                        photoionization_crosssections[levelid] = phixstable
-                        photoionization_thresholds_ev[levelid] = thresholds_ev_dict[
+                        photoionization_crosssections[levelindex] = phixstable
+                        photoionization_thresholds_ev[levelindex] = thresholds_ev_dict[
                             (twosplusone, l, parity, indexinsymmetry)
                         ]
                         foundamatch = (
@@ -972,9 +964,8 @@ def match_hydrogenic_phixs(atomic_number: int, energy_levels, ionization_energy_
     photoionization_targetfractions: list = [[] for _ in range(energy_levels.height)]
     photoionization_thresholds_ev = np.zeros(energy_levels.height)
     phixstables = {}
-    for level in energy_levels[1:].iter_rows(named=True):
-        lowerlevelid = level["levelid"]
-        if lowerlevelid > 100:
+    for levelindex, level in enumerate(energy_levels.iter_rows(named=True)):
+        if levelindex >= 100:
             # limit levels with hydrogenic photoionization cross sections
             break
         en_ev = hc_in_ev_cm * level["energyabovegsinpercm"]
@@ -982,20 +973,20 @@ def match_hydrogenic_phixs(atomic_number: int, energy_levels, ionization_energy_
         if threshold_ev <= 0.0:
             # level lies above the ionization energy, so there is nothing to ionize from
             continue
-        photoionization_thresholds_ev[lowerlevelid] = threshold_ev
+        photoionization_thresholds_ev[levelindex] = threshold_ev
         lambda_angstrom = hc_in_ev_angstrom / threshold_ev
 
         n = get_n(level["levelname"])
         # get_hydrogenic_n_phixstable() already scales by the effective charge, since its
         # scale factor 7.91 / (E_threshold / Ryd) / n is the Kramers result 7.91 * n / Z_eff^2
-        phixstables[lowerlevelid] = readhillierdata.get_hydrogenic_n_phixstable(lambda_angstrom=lambda_angstrom, n=n)
-        photoionization_targetfractions[lowerlevelid] = [(1, 1.0)]
+        phixstables[levelindex] = readhillierdata.get_hydrogenic_n_phixstable(lambda_angstrom=lambda_angstrom, n=n)
+        photoionization_targetfractions[levelindex] = [(1, 1.0)]
 
     reduced_phixs_dict = reduce_phixs_tables(
         phixstables, args.optimaltemperature, args.nphixspoints, args.phixsnuincrement
     )
-    for lowerlevelid, reduced_phixs_table in reduced_phixs_dict.items():
-        photoionization_crosssections[lowerlevelid] = reduced_phixs_table
+    for levelindex, reduced_phixs_table in reduced_phixs_dict.items():
+        photoionization_crosssections[levelindex] = reduced_phixs_table
 
     return photoionization_crosssections, photoionization_targetfractions, photoionization_thresholds_ev
 
@@ -1194,6 +1185,7 @@ def check_forbidden(levela, levelb) -> bool:
 
 
 def weightedavgenergyinev(energylevels_thision, ids) -> float:
+    """Statistical-weight-averaged energy of the levels at the given zero-based list indices."""
     genergysum = 0.0
     gsum = 0.0
     for levelid in ids:
@@ -1204,6 +1196,7 @@ def weightedavgenergyinev(energylevels_thision, ids) -> float:
 
 
 def weightedavgthresholdinev(energylevels_thision, ids) -> float:
+    """Statistical-weight-averaged ionisation threshold of the levels at the given zero-based list indices."""
     genergysum = 0.0
     gsum = 0.0
     for levelid in ids:
@@ -1643,8 +1636,8 @@ def write_output_files(atomic_number: int, iondatalist: list[IonData], args: arg
                 orient="row",
             ).with_columns(A=0.0)
             for id_lower, id_upper in dfupsilon_only_transitions[["lowerlevel", "upperlevel"]].iter_rows(named=False):
-                namefrom = dfenergylevels_ion["levelname"][id_upper]
-                nameto = dfenergylevels_ion["levelname"][id_lower]
+                namefrom = dfenergylevels_ion["levelname"][id_upper - 1]
+                nameto = dfenergylevels_ion["levelname"][id_lower - 1]
 
                 transition_count_of_level_name[namefrom] += 1
                 transition_count_of_level_name[nameto] += 1
@@ -1693,7 +1686,7 @@ def write_output_files(atomic_number: int, iondatalist: list[IonData], args: arg
         if i < len(iondatalist) - 1 and not args.nophixs:  # ignore the top ion
             photoionization_targetfractions = iondata.photoionization_targetfractions
             if len(photoionization_targetfractions) < 1:
-                if len(iondata.nahar_core_states) > 1:
+                if len(iondata.nahar_core_states) > 0:
                     photoionization_targetfractions = readnahardata.get_photoiontargetfractions(
                         dfenergylevels_ion,
                         iondatalist[i + 1].dfenergylevels,
@@ -1730,10 +1723,10 @@ def write_adata(
     transition_count_of_level_name,
     flog,
 ) -> None:
-    log_and_print(flog, f"Writing {dfenergylevels.height - 1} levels to 'adata.txt'")
-    fatommodels.write(f"{atomic_number:12d}{ion_stage:12d}{dfenergylevels.height - 1:12d}{ionization_energy:15.7f}\n")
+    log_and_print(flog, f"Writing {dfenergylevels.height} levels to 'adata.txt'")
+    fatommodels.write(f"{atomic_number:12d}{ion_stage:12d}{dfenergylevels.height:12d}{ionization_energy:15.7f}\n")
 
-    for energylevel in dfenergylevels[1:].iter_rows(named=True):
+    for energylevel in dfenergylevels.iter_rows(named=True):
         transitioncount = (
             transition_count_of_level_name.get(energylevel["levelname"], 0) if "levelname" in energylevel else 0
         )
@@ -1825,15 +1818,16 @@ def write_phixs_data(
         f"nphixspoints={args.nphixspoints}, phixsnuincrement={args.phixsnuincrement}\n"
     )
 
-    if len(photoionization_crosssections) >= 2 and photoionization_crosssections[1][0] == 0.0:
+    if len(photoionization_crosssections) >= 1 and photoionization_crosssections[0][0] == 0.0:
         log_and_print(flog, "ERROR: ground state has zero photoionization cross section")
         sys.exit()
 
     skipped_zero_threshold = 0
-    for lowerlevelid, targetlist in enumerate(photoionization_targetfractions[1:], 1):
+    for levelindex, targetlist in enumerate(photoionization_targetfractions):
+        lowerlevelid = levelindex + 1
         if not targetlist:
             continue
-        threshold_ev = photoionization_thresholds_ev[lowerlevelid]
+        threshold_ev = photoionization_thresholds_ev[levelindex]
         if threshold_ev == 0.0:
             # the threshold arrays start as zeros and are only filled in for levels that got a
             # cross-section table, so a threshold of exactly zero means "no data for this level".
@@ -1861,7 +1855,7 @@ def write_phixs_data(
                 print(f"level id {lowerlevelid}")
                 sys.exit()
 
-        for crosssection in photoionization_crosssections[lowerlevelid]:
+        for crosssection in photoionization_crosssections[levelindex]:
             fphixs.write(f"{crosssection:16.8E}\n")
 
     if skipped_zero_threshold > 0:

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -192,19 +192,23 @@ def add_handler_if_not_set(
 
 
 def leveltuples_to_pldataframe(energy_levels) -> pl.DataFrame:
-    """Convert a zero-indexed list of level tuples (or a DataFrame) into a DataFrame with 1-based levelid values."""
+    """Convert a list of level tuples (or a DataFrame) into a DataFrame with a zero-based levelid column.
+
+    Level ids are zero-based everywhere in memory; the 1-based numbering of the output files is
+    applied by the write_*() functions.
+    """
     dflevels = energy_levels if isinstance(energy_levels, pl.DataFrame) else pl.DataFrame(energy_levels)
 
     if "levelid" not in dflevels.columns:
-        dflevels = dflevels.with_row_index(name="levelid", offset=1)
+        dflevels = dflevels.with_row_index(name="levelid")
 
     dflevels = dflevels.with_columns(pl.col("levelid").cast(pl.Int64))
 
-    # positional lookups throughout assume level id n is at row n - 1, so a reader-supplied
-    # levelid column (e.g. from the tanakajplt data files) must be contiguous and start at 1.
+    # lookups elsewhere index this frame by level id, so a reader-supplied levelid column
+    # (e.g. from the tanakajplt data files) must be contiguous and start at zero.
     # A raise rather than an assert: this can be validating an input file's id column.
-    if not dflevels["levelid"].equals(pl.int_range(1, dflevels.height + 1, dtype=pl.Int64, eager=True)):
-        msg = "level ids must be contiguous and start at 1"
+    if not dflevels["levelid"].equals(pl.int_range(dflevels.height, dtype=pl.Int64, eager=True)):
+        msg = "level ids must be contiguous and start at zero"
         raise ValueError(msg)
 
     return dflevels
@@ -980,7 +984,7 @@ def match_hydrogenic_phixs(atomic_number: int, energy_levels, ionization_energy_
         # get_hydrogenic_n_phixstable() already scales by the effective charge, since its
         # scale factor 7.91 / (E_threshold / Ryd) / n is the Kramers result 7.91 * n / Z_eff^2
         phixstables[levelindex] = readhillierdata.get_hydrogenic_n_phixstable(lambda_angstrom=lambda_angstrom, n=n)
-        photoionization_targetfractions[levelindex] = [(1, 1.0)]
+        photoionization_targetfractions[levelindex] = [(0, 1.0)]  # the upper ion's ground state
 
     reduced_phixs_dict = reduce_phixs_tables(
         phixstables, args.optimaltemperature, args.nphixspoints, args.phixsnuincrement
@@ -1636,8 +1640,8 @@ def write_output_files(atomic_number: int, iondatalist: list[IonData], args: arg
                 orient="row",
             ).with_columns(A=0.0)
             for id_lower, id_upper in dfupsilon_only_transitions[["lowerlevel", "upperlevel"]].iter_rows(named=False):
-                namefrom = dfenergylevels_ion["levelname"][id_upper - 1]
-                nameto = dfenergylevels_ion["levelname"][id_lower - 1]
+                namefrom = dfenergylevels_ion["levelname"][id_upper]
+                nameto = dfenergylevels_ion["levelname"][id_lower]
 
                 transition_count_of_level_name[namefrom] += 1
                 transition_count_of_level_name[nameto] += 1
@@ -1757,8 +1761,9 @@ def write_adata(
         else:
             level_comment = level_comment.rstrip()
 
+        # level ids are zero-based in memory, but the output format numbers them from one
         fatommodels.write(
-            f"{energylevel['levelid']:5d} {hc_in_ev_cm * float(energylevel['energyabovegsinpercm']):19.16f} {float(energylevel['g']):8.3f} {transitioncount:4d} {level_comment:}\n"
+            f"{energylevel['levelid'] + 1:5d} {hc_in_ev_cm * float(energylevel['energyabovegsinpercm']):19.16f} {float(energylevel['g']):8.3f} {transitioncount:4d} {level_comment:}\n"
         )
 
     fatommodels.write("\n")
@@ -1781,8 +1786,9 @@ def write_transition_data(
         ].iter_rows():
             assert levelid_lower < levelid_upper
 
+            # level ids are zero-based in memory, but the output format numbers them from one
             ftransitiondata.write(
-                f"{levelid_lower:4d} {levelid_upper:4d} {float(A):11.5e} {coll_str:9.2e} {forbidden:d}\n"
+                f"{levelid_lower + 1:4d} {levelid_upper + 1:4d} {float(A):11.5e} {coll_str:9.2e} {forbidden:d}\n"
             )
 
     ftransitiondata.write("\n")
@@ -1823,11 +1829,12 @@ def write_phixs_data(
         sys.exit()
 
     skipped_zero_threshold = 0
-    for levelindex, targetlist in enumerate(photoionization_targetfractions):
-        lowerlevelid = levelindex + 1
+    # level ids (of this ion and of the upper ion's photoionisation targets) are zero-based in
+    # memory, but the output format numbers them from one
+    for lowerlevelid, targetlist in enumerate(photoionization_targetfractions):
         if not targetlist:
             continue
-        threshold_ev = photoionization_thresholds_ev[levelindex]
+        threshold_ev = photoionization_thresholds_ev[lowerlevelid]
         if threshold_ev == 0.0:
             # the threshold arrays start as zeros and are only filled in for levels that got a
             # cross-section table, so a threshold of exactly zero means "no data for this level".
@@ -1838,16 +1845,16 @@ def write_phixs_data(
             upperionlevelid = targetlist[0][0]
 
             fphixs.write(
-                f"{atomic_number:12d}{ion_stage + 1:12d}{upperionlevelid:8d}{ion_stage:12d}{lowerlevelid:8d}{threshold_ev:16.6E}\n"
+                f"{atomic_number:12d}{ion_stage + 1:12d}{upperionlevelid + 1:8d}{ion_stage:12d}{lowerlevelid + 1:8d}{threshold_ev:16.6E}\n"
             )
         else:
             fphixs.write(
-                f"{atomic_number:12d}{ion_stage + 1:12d}{-1:8d}{ion_stage:12d}{lowerlevelid:8d}{threshold_ev:16.6E}\n"
+                f"{atomic_number:12d}{ion_stage + 1:12d}{-1:8d}{ion_stage:12d}{lowerlevelid + 1:8d}{threshold_ev:16.6E}\n"
             )
             fphixs.write(f"{len(targetlist):8d}\n")
             probability_sum = 0.0
             for upperionlevelid, targetprobability in targetlist:
-                fphixs.write(f"{upperionlevelid:8d}{targetprobability:12f}\n")
+                fphixs.write(f"{upperionlevelid + 1:8d}{targetprobability:12f}\n")
                 probability_sum += targetprobability
             if abs(probability_sum - 1.0) > 0.00001:
                 print(f"STOP! phixs fractions sum to {probability_sum:.5f} != 1.0")
@@ -1855,7 +1862,7 @@ def write_phixs_data(
                 print(f"level id {lowerlevelid}")
                 sys.exit()
 
-        for crosssection in photoionization_crosssections[levelindex]:
+        for crosssection in photoionization_crosssections[lowerlevelid]:
             fphixs.write(f"{crosssection:16.8E}\n")
 
     if skipped_zero_threshold > 0:

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -22,8 +22,8 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import polars as pl
-from scipy import integrate
-from scipy import interpolate
+from scipy import integrate  # pyright: ignore[reportMissingTypeStubs]
+from scipy import interpolate  # pyright: ignore[reportMissingTypeStubs]
 
 from artisatomic import groundstatesonlynist
 from artisatomic import readboyledata
@@ -360,7 +360,7 @@ def get_default_handler(atomic_number: int, ion_stage: int) -> str:
 # handlers whose readers share a common call signature and return
 # (ionization_energy_ev, energy_levels, transitions, transition_count_of_level_name)
 # with an additional upsilondict for qub_data
-simple_handler_readers: dict[str, Callable[..., tuple]] = {
+simple_handler_readers: dict[str, Callable[..., tuple[t.Any, ...]]] = {
     "boyle": lambda atomic_number, ion_stage, _flog: readboyledata.read_levels_and_transitions(
         atomic_number, ion_stage
     ),
@@ -475,8 +475,8 @@ def read_ion_data(
 
             # keys are (2S+1, L, parity, indexinsymmetry), values are lists of
             # (energy in Rydberg, cross section in Mb) tuples
-            nahar_phixs_tables: dict = {}
-            thresholds_ev_dict: dict = {}
+            nahar_phixs_tables: dict[tuple[int, int, int, int], npt.NDArray[np.float64]] = {}
+            thresholds_ev_dict: dict[tuple[int, int, int, int], float] = {}
             if not is_top_ion:  # don't get cross sections for top ion
                 log_and_print(flog, f"Reading {path_for_log(path_nahar_px_file)}")
                 nahar_phixs_tables, thresholds_ev_dict = readnahardata.read_nahar_phixs_tables(
@@ -912,7 +912,7 @@ def isfloat(value: t.Any) -> bool:
     return True
 
 
-def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO:
+def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO[t.Any]:
     from xopen import xopen
 
     extensions = ["", ".zst", ".gz", ".xz"]
@@ -927,7 +927,7 @@ def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO:
 
 
 # split a list into evenly sized chunks
-def chunks(listin: list, chunk_size: int) -> list:
+def chunks[T](listin: list[T], chunk_size: int) -> list[list[T]]:
     return [listin[i : i + chunk_size] for i in range(0, len(listin), chunk_size)]
 
 
@@ -1010,7 +1010,9 @@ def parallel_map[ResultType](
     use_multiprocessing = True
     if sys.version_info >= (3, 13):
         with contextlib.suppress(AttributeError):
-            if not sys._is_gil_enabled():  # noqa: SLF001
+            # unreachable at the minimum supported version (3.12), which is what the type
+            # checkers are configured for, but reachable on the 3.13+ free-threading builds
+            if not sys._is_gil_enabled():  # noqa: SLF001 # pyright: ignore[reportUnreachable]
                 # return a thread pool if we have no GIL (free threading)
                 use_multiprocessing = False
 
@@ -1028,11 +1030,19 @@ def parallel_map[ResultType](
     return results
 
 
-def reduce_phixs_tables(dicttables, optimaltemperature: float, nphixspoints: int, phixsnuincrement: float) -> dict:
+def reduce_phixs_tables[KeyType](
+    dicttables: dict[KeyType, npt.NDArray[np.float64]],
+    optimaltemperature: float,
+    nphixspoints: int,
+    phixsnuincrement: float,
+) -> dict[KeyType, npt.NDArray[np.float64]]:
     """Receives a dictionary, with each item being a 2D array of energy and cross section points
     Returns a dictionary with the items having been downsampled into a 1D array.
 
     Units don't matter, but the first (lowest) energy point is assumed to be the threshold energy
+
+    The key type is preserved: callers index the tables by level name, by Nahar state tuple, or
+    by level id.
     """
     print(f"Processing {len(dicttables.keys()):d} phixs tables")
 
@@ -1237,6 +1247,7 @@ def get_term_as_tuple(config: str) -> tuple[int, int, int]:
         return (-1, -1, -1)
 
     lposition = -1
+    l = -1
     for charpos, char in reversed(list(enumerate(config))):
         if char in lchars:
             lposition = charpos
@@ -1277,6 +1288,7 @@ def get_term_as_tuple(config: str) -> tuple[int, int, int]:
 def interpret_parent_term(strin: str) -> tuple[int, int, int]:
     strin = strin.strip("()")
     lposition = -1
+    l = -1
     for charpos, char in reversed(list(enumerate(strin))):
         if char in lchars:
             lposition = charpos

--- a/artisatomic/groundstatesonlynist.py
+++ b/artisatomic/groundstatesonlynist.py
@@ -31,7 +31,6 @@ def read_ground_levels(atomic_number, ion_stage, flog):
     ionization_energy_in_ev = this_ion["IonizationEnergy"].to_numpy()[0]
     artisatomic.log_and_print(flog, f"ionization energy: {ionization_energy_in_ev} eV")
     energy_levels = [
-        None,
         EnergyLevel(
             levelname=this_ion["config"].to_numpy()[0],
             parity=0,

--- a/artisatomic/groundstatesonlynist.py
+++ b/artisatomic/groundstatesonlynist.py
@@ -38,8 +38,8 @@ def read_ground_levels(atomic_number, ion_stage, flog):
             energyabovegsinpercm=0.0,
         ),
     ]
-    transitions = []
-    transition_count_of_level_name = defaultdict(int)
+    transitions: list[t.Any] = []  # this handler provides ground states only, so never any transitions
+    transition_count_of_level_name: defaultdict[str, int] = defaultdict(int)
 
     return ionization_energy_in_ev, energy_levels, transitions, transition_count_of_level_name
 

--- a/artisatomic/makerecombratefile.py
+++ b/artisatomic/makerecombratefile.py
@@ -5,7 +5,7 @@ import sys
 from collections import namedtuple
 from pathlib import Path
 
-import ChiantiPy.core as ch
+import ChiantiPy.core as ch  # pyright: ignore[reportMissingTypeStubs]
 import numpy as np
 import pandas as pd
 from artistools import get_composition_data
@@ -16,7 +16,7 @@ def read_nahar_rrcfile(filename, noprint=False):
     if not noprint:
         print(f"  reading {filename}")
 
-    header_row = []
+    header_row: list[str] = []
     with open(filename) as filein:
         while True:
             line = filein.readline()
@@ -52,7 +52,8 @@ def read_nahar_rrcfile(filename, noprint=False):
 
 def main():
     # Shull & Steenberg 1982
-    A_rad, X_rad = {}, {}
+    A_rad: dict[tuple[int, int], float] = {}
+    X_rad: dict[tuple[int, int], float] = {}
     A_rad[26, 1], X_rad[26, 1] = 1.42e-13, 0.891
     A_rad[26, 2], X_rad[26, 2] = 1.02e-12, 0.843
     A_rad[26, 3], X_rad[26, 3] = 3.32e-12, 0.746

--- a/artisatomic/readboyledata.py
+++ b/artisatomic/readboyledata.py
@@ -40,7 +40,7 @@ def read_levels_data(atomic_number, ion_stage):
         "energy_level_row",
         "atomic_number ion_number level_number energy g metastable energyabovegsinpercm parity levelname",
     )
-    energy_levels: list[energy_level_row | None] = [None]
+    energy_levels: list[energy_level_row] = []
 
     for rowtuple in levels_data:  # pyright: ignore[reportGeneralTypeIssues]
         _atomic_num, _ion_number, level_number, energyabovegsinpercm, _g, _metastable = rowtuple
@@ -97,7 +97,6 @@ def read_lines_data(atomic_number, ion_stage):
 
 def read_levels_and_transitions(atomic_number, ion_stage):
     assert atomic_number == 2
-    # energy_levels = ['IGNORE']
     # artisatomic.log_and_print(flog, 'Reading atomic-data-He')
     transitions, transition_count_of_level_name = read_lines_data(atomic_number, ion_stage)
 
@@ -105,6 +104,6 @@ def read_levels_and_transitions(atomic_number, ion_stage):
     # ionization_energy_in_ev = -1
 
     energy_levels = read_levels_data(atomic_number, ion_stage)
-    # artisatomic.log_and_print(flog, f'Read {len(energy_levels[1:]):d} levels')
+    # artisatomic.log_and_print(flog, f'Read {len(energy_levels):d} levels')
 
     return ionization_energy_in_ev, energy_levels, transitions, transition_count_of_level_name

--- a/artisatomic/readboyledata.py
+++ b/artisatomic/readboyledata.py
@@ -80,8 +80,9 @@ def read_lines_data(atomic_number, ion_stage):
         ) = rowtuple
 
         coll_str = -1  # TODO
+        # the file's level numbers are already zero-based, matching the level ids used in memory
         line = transition_tuple(
-            atomic_num, ion_number, int(level_number_lower + 1), int(level_number_upper + 1), A_ul, wavelength, coll_str
+            atomic_num, ion_number, int(level_number_lower), int(level_number_upper), A_ul, wavelength, coll_str
         )
         if int(atomic_num) != atomic_number or int(ion_number) != ion_stage - 1:
             continue

--- a/artisatomic/readboyledata.py
+++ b/artisatomic/readboyledata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 datafilepath = Path(os.path.dirname(os.path.abspath(__file__)), "..", "atomic-data-helium-boyle", "aoife.hdf5")
 
 try:
-    import h5py
+    import h5py  # pyright: ignore[reportMissingTypeStubs]
 
     aoife_dataset = h5py.File(datafilepath, "r") if datafilepath.exists() else None
 except ModuleNotFoundError:
@@ -44,7 +44,9 @@ def read_levels_data(atomic_number, ion_stage):
 
     for rowtuple in levels_data:  # pyright: ignore[reportGeneralTypeIssues]
         _atomic_num, _ion_number, level_number, energyabovegsinpercm, _g, _metastable = rowtuple
-        energy_level = energy_level_row(*rowtuple, energyabovegsinpercm, 0, f"level{level_number:05d}")  # pyrefly: ignore [bad-argument-count] # ty:ignore[too-many-positional-arguments]
+        # the six unpacked columns plus three more make up the nine fields, which the type
+        # checkers cannot count through the star-unpacking
+        energy_level = energy_level_row(*rowtuple, energyabovegsinpercm, 0, f"level{level_number:05d}")  # pyrefly: ignore [bad-argument-count] # ty:ignore[too-many-positional-arguments] # pyright: ignore[reportCallIssue]
 
         if int(energy_level.atomic_number) != atomic_number or int(energy_level.ion_number) != ion_stage - 1:
             continue

--- a/artisatomic/readdreamdata.py
+++ b/artisatomic/readdreamdata.py
@@ -78,8 +78,8 @@ def read_lines_data(dfiondata, energy_levels):
         transtuple = transitiontuple(lowerlevel=lowerindex, upperlevel=upperindex, A=A, coll_str=-1)
 
         # print(line)
-        transition_count_of_level_name[energy_levels[lowerindex - 1].levelname] += 1
-        transition_count_of_level_name[energy_levels[upperindex - 1].levelname] += 1
+        transition_count_of_level_name[energy_levels[lowerindex].levelname] += 1
+        transition_count_of_level_name[energy_levels[upperindex].levelname] += 1
 
         transitions.append(transtuple)
 
@@ -109,10 +109,10 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
     # for x in energy_levels:
     #     print(x)
     def get_level_index(row, prefix):
-        """Return the 1-based level id of the row's level."""
+        """Return the zero-based level id of the row's level."""
         leveltuple = energytuplefromrow(row, prefix)
         if leveltuple in energy_levels:
-            return energy_levels.index(leveltuple) + 1
+            return energy_levels.index(leveltuple)
         raise AssertionError
 
     dfiondata.insert(

--- a/artisatomic/readdreamdata.py
+++ b/artisatomic/readdreamdata.py
@@ -63,7 +63,7 @@ def read_levels_data(dflines):
 
     energy_levels.sort(key=lambda x: x.energyabovegsinpercm)
 
-    return [None, *energy_levels]
+    return energy_levels
 
 
 def read_lines_data(dfiondata, energy_levels):
@@ -78,8 +78,8 @@ def read_lines_data(dfiondata, energy_levels):
         transtuple = transitiontuple(lowerlevel=lowerindex, upperlevel=upperindex, A=A, coll_str=-1)
 
         # print(line)
-        transition_count_of_level_name[energy_levels[lowerindex].levelname] += 1
-        transition_count_of_level_name[energy_levels[upperindex].levelname] += 1
+        transition_count_of_level_name[energy_levels[lowerindex - 1].levelname] += 1
+        transition_count_of_level_name[energy_levels[upperindex - 1].levelname] += 1
 
         transitions.append(transtuple)
 
@@ -109,9 +109,10 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
     # for x in energy_levels:
     #     print(x)
     def get_level_index(row, prefix):
+        """Return the 1-based level id of the row's level."""
         leveltuple = energytuplefromrow(row, prefix)
         if leveltuple in energy_levels:
-            return energy_levels.index(leveltuple)
+            return energy_levels.index(leveltuple) + 1
         raise AssertionError
 
     dfiondata.insert(
@@ -134,6 +135,6 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
     ionization_energy_in_ev = artisatomic.get_nist_ionization_energies_ev()[(atomic_number, ion_stage)]
     artisatomic.log_and_print(flog, f"ionization energy: {ionization_energy_in_ev} eV")
 
-    artisatomic.log_and_print(flog, f"Read {len(energy_levels[1:]):d} levels")
+    artisatomic.log_and_print(flog, f"Read {len(energy_levels):d} levels")
 
     return ionization_energy_in_ev, energy_levels, transitions, transition_count_of_level_name

--- a/artisatomic/readfacdata.py
+++ b/artisatomic/readfacdata.py
@@ -199,7 +199,7 @@ def read_levels_data(dflevels):
         msg = f"Duplicate Ilev values in FAC levels file: {len(energy_levels)} rows but only {len(ilev_enlevelindex_map)} unique Ilev"
         raise ValueError(msg)
 
-    return [None, *energy_levels], ilev_enlevelindex_map
+    return energy_levels, ilev_enlevelindex_map
 
 
 class FACTransition(t.NamedTuple):
@@ -223,8 +223,8 @@ def read_lines_data(energy_levels, dflines, ilev_enlevelindex_map):
 
         transtuple = FACTransition(lowerlevel=lowerlevel, upperlevel=upperlevel, A=row["A"], coll_str=-1)
 
-        transition_count_of_level_name[energy_levels[lowerlevel].levelname] += 1
-        transition_count_of_level_name[energy_levels[upperlevel].levelname] += 1
+        transition_count_of_level_name[energy_levels[lowerlevel - 1].levelname] += 1
+        transition_count_of_level_name[energy_levels[upperlevel - 1].levelname] += 1
 
         transitions.append(transtuple)
 
@@ -264,7 +264,7 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
     # map associates source file level numbers with energy-sorted level numbers (0 indexed)
     energy_levels, ilev_enlevelindex_map = read_levels_data(dflevels)
 
-    artisatomic.log_and_print(flog, f"Read {len(energy_levels[1:]):d} levels")
+    artisatomic.log_and_print(flog, f"Read {len(energy_levels):d} levels")
 
     assert Path(lines_file).exists()
     dflines = GetLines(filename=lines_file, Z=atomic_number)

--- a/artisatomic/readfacdata.py
+++ b/artisatomic/readfacdata.py
@@ -215,16 +215,16 @@ def read_lines_data(energy_levels, dflines, ilev_enlevelindex_map):
 
     for index, row in dflines.iterrows():
         try:
-            lowerlevel = ilev_enlevelindex_map[int(row["Lower"])] + 1
-            upperlevel = ilev_enlevelindex_map[int(row["Upper"])] + 1
+            lowerlevel = ilev_enlevelindex_map[int(row["Lower"])]
+            upperlevel = ilev_enlevelindex_map[int(row["Upper"])]
         except KeyError:
             continue
         assert lowerlevel < upperlevel
 
         transtuple = FACTransition(lowerlevel=lowerlevel, upperlevel=upperlevel, A=row["A"], coll_str=-1)
 
-        transition_count_of_level_name[energy_levels[lowerlevel - 1].levelname] += 1
-        transition_count_of_level_name[energy_levels[upperlevel - 1].levelname] += 1
+        transition_count_of_level_name[energy_levels[lowerlevel].levelname] += 1
+        transition_count_of_level_name[energy_levels[upperlevel].levelname] += 1
 
         transitions.append(transtuple)
 

--- a/artisatomic/readfloers25data.py
+++ b/artisatomic/readfloers25data.py
@@ -127,15 +127,13 @@ def read_levels_and_transitions(atomic_number: int, ion_stage: int, flog, calibr
         for index, levelname in dflevels.select("Index", "levelname").iter_rows()
     }
 
-    # use standard artisatomic column names and convert to 1-indexed levels
+    # use standard artisatomic column names
 
-    dflevels = artisatomic.add_dummy_zero_level(
-        dflevels.select(
-            levelname=pl.col("levelname"),
-            parity=pl.col("Parity"),
-            g=pl.col("g"),
-            energyabovegsinpercm=pl.col("Energy"),
-        )
+    dflevels = dflevels.select(
+        levelname=pl.col("levelname"),
+        parity=pl.col("Parity"),
+        g=pl.col("g"),
+        energyabovegsinpercm=pl.col("Energy"),
     )
 
     # the levels carry a parity, so let add_level_ids_forbidden() derive the forbidden flag from it

--- a/artisatomic/readfloers25data.py
+++ b/artisatomic/readfloers25data.py
@@ -136,8 +136,9 @@ def read_levels_and_transitions(atomic_number: int, ion_stage: int, flog, calibr
         energyabovegsinpercm=pl.col("Energy"),
     )
 
-    # the levels carry a parity, so let add_level_ids_forbidden() derive the forbidden flag from it
-    dftransitions = dftransitions.select(lowerlevel=pl.col("Lower") + 1, upperlevel=pl.col("Upper") + 1, A=pl.col("A"))
+    # the levels carry a parity, so let add_level_ids_forbidden() derive the forbidden flag from it.
+    # the file's Lower/Upper indices are already zero-based, matching the level ids used in memory
+    dftransitions = dftransitions.select(lowerlevel=pl.col("Lower"), upperlevel=pl.col("Upper"), A=pl.col("A"))
 
     return ionization_energy_in_ev, dflevels, dftransitions, transition_count_of_level_name
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -253,7 +253,7 @@ def hillier_ion_folder(atomic_number, ion_stage):
 def read_levels_and_transitions(
     atomic_number: int, ion_stage: int, flog
 ) -> tuple[float, list, list, defaultdict[str, int], defaultdict[tuple[int, int, int], list[str]]]:
-    hillier_energy_levels: list = [None]
+    hillier_energy_levels: list = []
     hillier_levelnamesnoJ_matching_term: defaultdict[tuple[int, int, int], list[str]] = defaultdict(list)
     transition_count_of_level_name: defaultdict[str, int] = defaultdict(int)
     hillier_ionization_energy_ev = 0.0
@@ -375,19 +375,19 @@ def read_levels_and_transitions(
                 if float(hillier_energy_levels[-1].energyabovegsinpercm) < 1.0:
                     hillier_ionization_energy_ev = hc_in_ev_angstrom / float(hillier_energy_levels[-1].lambdaangstrom)
 
-                if hillierlevelid != len(hillier_energy_levels) - 1:
+                if hillierlevelid != len(hillier_energy_levels):
                     artisatomic.log_and_print(
                         flog,
-                        f"Hillier levels mismatch: id {len(hillier_energy_levels) - 1:d} found at entry number"
+                        f"Hillier levels mismatch: id {len(hillier_energy_levels):d} found at entry number"
                         f" {hillierlevelid:d}",
                     )
                     sys.exit()
 
-            if line.lstrip().startswith("Oscillator strengths") and len(hillier_energy_levels) > 1:
+            if line.lstrip().startswith("Oscillator strengths") and len(hillier_energy_levels) > 0:
                 break
 
-        artisatomic.log_and_print(flog, f"Read {len(hillier_energy_levels[1:]):d} levels")
-        assert len(hillier_energy_levels[1:]) == expected_energy_levels
+        artisatomic.log_and_print(flog, f"Read {len(hillier_energy_levels):d} levels")
+        assert len(hillier_energy_levels) == expected_energy_levels
 
         # defined_transition_ids = []
         for line in fhillierosc:
@@ -438,8 +438,7 @@ def read_levels_and_transitions(
 
     # filter out levels with no transitions
     hillier_energy_levels = [
-        hillier_energy_levels[0],
-        *[level for level in hillier_energy_levels[1:] if transition_count_of_level_name[level.levelname] > 0],
+        level for level in hillier_energy_levels if transition_count_of_level_name[level.levelname] > 0
     ]
 
     return (
@@ -504,7 +503,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
         artisatomic.log_and_print(flog, f"Reading {artisatomic.path_for_log(filename)}")
 
         with artisatomic.xopen_check_extension(filename) as fhillierphot:
-            lowerlevelid = -1
+            lowerlevelindex = -1
             lowerlevelname = ""
             targetlevelname = ""
             numpointsexpected = 0
@@ -548,17 +547,17 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                         lowerlevelname = lowerlevelname.split("[")[0]
                     fitcoefficients = []
                     numpointsexpected = 0
-                    lowerlevelid = 1
-                    # find the first matching level (several matches by differ by J values)
-                    for levelid, energy_level in enumerate(energy_levels[1:], 1):
+                    lowerlevelindex = 0
+                    # find the zero-based index of the first matching level (several matches may differ by J values)
+                    for levelindex, energy_level in enumerate(energy_levels):
                         this_levelnamenoj = energy_level.levelname.split("[")[0]
                         if this_levelnamenoj == lowerlevelname:
-                            lowerlevelid = levelid
+                            lowerlevelindex = levelindex
                             break
                     if targetlevelname == "":
                         print("ERROR: no upper level name")
                         sys.exit()
-                    # print(f"Reading level {lowerlevelid} '{lowerlevelname}'")
+                    # print(f"Reading level {lowerlevelindex} '{lowerlevelname}'")
 
                 if len(row) >= 2 and " ".join(row[-3:]) == "!Screened nuclear charge":
                     # CMFGEN's ZION comes from the oscillator file, not from here: RDPHOT_GEN_V2
@@ -596,7 +595,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                     if len(row) == 1 and row_is_all_floats and numpointsexpected > 0:
                         fitcoefficients.append(float(row[0].replace("D", "E")))
                         if len(fitcoefficients) == 3:
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = abs(float(energy_levels[lowerlevelindex].lambdaangstrom))
                             phixstables[filenum][lowerlevelname] = get_seaton_phixstable(
                                 lambda_angstrom, *fitcoefficients
                             )
@@ -611,7 +610,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                             if l_end > n - 1:
                                 artisatomic.log_and_print(flog, f"ERROR: can't have l_end = {l_end} > n - 1 = {n - 1}")
                             else:
-                                lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                                lambda_angstrom = abs(float(energy_levels[lowerlevelindex].lambdaangstrom))
                                 phixstables[filenum][lowerlevelname] = get_hydrogenic_nl_phixstable(
                                     lambda_angstrom, n, l_start, l_end
                                 )
@@ -624,7 +623,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                         if len(fitcoefficients) == 2:
                             scale, n = fitcoefficients
                             n = int(n)
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = abs(float(energy_levels[lowerlevelindex].lambdaangstrom))
                             # scale the cross sections but not the energy grid
                             phixstable = get_hydrogenic_n_phixstable(lambda_angstrom, n)
                             phixstable[:, 1] *= scale
@@ -640,7 +639,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                     if len(row) == 1 and row_is_all_floats and numpointsexpected > 0:
                         fitcoefficients.append(float(row[0].replace("D", "E")))
                         if len(fitcoefficients) == 5:
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = abs(float(energy_levels[lowerlevelindex].lambdaangstrom))
                             phixstables[filenum][lowerlevelname] = get_opproject_phixstable(
                                 lambda_angstrom, *fitcoefficients
                             )
@@ -652,7 +651,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                     if len(row) == 1 and row_is_all_floats and numpointsexpected > 0:
                         fitcoefficients.append(float(row[0].replace("D", "E")))
                         if len(fitcoefficients) == 8:
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = abs(float(energy_levels[lowerlevelindex].lambdaangstrom))
                             phixstables[filenum][lowerlevelname] = get_hummer_phixstable(
                                 lambda_angstrom, *fitcoefficients
                             )
@@ -669,7 +668,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                     if len(row) == 1 and row_is_all_floats and numpointsexpected > 0:
                         fitcoefficients.append(float(row[0].replace("D", "E")))
                         if len(fitcoefficients) == 4:
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = abs(float(energy_levels[lowerlevelindex].lambdaangstrom))
                             phixstables[filenum][lowerlevelname] = get_seaton_phixstable(
                                 lambda_angstrom, *fitcoefficients
                             )
@@ -690,7 +689,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                             if l_end > n - 1:
                                 artisatomic.log_and_print(flog, f"ERROR: can't have l_end = {l_end} > n - 1 = {n - 1}")
                             else:
-                                lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                                lambda_angstrom = abs(float(energy_levels[lowerlevelindex].lambdaangstrom))
                                 phixstables[filenum][lowerlevelname] = get_hydrogenic_nl_phixstable(
                                     lambda_angstrom, n, l_start, l_end, nu_o=nu_o, zion=zion
                                 )
@@ -704,7 +703,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                         )
 
                         if len(fitcoefficients) * 8 == numpointsexpected:
-                            lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                            lambda_angstrom = abs(float(energy_levels[lowerlevelindex].lambdaangstrom))
                             phixstables[filenum][lowerlevelname] = get_vy95_phixstable(lambda_angstrom, fitcoefficients)
                             numpointsexpected = len(phixstables[filenum][lowerlevelname])
                             # artisatomic.log_and_print(flog, 'Using Verner & Yakolev 1995 formula values for level {0}'.format(lowerlevelname))
@@ -714,7 +713,7 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
                         if lowerlevelname not in phixstables[filenum]:
                             phixstables[filenum][lowerlevelname] = np.zeros((numpointsexpected, 2))
 
-                        lambda_angstrom = abs(float(energy_levels[lowerlevelid].lambdaangstrom))
+                        lambda_angstrom = abs(float(energy_levels[lowerlevelindex].lambdaangstrom))
                         thresholdenergyryd = hc_in_ev_angstrom / lambda_angstrom / ryd_to_ev
                         enryd = float(row[0].replace("D", "E"))
 
@@ -881,20 +880,20 @@ def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
 
     # now the non-J-split cross sections are mapped onto J-split levels
     for lowerlevelname_a, phixstable in reduced_phixs_dict.items():
-        for levelid, energy_level in enumerate(energy_levels[1:], 1):
+        for levelindex, energy_level in enumerate(energy_levels):
             levelname_b = energy_level.levelname if j_splitting_on else energy_level.levelname.split("[")[0]
 
             if levelname_b == lowerlevelname_a:  # due to J splitting, we may match multiple levels here
-                photoionization_crosssections[levelid] = phixstable
+                photoionization_crosssections[levelindex] = phixstable
                 # .get() rather than the defaultdict's __getitem__: a level whose target factors
                 # all came out zero is absent here, and inserting an empty list for it would look
                 # like "has data, no targets" instead of "no data" to get_photoiontargetfractions()
-                photoionization_targetconfig_fractions[levelid] = phixs_targetconfigfractions_of_levelname.get(
+                photoionization_targetconfig_fractions[levelindex] = phixs_targetconfigfractions_of_levelname.get(
                     levelname_b
                 )
 
-                # photoionization_thresholds_ev[levelid] = energy_level.thresholdenergyev
-                photoionization_thresholds_ev[levelid] = hc_in_ev_angstrom / float(energy_level.lambdaangstrom)
+                # photoionization_thresholds_ev[levelindex] = energy_level.thresholdenergyev
+                photoionization_thresholds_ev[levelindex] = hc_in_ev_angstrom / float(energy_level.lambdaangstrom)
 
     return photoionization_crosssections, photoionization_targetconfig_fractions, photoionization_thresholds_ev
 
@@ -1118,9 +1117,9 @@ def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
 
     found_nonjsplit_transition = False
     level_ids_of_level_name = {}
-    for levelid in range(1, len(energy_levels)):
-        if hasattr(energy_levels[levelid], "levelname"):
-            levelname = energy_levels[levelid].levelname
+    for levelid, energy_level in enumerate(energy_levels, 1):
+        if hasattr(energy_level, "levelname"):
+            levelname = energy_level.levelname
 
             levelnamenoJ = levelname.split("[")[0]
             if levelname != levelnamenoJ:  # levels are J split
@@ -1139,7 +1138,7 @@ def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
     # total statistical weight of each term, used to share a term-resolved collision strength over
     # its J levels. Depends only on the level list, so build it once rather than per input row.
     g_sum_of_level_name = {
-        levelname: sum(energy_levels[levelid].g for levelid in levelids)
+        levelname: sum(energy_levels[levelid - 1].g for levelid in levelids)
         for levelname, levelids in level_ids_of_level_name.items()
     }
 
@@ -1251,8 +1250,8 @@ def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
                             # print(f'Transition {namefrom} (level {id_lower:d} in {level_ids_of_level_name[namefrom]}) -> {nameto} (level {id_upper:d} in {level_ids_of_level_name[nameto]})')
                             upsilonscaled = (
                                 upsilon
-                                * (energy_levels[id_lower].g / lower_g_sum)
-                                * (energy_levels[id_upper].g / upper_g_sum)
+                                * (energy_levels[id_lower - 1].g / lower_g_sum)
+                                * (energy_levels[id_upper - 1].g / upper_g_sum)
                             )
                             # upsilon is symmetric, and the output wants lower id < upper id. The
                             # two terms' J levels can interleave in energy, so order the key here
@@ -1309,18 +1308,18 @@ def get_photoiontargetfractions(
     if hillier_photoion_targetconfigs is None:
         return targetlist
 
-    for energy_level in dfenergy_levels[1:].iter_rows(named=True):
-        lowerlevelid = energy_level["levelid"]
-        if hillier_photoion_targetconfigs[lowerlevelid] is None:
+    for lowerlevelindex in range(dfenergy_levels.height):
+        targetconfig_fractions = hillier_photoion_targetconfigs[lowerlevelindex]
+        if targetconfig_fractions is None:
             continue  # photoionisation flagged as not available
 
-        for targetconfig, targetconfig_fraction in hillier_photoion_targetconfigs[lowerlevelid]:
+        for targetconfig, targetconfig_fraction in targetconfig_fractions:
             if targetconfig not in targetlist_of_targetconfig:
                 # sometimes the target has a slash, e.g. '3d7_4Fe/3d7_a4Fe'
                 # so split on the slash and match all parts
                 targetconfiglist = targetconfig.split("/")
                 upperionlevelids = []
-                for upperlevelid, levelname in dfenergy_levels_upperion[["levelid", "levelname"]][1:].iter_rows():
+                for upperlevelid, levelname in dfenergy_levels_upperion[["levelid", "levelname"]].iter_rows():
                     upperlevelnamenoj = levelname.split("[")[0]
                     if upperlevelnamenoj in targetconfiglist:
                         upperionlevelids.append(upperlevelid)
@@ -1329,17 +1328,19 @@ def get_photoiontargetfractions(
                 targetlist_of_targetconfig[targetconfig] = []
 
                 summed_statistical_weights = sum(
-                    float(dfenergy_levels_upperion["g"][index]) for index in upperionlevelids
+                    float(dfenergy_levels_upperion["g"][index - 1]) for index in upperionlevelids
                 )
                 for upperionlevelid in sorted(upperionlevelids):
-                    statweight_fraction = dfenergy_levels_upperion["g"][upperionlevelid] / summed_statistical_weights
+                    statweight_fraction = (
+                        dfenergy_levels_upperion["g"][upperionlevelid - 1] / summed_statistical_weights
+                    )
                     targetlist_of_targetconfig[targetconfig].append((upperionlevelid, statweight_fraction))
 
             for upperlevelid, statweight_fraction in targetlist_of_targetconfig[targetconfig]:
-                targetlist[lowerlevelid].append((upperlevelid, targetconfig_fraction * statweight_fraction))
+                targetlist[lowerlevelindex].append((upperlevelid, targetconfig_fraction * statweight_fraction))
 
-        if len(targetlist[lowerlevelid]) == 0:
-            targetlist[lowerlevelid].append((1, 1.0))
+        if len(targetlist[lowerlevelindex]) == 0:
+            targetlist[lowerlevelindex].append((1, 1.0))
 
     return targetlist
 
@@ -1360,7 +1361,7 @@ def read_hyd_phixsdata():
 
     # the tables below are indexed by principal quantum number, so the H I level list must not
     # have been filtered (read_levels_and_transitions drops levels with no transitions)
-    for levelid, energy_level in enumerate(hillier_energy_levels[1:], 1):
+    for levelid, energy_level in enumerate(hillier_energy_levels, 1):
         assert energy_level.hillierlevelid == levelid, (
             "H I level list is not indexed by principal quantum number, so the hydrogenic"
             " cross-section thresholds would be taken from the wrong levels"
@@ -1391,7 +1392,7 @@ def read_hyd_phixsdata():
                 continue
 
             n, l, num_points = (int(x) for x in line.split())
-            e_threshold_ev = hc_in_ev_angstrom / float(hillier_energy_levels[n].lambdaangstrom)
+            e_threshold_ev = hc_in_ev_angstrom / float(hillier_energy_levels[n - 1].lambdaangstrom)
 
             xs_values = []
             for line in fhyd:
@@ -1439,7 +1440,7 @@ def read_hyd_phixsdata():
                 continue
 
             n, num_points = (int(x) for x in line.split())
-            e_threshold_ev = hc_in_ev_angstrom / float(hillier_energy_levels[n].lambdaangstrom)
+            e_threshold_ev = hc_in_ev_angstrom / float(hillier_energy_levels[n - 1].lambdaangstrom)
 
             gaunt_values = []
             for line in fhyd:

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1117,7 +1117,7 @@ def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
 
     found_nonjsplit_transition = False
     level_ids_of_level_name = {}
-    for levelid, energy_level in enumerate(energy_levels, 1):
+    for levelid, energy_level in enumerate(energy_levels):
         if hasattr(energy_level, "levelname"):
             levelname = energy_level.levelname
 
@@ -1138,7 +1138,7 @@ def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
     # total statistical weight of each term, used to share a term-resolved collision strength over
     # its J levels. Depends only on the level list, so build it once rather than per input row.
     g_sum_of_level_name = {
-        levelname: sum(energy_levels[levelid - 1].g for levelid in levelids)
+        levelname: sum(energy_levels[levelid].g for levelid in levelids)
         for levelname, levelids in level_ids_of_level_name.items()
     }
 
@@ -1250,8 +1250,8 @@ def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
                             # print(f'Transition {namefrom} (level {id_lower:d} in {level_ids_of_level_name[namefrom]}) -> {nameto} (level {id_upper:d} in {level_ids_of_level_name[nameto]})')
                             upsilonscaled = (
                                 upsilon
-                                * (energy_levels[id_lower - 1].g / lower_g_sum)
-                                * (energy_levels[id_upper - 1].g / upper_g_sum)
+                                * (energy_levels[id_lower].g / lower_g_sum)
+                                * (energy_levels[id_upper].g / upper_g_sum)
                             )
                             # upsilon is symmetric, and the output wants lower id < upper id. The
                             # two terms' J levels can interleave in energy, so order the key here
@@ -1308,8 +1308,8 @@ def get_photoiontargetfractions(
     if hillier_photoion_targetconfigs is None:
         return targetlist
 
-    for lowerlevelindex in range(dfenergy_levels.height):
-        targetconfig_fractions = hillier_photoion_targetconfigs[lowerlevelindex]
+    for lowerlevelid in range(dfenergy_levels.height):
+        targetconfig_fractions = hillier_photoion_targetconfigs[lowerlevelid]
         if targetconfig_fractions is None:
             continue  # photoionisation flagged as not available
 
@@ -1324,23 +1324,21 @@ def get_photoiontargetfractions(
                     if upperlevelnamenoj in targetconfiglist:
                         upperionlevelids.append(upperlevelid)
                 if not upperionlevelids:
-                    upperionlevelids = [1]
+                    upperionlevelids = [0]  # the upper ion's ground state
                 targetlist_of_targetconfig[targetconfig] = []
 
                 summed_statistical_weights = sum(
-                    float(dfenergy_levels_upperion["g"][index - 1]) for index in upperionlevelids
+                    float(dfenergy_levels_upperion["g"][levelid]) for levelid in upperionlevelids
                 )
                 for upperionlevelid in sorted(upperionlevelids):
-                    statweight_fraction = (
-                        dfenergy_levels_upperion["g"][upperionlevelid - 1] / summed_statistical_weights
-                    )
+                    statweight_fraction = dfenergy_levels_upperion["g"][upperionlevelid] / summed_statistical_weights
                     targetlist_of_targetconfig[targetconfig].append((upperionlevelid, statweight_fraction))
 
             for upperlevelid, statweight_fraction in targetlist_of_targetconfig[targetconfig]:
-                targetlist[lowerlevelindex].append((upperlevelid, targetconfig_fraction * statweight_fraction))
+                targetlist[lowerlevelid].append((upperlevelid, targetconfig_fraction * statweight_fraction))
 
-        if len(targetlist[lowerlevelindex]) == 0:
-            targetlist[lowerlevelindex].append((1, 1.0))
+        if len(targetlist[lowerlevelid]) == 0:
+            targetlist[lowerlevelid].append((0, 1.0))  # the upper ion's ground state
 
     return targetlist
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1,6 +1,7 @@
 import math
 import os
 import sys
+import typing as t
 from collections import defaultdict
 from collections import namedtuple
 from functools import cache
@@ -253,12 +254,14 @@ def hillier_ion_folder(atomic_number, ion_stage):
 
 def read_levels_and_transitions(
     atomic_number: int, ion_stage: int, flog
-) -> tuple[float, list, list, defaultdict[str, int], defaultdict[tuple[int, int, int], list[str]]]:
-    hillier_energy_levels: list = []
+) -> tuple[float, list[t.Any], list[t.Any], defaultdict[str, int], defaultdict[tuple[int, int, int], list[str]]]:
+    # the level and transition rows are namedtuples built at runtime from the column names in
+    # each oscillator file, so they cannot be given a static type
+    hillier_energy_levels: list[t.Any] = []
     hillier_levelnamesnoJ_matching_term: defaultdict[tuple[int, int, int], list[str]] = defaultdict(list)
     transition_count_of_level_name: defaultdict[str, int] = defaultdict(int)
     hillier_ionization_energy_ev = 0.0
-    transitions: list = []
+    transitions: list[t.Any] = []
 
     if atomic_number == 1 and ion_stage == 2:
         ionization_energy_ev = 0.0
@@ -429,7 +432,9 @@ def read_levels_and_transitions(
                         )
                         # sys.exit()
                 else:
-                    artisatomic.log_and_print(
+                    # dead while the duplicate check above is disabled for speed, but kept so
+                    # that re-enabling it restores the error path
+                    artisatomic.log_and_print(  # pyright: ignore[reportUnreachable]
                         flog, f"FATAL: multiply-defined Hillier transition: {transition.namefrom} {transition.nameto}"
                     )
                     sys.exit()
@@ -512,7 +517,7 @@ def read_phixs_tables(
             numpointsexpected = 0
             pointnumber = 0
             crosssectiontype = -1
-            fitcoefficients = []
+            fitcoefficients: list[t.Any] = []
 
             for line in fhillierphot:
                 row = line.split()
@@ -1112,7 +1117,7 @@ def get_vy95_phixstable(lambda_angstrom, fitcoefficients):
 
 def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
     t_scale_factor = 1e4  # Hiller temperatures are given as T_4
-    upsilondict = {}
+    upsilondict: dict[tuple[int, int], float] = {}
     coldatafilename = ions_data[(atomic_number, ion_stage)].coldatafilename
     if coldatafilename == "":
         artisatomic.log_and_print(flog, "No collisional data file specified")
@@ -1152,7 +1157,7 @@ def read_coldata(atomic_number, ion_stage, energy_levels, flog, args):
     coll_lines_in = 0
     number_expected_transitions = -1
     with artisatomic.xopen_check_extension(filename) as fcoldata:
-        header_row = []
+        header_row: list[str] = []
         temperature_index = -1
         num_expected_t_values = -1
         for line in fcoldata:
@@ -1395,7 +1400,7 @@ def read_hyd_phixsdata():
             n, l, num_points = (int(x) for x in line.split())
             e_threshold_ev = hc_in_ev_angstrom / float(hillier_energy_levels[n - 1].lambdaangstrom)
 
-            xs_values = []
+            xs_values: list[float] = []
             for line in fhyd:
                 values_thisline = [float(x) for x in line.split()]
                 xs_values = xs_values + values_thisline
@@ -1443,7 +1448,7 @@ def read_hyd_phixsdata():
             n, num_points = (int(x) for x in line.split())
             e_threshold_ev = hc_in_ev_angstrom / float(hillier_energy_levels[n - 1].lambdaangstrom)
 
-            gaunt_values = []
+            gaunt_values: list[float] = []
             for line in fhyd:
                 values_thisline = [float(x) for x in line.split()]
                 gaunt_values = gaunt_values + values_thisline

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -7,6 +7,7 @@ from functools import cache
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 import artisatomic
@@ -468,7 +469,9 @@ phixs_type_labels = {
 }
 
 
-def read_phixs_tables(atomic_number, ion_stage, energy_levels, args, flog):
+def read_phixs_tables(
+    atomic_number, ion_stage, energy_levels, args, flog
+) -> tuple[npt.NDArray[np.float64], list[list[tuple[str, float]] | None], npt.NDArray[np.float64]]:
     # this gets partially overwritten anyway
     photoionization_crosssections = np.zeros((len(energy_levels), args.nphixspoints))
     photoionization_thresholds_ev = np.zeros(len(energy_levels))

--- a/artisatomic/readkuruczdata.py
+++ b/artisatomic/readkuruczdata.py
@@ -179,7 +179,6 @@ def read_levels_and_transitions(
         # without it the level names in adata.txt can differ from run to run
         .unique(["energyabovegsinpercm", "j"], keep="first", maintain_order=True)
         .sort(["energyabovegsinpercm", "j", "label"])
-        .with_row_index("levelid")
         .select(
             pl.col("energyabovegsinpercm"),
             pl.col("j"),
@@ -195,13 +194,10 @@ def read_levels_and_transitions(
         .sort("energyabovegsinpercm", "j")
         .collect()
     )
-    dflevels = (
-        artisatomic.add_dummy_zero_level(dflevels)
-        .with_row_index("levelid")
-        .with_columns(pl.col("levelid").cast(pl.Int64))
-        .with_columns(parity=-pl.col("levelid"))  # give a unique parity so that all transitions are permitted
+    dflevels = artisatomic.leveltuples_to_pldataframe(dflevels).with_columns(
+        parity=-pl.col("levelid")  # give a unique parity so that all transitions are permitted
     )
-    artisatomic.log_and_print(flog, f"Read {len(dflevels) - 1:d} levels")
+    artisatomic.log_and_print(flog, f"Read {len(dflevels):d} levels")
 
     transitions = (
         gfall.select(

--- a/artisatomic/readlisbondata.py
+++ b/artisatomic/readlisbondata.py
@@ -44,7 +44,8 @@ class LisbonReader:
             keys `levels` and `lines`.
 
         """
-        from carsus.util import parse_selected_species  # ty:ignore[unresolved-import]
+        # carsus is an optional extra that is not a declared dependency of this package
+        from carsus.util import parse_selected_species  # noqa: I001 # ty:ignore[unresolved-import] # pyright: ignore[reportMissingImports] # pyrefly: ignore[missing-import]
 
         lvl_list = []
         lns_list = []
@@ -82,7 +83,7 @@ class LisbonReader:
             lines = lines.set_index(["atomic_number", "ion_charge", "level_index_lower", "level_index_upper"])
             lns_list.append(lines)
         levels = pd.concat(lvl_list)
-        lines = pd.concat(lns_list)
+        lines = pd.concat(lns_list)  # pyright: ignore[reportUnreachable]
         self.levels = levels
         self.lines = lines
 

--- a/artisatomic/readlisbondata.py
+++ b/artisatomic/readlisbondata.py
@@ -137,15 +137,12 @@ def read_lines_data(energy_levels, dflines):
     transition_count_of_level_name = defaultdict(int)
     transitiontuple = namedtuple("transitiontuple", "lowerlevel upperlevel A coll_str")
 
-    for (lowerindex, upperindex), row in dflines.iterrows():
-        lowerlevel = lowerindex + 1
-        upperlevel = upperindex + 1
-
+    for (lowerlevel, upperlevel), row in dflines.iterrows():
         transtuple = transitiontuple(lowerlevel=lowerlevel, upperlevel=upperlevel, A=row.A, coll_str=-1)
 
         # print(line)
-        transition_count_of_level_name[energy_levels[lowerlevel - 1].levelname] += 1
-        transition_count_of_level_name[energy_levels[upperlevel - 1].levelname] += 1
+        transition_count_of_level_name[energy_levels[lowerlevel].levelname] += 1
+        transition_count_of_level_name[energy_levels[upperlevel].levelname] += 1
 
         transitions.append(transtuple)
 

--- a/artisatomic/readlisbondata.py
+++ b/artisatomic/readlisbondata.py
@@ -129,7 +129,7 @@ def read_levels_data(dflevels):
 
     energy_levels.sort(key=lambda x: x.energyabovegsinpercm)
 
-    return [None, *energy_levels]
+    return energy_levels
 
 
 def read_lines_data(energy_levels, dflines):
@@ -144,8 +144,8 @@ def read_lines_data(energy_levels, dflines):
         transtuple = transitiontuple(lowerlevel=lowerlevel, upperlevel=upperlevel, A=row.A, coll_str=-1)
 
         # print(line)
-        transition_count_of_level_name[energy_levels[lowerlevel].levelname] += 1
-        transition_count_of_level_name[energy_levels[upperlevel].levelname] += 1
+        transition_count_of_level_name[energy_levels[lowerlevel - 1].levelname] += 1
+        transition_count_of_level_name[energy_levels[upperlevel - 1].levelname] += 1
 
         transitions.append(transtuple)
 
@@ -194,6 +194,6 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
 
     ionization_energy_in_ev = -1
 
-    artisatomic.log_and_print(flog, f"Read {len(energy_levels[1:]):d} levels")
+    artisatomic.log_and_print(flog, f"Read {len(energy_levels):d} levels")
 
     return ionization_energy_in_ev, energy_levels, transitions, transition_count_of_level_name

--- a/artisatomic/readnahardata.py
+++ b/artisatomic/readnahardata.py
@@ -346,7 +346,8 @@ def get_naharphotoion_upperlevelids(
                 f" E={core_state_energy_ev:0.3f} eV to:\n"
             )
 
-            candidate_upper_levels = {}
+            # per configuration: the energy differences and the upper ion level ids
+            candidate_upper_levels: dict[str, tuple[list[float], list[int]]] = {}
             for upperlevel in dfenergy_levels_upperion.iter_rows(named=True):
                 upperlevelid = upperlevel["levelid"]
                 if "levelname" in upperlevel:
@@ -366,7 +367,7 @@ def get_naharphotoion_upperlevelids(
                     ediff = energyev - core_state_energy_ev
                     upperlevelconfignoj = upperlevelconfig.split("[")[0]
                     if upperlevelconfignoj not in candidate_upper_levels:
-                        candidate_upper_levels[upperlevelconfignoj] = [[], []]
+                        candidate_upper_levels[upperlevelconfignoj] = ([], [])
                     candidate_upper_levels[upperlevelconfignoj][1].append(upperlevelid)
                     candidate_upper_levels[upperlevelconfignoj][0].append(ediff)
                     flog.write(
@@ -374,7 +375,7 @@ def get_naharphotoion_upperlevelids(
                     )
 
             best_ediff = float("inf")
-            best_match_upperlevelids = []
+            best_match_upperlevelids: list[int] = []
             for ediffs, upperlevelids in candidate_upper_levels.values():
                 avg_ediff = abs(sum(ediffs) / len(ediffs))
                 if avg_ediff < best_ediff:

--- a/artisatomic/readnahardata.py
+++ b/artisatomic/readnahardata.py
@@ -42,9 +42,9 @@ class NaharEnergyLevel(t.NamedTuple):
 
 def read_nahar_energy_level_file(path_nahar_energy_file, atomic_number, ion_stage, flog):
     nahar_configurations = {}
-    nahar_energy_levels: list[NaharEnergyLevel | None] = [None]
+    nahar_energy_levels: list[NaharEnergyLevel] = []
     nahar_level_index_of_state = {}
-    nahar_core_states: list[NaharCoreState | None] = []
+    nahar_core_states: list[NaharCoreState] = []
     nahar_ionization_potential_rydberg = -1.0
 
     if not os.path.isfile(path_nahar_energy_file):
@@ -148,17 +148,16 @@ def read_nahar_energy_level_file(path_nahar_energy_file, atomic_number, ion_stag
                             "",
                         )
                     )
-                    assert nahar_energy_levels[-1] is not None
                     energyabovegsinpercm = (
-                        (nahar_ionization_potential_rydberg + float(nahar_energy_levels[-1].energyreltoionpotrydberg))  # ty:ignore[possibly-missing-attribute]
+                        (nahar_ionization_potential_rydberg + float(nahar_energy_levels[-1].energyreltoionpotrydberg))
                         * ryd_to_ev
                         / hc_in_ev_cm
                     )
 
-                    nahar_energy_levels[-1] = nahar_energy_levels[-1]._replace(  # ty:ignore[possibly-missing-attribute]
+                    nahar_energy_levels[-1] = nahar_energy_levels[-1]._replace(
                         indexinsymmetry=indexinsymmetry,
                         corestateid=nahar_core_state_id,
-                        energyreltoionpotrydberg=float(nahar_energy_levels[-1].energyreltoionpotrydberg),  # ty:ignore[possibly-missing-attribute]
+                        energyreltoionpotrydberg=float(nahar_energy_levels[-1].energyreltoionpotrydberg),
                         energyabovegsinpercm=energyabovegsinpercm,
                         g=twosplusone * (2 * l_val + 1),
                     )
@@ -178,7 +177,7 @@ def read_nahar_energy_level_file(path_nahar_energy_file, atomic_number, ion_stag
     )
 
 
-def read_nahar_core_states(fenlist) -> list[NaharCoreState | None]:
+def read_nahar_core_states(fenlist) -> list[NaharCoreState]:
     while True:
         line = fenlist.readline()
         if not line:
@@ -199,15 +198,14 @@ def read_nahar_core_states(fenlist) -> list[NaharCoreState | None]:
     fenlist.readline()  # ' target states and energies:'
     fenlist.readline()  # blank line
 
-    nahar_core_states: list[NaharCoreState | None] = [None] * (numberofcorestates + 1)
+    # core state id n is stored at index n - 1
+    nahar_core_states: list[NaharCoreState] = []
     for c in range(1, numberofcorestates + 1):
         row = fenlist.readline().split()
         state = NaharCoreState(int(row[0]), row[1], row[2], float(row[3]))
-        nahar_core_states[c] = state
-        if int(state.nahar_core_state_id) != c:  # ty:ignore[possibly-missing-attribute]
-            print(
-                f"Nahar levels mismatch: id {c:d} found at entry number {int(state.nahar_core_state_id):d}"  # ty:ignore[possibly-missing-attribute]
-            )
+        nahar_core_states.append(state)
+        if int(state.nahar_core_state_id) != c:
+            print(f"Nahar levels mismatch: id {c:d} found at entry number {int(state.nahar_core_state_id):d}")
             sys.exit()
     return nahar_core_states
 
@@ -326,10 +324,10 @@ def get_naharphotoion_upperlevelids(
     """Returns a list of upper level id numbers for a given energy level's photoionisation processes."""
     # core_state_id = int(energy_level.corestateid)
     core_state_id = 1  # temporary fix
-    if core_state_id > 0 and core_state_id < len(nahar_core_states):
+    if core_state_id > 0 and core_state_id <= len(nahar_core_states):
         if not upper_level_ids_of_core_state_id[core_state_id]:
             # go find matching levels if they haven't been found yet
-            nahar_core_state = nahar_core_states[core_state_id]
+            nahar_core_state = nahar_core_states[core_state_id - 1]
             nahar_core_state_reduced_configuration = artisatomic.reduce_configuration(
                 nahar_core_state.configuration + "_" + nahar_core_state.term
             )
@@ -340,7 +338,7 @@ def get_naharphotoion_upperlevelids(
             )
 
             candidate_upper_levels = {}
-            for upperlevel in dfenergy_levels_upperion[1:].iter_rows(named=True):
+            for upperlevel in dfenergy_levels_upperion.iter_rows(named=True):
                 upperlevelid = upperlevel["levelid"]
                 if "levelname" in upperlevel:
                     upperlevelconfig = upperlevel["levelname"]
@@ -399,8 +397,7 @@ def get_photoiontargetfractions(
 ):
     targetlist: list[list[tuple[int, float]]] = [[] for _ in range(dfenergy_levels.height)]
     upper_level_ids_of_core_state_id = defaultdict(list)
-    for energy_level in dfenergy_levels[1:].iter_rows(named=True):
-        lowerlevelid = energy_level["levelid"]
+    for lowerlevelindex in range(dfenergy_levels.height):
         # find the upper level ids from the Nahar core state
         upperionlevelids = get_naharphotoion_upperlevelids(
             dfenergy_levels_upperion,
@@ -410,9 +407,11 @@ def get_photoiontargetfractions(
             flog,
         )
 
-        summed_statistical_weights = sum(float(dfenergy_levels_upperion["g"][levelid]) for levelid in upperionlevelids)
+        summed_statistical_weights = sum(
+            float(dfenergy_levels_upperion["g"][levelid - 1]) for levelid in upperionlevelids
+        )
         for upperionlevelid in sorted(upperionlevelids):
-            phixsprobability = dfenergy_levels_upperion["g"][upperionlevelid] / summed_statistical_weights
-            targetlist[lowerlevelid].append((upperionlevelid, phixsprobability))
+            phixsprobability = dfenergy_levels_upperion["g"][upperionlevelid - 1] / summed_statistical_weights
+            targetlist[lowerlevelindex].append((upperionlevelid, phixsprobability))
 
     return targetlist

--- a/artisatomic/readnahardata.py
+++ b/artisatomic/readnahardata.py
@@ -378,16 +378,16 @@ def get_naharphotoion_upperlevelids(
 
             # after matching process, still no upper levels matched!
             if not upper_level_ids_of_core_state_id[core_state_id]:
-                upper_level_ids_of_core_state_id[core_state_id] = [1]
+                upper_level_ids_of_core_state_id[core_state_id] = [0]  # the upper ion's ground state
                 artisatomic.log_and_print(
                     flog,
-                    "No upper levels matched. Defaulting to level 1 (reduced string:"
+                    "No upper levels matched. Defaulting to the ground state (reduced string:"
                     f" '{nahar_core_state_reduced_configuration}')",
                 )
 
         upperionlevelids = upper_level_ids_of_core_state_id[core_state_id]
     else:
-        upperionlevelids = [1]
+        upperionlevelids = [0]  # the upper ion's ground state
 
     return upperionlevelids
 
@@ -397,7 +397,7 @@ def get_photoiontargetfractions(
 ):
     targetlist: list[list[tuple[int, float]]] = [[] for _ in range(dfenergy_levels.height)]
     upper_level_ids_of_core_state_id = defaultdict(list)
-    for lowerlevelindex in range(dfenergy_levels.height):
+    for lowerlevelid in range(dfenergy_levels.height):
         # find the upper level ids from the Nahar core state
         upperionlevelids = get_naharphotoion_upperlevelids(
             dfenergy_levels_upperion,
@@ -407,11 +407,9 @@ def get_photoiontargetfractions(
             flog,
         )
 
-        summed_statistical_weights = sum(
-            float(dfenergy_levels_upperion["g"][levelid - 1]) for levelid in upperionlevelids
-        )
+        summed_statistical_weights = sum(float(dfenergy_levels_upperion["g"][levelid]) for levelid in upperionlevelids)
         for upperionlevelid in sorted(upperionlevelids):
-            phixsprobability = dfenergy_levels_upperion["g"][upperionlevelid - 1] / summed_statistical_weights
-            targetlist[lowerlevelindex].append((upperionlevelid, phixsprobability))
+            phixsprobability = dfenergy_levels_upperion["g"][upperionlevelid] / summed_statistical_weights
+            targetlist[lowerlevelid].append((upperionlevelid, phixsprobability))
 
     return targetlist

--- a/artisatomic/readnahardata.py
+++ b/artisatomic/readnahardata.py
@@ -40,10 +40,19 @@ class NaharEnergyLevel(t.NamedTuple):
     naharconfiguration: str
 
 
-def read_nahar_energy_level_file(path_nahar_energy_file, atomic_number, ion_stage, flog):
-    nahar_configurations = {}
+def read_nahar_energy_level_file(
+    path_nahar_energy_file, atomic_number, ion_stage, flog
+) -> tuple[
+    list[NaharEnergyLevel],
+    list[NaharCoreState],
+    dict[tuple[int, int, int, int], int],
+    dict[tuple[int, int, int, int], str],
+    float,
+]:
+    # state tuples are (2S+1, L, parity, index in symmetry)
+    nahar_configurations: dict[tuple[int, int, int, int], str] = {}
     nahar_energy_levels: list[NaharEnergyLevel] = []
-    nahar_level_index_of_state = {}
+    nahar_level_index_of_state: dict[tuple[int, int, int, int], int] = {}
     nahar_core_states: list[NaharCoreState] = []
     nahar_ionization_potential_rydberg = -1.0
 
@@ -267,8 +276,8 @@ def read_nahar_phixs_tables(path_nahar_px_file, atomic_number, ion_stage, args):
     return nahar_phixs_tables, thresholds_ev_dict
 
 
-def read_nahar_configurations(fenlist, flog):
-    nahar_configurations = {}
+def read_nahar_configurations(fenlist, flog) -> tuple[dict[tuple[int, int, int, int], str], float]:
+    nahar_configurations: dict[tuple[int, int, int, int], str] = {}
     nahar_ionization_potential_rydberg = -1.0
     while True:
         line = fenlist.readline()
@@ -393,8 +402,12 @@ def get_naharphotoion_upperlevelids(
 
 
 def get_photoiontargetfractions(
-    dfenergy_levels, dfenergy_levels_upperion, nahar_core_states, nahar_configurations_upperion, flog
-):
+    dfenergy_levels,
+    dfenergy_levels_upperion,
+    nahar_core_states: list[NaharCoreState],
+    nahar_configurations_upperion: dict[tuple[int, int, int, int], str],
+    flog,
+) -> list[list[tuple[int, float]]]:
     targetlist: list[list[tuple[int, float]]] = [[] for _ in range(dfenergy_levels.height)]
     upper_level_ids_of_core_state_id = defaultdict(list)
     for lowerlevelid in range(dfenergy_levels.height):

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -53,7 +53,7 @@ def read_adf04(
     filepath: str | Path, atomic_number: int, ion_stage: int, flog
 ) -> tuple[float, list[QUBEnergyLevel], dict[tuple[int, int], float]]:
     energylevels: list[QUBEnergyLevel] = []
-    upsilondict = {}
+    upsilondict: dict[tuple[int, int], float] = {}
     ionization_energy_ev = 0.0
     artisatomic.log_and_print(flog, f"Reading {artisatomic.path_for_log(filepath)}")
     with artisatomic.xopen_check_extension(filepath) as fleveltrans:
@@ -263,7 +263,7 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
         transition_count_of_level_name = defaultdict(int)
         qub_energylevels: list[QUBEnergyLevel] = [QUBEnergyLevel("groundstate", 1, 0, 0, 0, 0.0, 10, 0)]
         qub_transitions = pl.DataFrame(schema={"lowerlevel": pl.Int64, "upperlevel": pl.Int64, "A": pl.Float64})
-        upsilondict = {}
+        upsilondict: dict[tuple[int, int], float] = {}
         ionization_energy_ev = 54.9000015
 
     elif (atomic_number, ion_stage) in new_qub_calculations:

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -166,13 +166,16 @@ def read_adf04(
                 strtemperature = "5.00+03"
             strupsilon = str(row[f"upsT={strtemperature}"])
             upsilon = float(strupsilon.replace("-", "E-").replace("+", "E+"))
-            if (lower, upper) not in upsilondict:
-                upsilondict[(lower, upper)] = upsilon
+            # the file numbers levels from one; level ids are zero-based in memory. The log
+            # messages keep the file's numbering, since they are about the file's contents.
+            levelidpair = (lower - 1, upper - 1)
+            if levelidpair not in upsilondict:
+                upsilondict[levelidpair] = upsilon
             else:
                 artisatomic.log_and_print(
                     flog,
                     f"Duplicate upsilon value for transition {lower:d} to {upper:d} keeping"
-                    f" {upsilondict[(lower, upper)]:5.2e} instead of using {upsilon:5.2e}",
+                    f" {upsilondict[levelidpair]:5.2e} instead of using {upsilon:5.2e}",
                 )
 
     artisatomic.log_and_print(flog, f"Read {len(energylevels):d} levels")
@@ -233,8 +236,11 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
                     if id_lower < 1 or id_upper < 1:
                         msg = f"non-positive transition level ids {id_lower}, {id_upper} in {transitionfile}"
                         raise ValueError(msg)
-                    level_upper = qub_energylevels[id_upper - 1]
-                    level_lower = qub_energylevels[id_lower - 1]
+                    # the file numbers levels from one; level ids are zero-based in memory
+                    id_lower -= 1
+                    id_upper -= 1
+                    level_upper = qub_energylevels[id_upper]
+                    level_lower = qub_energylevels[id_lower]
                     namefrom = level_upper.levelname
                     nameto = level_lower.levelname
                     # WARNING replace with correct selection rules!
@@ -306,8 +312,11 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
                         if id_lower < 1 or id_upper < 1:
                             msg = f"non-positive transition level ids {id_lower}, {id_upper} in {atom_file}"
                             raise ValueError(msg)
-                        level_upper = qub_energylevels[id_upper - 1]
-                        level_lower = qub_energylevels[id_lower - 1]
+                        # the file numbers levels from one; level ids are zero-based in memory
+                        id_lower -= 1
+                        id_upper -= 1
+                        level_upper = qub_energylevels[id_upper]
+                        level_lower = qub_energylevels[id_lower]
                         namefrom = level_upper.levelname
                         nameto = level_lower.levelname
                         forbidden = artisatomic.check_forbidden(level_upper, level_lower)
@@ -342,29 +351,31 @@ def read_qub_photoionizations(atomic_number, ion_stage, energy_levels, args, flo
     photoionization_thresholds_ev = np.zeros(len(energy_levels))
 
     if atomic_number == 27 and ion_stage == 2:
-        for lowerlevelid in [1, 2, 3, 4, 5, 6, 7, 8]:
-            filename = tyndall_co3_path / f"{lowerlevelid:d}.gz"
+        for lowerlevelid in range(8):
+            # the cross-section files are named after the level's number in the source data,
+            # which counts from one
+            filename = tyndall_co3_path / f"{lowerlevelid + 1:d}.gz"
             artisatomic.log_and_print(flog, f"Reading {artisatomic.path_for_log(filename)}")
             photdata = pd.read_csv(filename, sep=r"\s+", header=None)
             phixstables = {}
             ntargets = 4  # just the 4Fe ground quartet (the file has 40 target columns)
 
-            for targetlevel in range(1, ntargets + 1):
-                phixstables[targetlevel] = photdata.loc[photdata[:][targetlevel] > 0.0][[0, targetlevel]].to_numpy()
+            # column n of the file holds the cross section to the upper ion's level id n - 1
+            for targetcolumn in range(1, ntargets + 1):
+                phixstables[targetcolumn] = photdata.loc[photdata[:][targetcolumn] > 0.0][[0, targetcolumn]].to_numpy()
 
             reduced_phixs_dict = artisatomic.reduce_phixs_tables(
                 phixstables, args.optimaltemperature, args.nphixspoints, args.phixsnuincrement
             )
             target_scalefactors = np.zeros(ntargets)
-            upperlevelid_withmaxfraction = 1
+            targetcolumn_withmaxfraction = 1
             max_scalefactor = 0.0
-            for upperlevelid in reduced_phixs_dict:
+            for targetcolumn, reduced_phixstable in reduced_phixs_dict.items():
                 # take the ratio of cross sections at the threshold energies
-                scalefactor = reduced_phixs_dict[upperlevelid][0]
-                target_scalefactors[upperlevelid - 1] = scalefactor
-                # target_scalefactors[upperlevelid - 1] = np.average(reduced_phixs_dict[upperlevelid])
+                scalefactor = reduced_phixstable[0]
+                target_scalefactors[targetcolumn - 1] = scalefactor
                 if scalefactor > max_scalefactor:
-                    upperlevelid_withmaxfraction = upperlevelid
+                    targetcolumn_withmaxfraction = targetcolumn
                     max_scalefactor = scalefactor
 
             scalefactorsum = sum(target_scalefactors)
@@ -379,15 +390,15 @@ def read_qub_photoionizations(atomic_number, ion_stage, energy_levels, args, flo
 
             # -1.0 sentinel: the threshold energy comes from the level energies, not from the
             # first energy point of the cross-section table
-            photoionization_thresholds_ev[lowerlevelid - 1] = -1.0
-            for upperlevelid, target_scalefactor in enumerate(target_scalefactors, 1):
+            photoionization_thresholds_ev[lowerlevelid] = -1.0
+            for upperlevelid, target_scalefactor in enumerate(target_scalefactors):
                 target_fraction = target_scalefactor / scalefactorsum
                 if target_fraction > 0.001:
-                    photoionization_targetfractions[lowerlevelid - 1].append((upperlevelid, target_fraction))
+                    photoionization_targetfractions[lowerlevelid].append((upperlevelid, target_fraction))
 
             max_fraction = max_scalefactor / scalefactorsum
-            photoionization_crosssections[lowerlevelid - 1] = (
-                reduced_phixs_dict[upperlevelid_withmaxfraction] / max_fraction
+            photoionization_crosssections[lowerlevelid] = (
+                reduced_phixs_dict[targetcolumn_withmaxfraction] / max_fraction
             )
 
     elif atomic_number == 27 and ion_stage == 3:
@@ -507,11 +518,11 @@ def read_qub_photoionizations(atomic_number, ion_stage, energy_levels, args, flo
         # Unlike the Co II branch above, every level is deliberately given a phixs entry: levels
         # of the ground quartet get the tabulated cross section, and all higher levels get an
         # explicit all-zero table (no photoionization) rather than being omitted from the output.
-        for levelindex in range(len(energy_levels)):
-            photoionization_thresholds_ev[levelindex] = -1.0
-            photoionization_targetfractions[levelindex] = [(1, 1.0)]
-            if levelindex < 4:
-                photoionization_crosssections[levelindex] = phixsvalues
+        for levelid in range(len(energy_levels)):
+            photoionization_thresholds_ev[levelid] = -1.0
+            photoionization_targetfractions[levelid] = [(0, 1.0)]  # the upper ion's ground state
+            if levelid < 4:
+                photoionization_crosssections[levelid] = phixsvalues
 
     return photoionization_crosssections, photoionization_targetfractions, photoionization_thresholds_ev
 

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -50,8 +50,8 @@ def extend_ion_list(ion_handlers):
 
 def read_adf04(
     filepath: str | Path, atomic_number: int, ion_stage: int, flog
-) -> tuple[float, list[QUBEnergyLevel | None], dict[tuple[int, int], float]]:
-    energylevels: list[QUBEnergyLevel | None] = [None]
+) -> tuple[float, list[QUBEnergyLevel], dict[tuple[int, int], float]]:
+    energylevels: list[QUBEnergyLevel] = []
     upsilondict = {}
     ionization_energy_ev = 0.0
     artisatomic.log_and_print(flog, f"Reading {artisatomic.path_for_log(filepath)}")
@@ -117,13 +117,13 @@ def read_adf04(
             energylevel = energylevel._replace(g=g, parity=parity, levelname=levelname)
             energylevels.append(energylevel)
 
-            # the transition and upsilon tables index levels by this id, and the rest of the code
-            # indexes the list by position, so a non-contiguous or non-1-based file would silently
-            # attach every transition to the wrong level. Not an assert: this validates an input
-            # file and must not disappear under python -O.
-            if energylevel.qub_id != len(energylevels) - 1:
+            # the transition and upsilon tables index levels by this 1-based id, and the rest of
+            # the code looks up id n at list index n - 1, so a non-contiguous or non-1-based file
+            # would silently attach every transition to the wrong level. Not an assert: this
+            # validates an input file and must not disappear under python -O.
+            if energylevel.qub_id != len(energylevels):
                 msg = (
-                    f"adf04 level id {energylevel.qub_id} found at position {len(energylevels) - 1} in {filepath}."
+                    f"adf04 level id {energylevel.qub_id} found at position {len(energylevels)} in {filepath}."
                     " Level ids must be contiguous and start at 1."
                 )
                 raise ValueError(msg)
@@ -175,7 +175,7 @@ def read_adf04(
                     f" {upsilondict[(lower, upper)]:5.2e} instead of using {upsilon:5.2e}",
                 )
 
-    artisatomic.log_and_print(flog, f"Read {len(energylevels[1:]):d} levels")
+    artisatomic.log_and_print(flog, f"Read {len(energylevels):d} levels")
 
     return ionization_energy_ev, energylevels, upsilondict
 
@@ -228,10 +228,13 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
                 id_lower = int(row[1])
                 A = float(row[2])
                 if A > 2e-30:
-                    level_upper = qub_energylevels[id_upper]
-                    level_lower = qub_energylevels[id_lower]
-                    assert level_upper is not None
-                    assert level_lower is not None
+                    # a raise rather than an assert: this validates an input file, and a
+                    # non-positive id would otherwise wrap to the wrong level via negative indexing
+                    if id_lower < 1 or id_upper < 1:
+                        msg = f"non-positive transition level ids {id_lower}, {id_upper} in {transitionfile}"
+                        raise ValueError(msg)
+                    level_upper = qub_energylevels[id_upper - 1]
+                    level_lower = qub_energylevels[id_lower - 1]
                     namefrom = level_upper.levelname
                     nameto = level_lower.levelname
                     # WARNING replace with correct selection rules!
@@ -251,11 +254,10 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
 
     elif (atomic_number == 27) and (ion_stage == 4):
         transition_count_of_level_name = defaultdict(int)
-        qub_energylevels: list[QUBEnergyLevel | None] = [None]
+        qub_energylevels: list[QUBEnergyLevel] = [QUBEnergyLevel("groundstate", 1, 0, 0, 0, 0.0, 10, 0)]
         qub_transitions = pl.DataFrame(schema={"lowerlevel": pl.Int64, "upperlevel": pl.Int64, "A": pl.Float64})
         upsilondict = {}
         ionization_energy_ev = 54.9000015
-        qub_energylevels.append(QUBEnergyLevel("groundstate", 1, 0, 0, 0, 0.0, 10, 0))
 
     elif (atomic_number, ion_stage) in new_qub_calculations:
         atom_file = f"{atomic_number}_{ion_stage}.adf04"
@@ -299,10 +301,13 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
                         id_lower = int(row[1])
                     A = float(row[2].replace("-", "E-").replace("+", "E+"))
                     if A > 2e-30:
-                        level_upper = qub_energylevels[id_upper]
-                        level_lower = qub_energylevels[id_lower]
-                        assert level_upper is not None
-                        assert level_lower is not None
+                        # a raise rather than an assert: this validates an input file, and a
+                        # non-positive id would otherwise wrap to the wrong level via negative indexing
+                        if id_lower < 1 or id_upper < 1:
+                            msg = f"non-positive transition level ids {id_lower}, {id_upper} in {atom_file}"
+                            raise ValueError(msg)
+                        level_upper = qub_energylevels[id_upper - 1]
+                        level_lower = qub_energylevels[id_lower - 1]
                         namefrom = level_upper.levelname
                         nameto = level_lower.levelname
                         forbidden = artisatomic.check_forbidden(level_upper, level_lower)
@@ -350,14 +355,14 @@ def read_qub_photoionizations(atomic_number, ion_stage, energy_levels, args, flo
             reduced_phixs_dict = artisatomic.reduce_phixs_tables(
                 phixstables, args.optimaltemperature, args.nphixspoints, args.phixsnuincrement
             )
-            target_scalefactors = np.zeros(ntargets + 1)
+            target_scalefactors = np.zeros(ntargets)
             upperlevelid_withmaxfraction = 1
             max_scalefactor = 0.0
             for upperlevelid in reduced_phixs_dict:
                 # take the ratio of cross sections at the threshold energies
                 scalefactor = reduced_phixs_dict[upperlevelid][0]
-                target_scalefactors[upperlevelid] = scalefactor
-                # target_scalefactors[upperlevelid] = np.average(reduced_phixs_dict[upperlevelid])
+                target_scalefactors[upperlevelid - 1] = scalefactor
+                # target_scalefactors[upperlevelid - 1] = np.average(reduced_phixs_dict[upperlevelid])
                 if scalefactor > max_scalefactor:
                     upperlevelid_withmaxfraction = upperlevelid
                     max_scalefactor = scalefactor
@@ -374,14 +379,14 @@ def read_qub_photoionizations(atomic_number, ion_stage, energy_levels, args, flo
 
             # -1.0 sentinel: the threshold energy comes from the level energies, not from the
             # first energy point of the cross-section table
-            photoionization_thresholds_ev[lowerlevelid] = -1.0
-            for upperlevelid, target_scalefactor in enumerate(target_scalefactors[1:], 1):
+            photoionization_thresholds_ev[lowerlevelid - 1] = -1.0
+            for upperlevelid, target_scalefactor in enumerate(target_scalefactors, 1):
                 target_fraction = target_scalefactor / scalefactorsum
                 if target_fraction > 0.001:
-                    photoionization_targetfractions[lowerlevelid].append((upperlevelid, target_fraction))
+                    photoionization_targetfractions[lowerlevelid - 1].append((upperlevelid, target_fraction))
 
             max_fraction = max_scalefactor / scalefactorsum
-            photoionization_crosssections[lowerlevelid] = (
+            photoionization_crosssections[lowerlevelid - 1] = (
                 reduced_phixs_dict[upperlevelid_withmaxfraction] / max_fraction
             )
 
@@ -502,11 +507,11 @@ def read_qub_photoionizations(atomic_number, ion_stage, energy_levels, args, flo
         # Unlike the Co II branch above, every level is deliberately given a phixs entry: levels
         # of the ground quartet get the tabulated cross section, and all higher levels get an
         # explicit all-zero table (no photoionization) rather than being omitted from the output.
-        for lowerlevelid in range(1, len(energy_levels)):
-            photoionization_thresholds_ev[lowerlevelid] = -1.0
-            photoionization_targetfractions[lowerlevelid] = [(1, 1.0)]
-            if lowerlevelid <= 4:
-                photoionization_crosssections[lowerlevelid] = phixsvalues
+        for levelindex in range(len(energy_levels)):
+            photoionization_thresholds_ev[levelindex] = -1.0
+            photoionization_targetfractions[levelindex] = [(1, 1.0)]
+            if levelindex < 4:
+                photoionization_crosssections[levelindex] = phixsvalues
 
     return photoionization_crosssections, photoionization_targetfractions, photoionization_thresholds_ev
 

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import polars as pl
 
@@ -344,7 +345,9 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
     return ionization_energy_ev, qub_energylevels, qub_transitions, transition_count_of_level_name, upsilondict
 
 
-def read_qub_photoionizations(atomic_number, ion_stage, energy_levels, args, flog):
+def read_qub_photoionizations(
+    atomic_number, ion_stage, energy_levels, args, flog
+) -> tuple[npt.NDArray[np.float64], list[list[tuple[int, float]]], npt.NDArray[np.float64]]:
     photoionization_crosssections = np.zeros((len(energy_levels), args.nphixspoints))
     # levels stay empty (write_phixs_data() skips them) unless real data is assigned below
     photoionization_targetfractions: list[list[tuple[int, float]]] = [[] for _ in energy_levels]

--- a/artisatomic/readtanakajpltdata.py
+++ b/artisatomic/readtanakajpltdata.py
@@ -25,6 +25,7 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
     filename = f"{atomic_number}_{ion_stage}.txt"
     print(f"Reading Tanaka et al. Japan-Lithuania database for Z={atomic_number} ion_stage {ion_stage} from {filename}")
     with artisatomic.xopen_check_extension(jpltpath / filename) as fin:
+        readlinein = ""
         for linenumber in range(7):
             readlinein = fin.readline().strip()
             if linenumber < 3:

--- a/artisatomic/readtanakajpltdata.py
+++ b/artisatomic/readtanakajpltdata.py
@@ -59,10 +59,12 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
                 energyabovegsinpercm=pl.col("energy_ev").cast(pl.Float64) / hc_in_ev_cm,
                 parity=pl.when(pl.col("parity").str.strip_chars() == "odd").then(1).otherwise(0),
                 g=pl.col("g").cast(pl.Float64),
+                # the level name keeps the file's own 1-based number, but the level id is
+                # zero-based like everywhere else in memory
                 levelname=pl.format(
                     "{},{},{}", pl.col("levelid"), pl.col("parity"), pl.col("configuration").str.strip_chars()
                 ),
-                levelid=pl.col("levelid").cast(pl.Int64),
+                levelid=pl.col("levelid").cast(pl.Int64) - 1,
             )
 
         assert dflevels.height == levelcount
@@ -79,8 +81,9 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
                 dtype_backend="pyarrow",
             )
         ).select(
-            pl.col("lowerlevel").cast(pl.Int64),
-            pl.col("upperlevel").cast(pl.Int64),
+            # the file numbers levels from one; level ids are zero-based in memory
+            pl.col("lowerlevel").cast(pl.Int64) - 1,
+            pl.col("upperlevel").cast(pl.Int64) - 1,
             pl.col("g_u_times_A").cast(pl.Float64),
         )
 

--- a/artisatomic/readtanakajpltdata.py
+++ b/artisatomic/readtanakajpltdata.py
@@ -55,19 +55,17 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
         ) as reader:
             hc_in_ev_cm = 0.0001239841984332003
 
-            dflevels = artisatomic.add_dummy_zero_level(
-                pl.from_pandas(reader.get_chunk(levelcount)).select(
-                    energyabovegsinpercm=pl.col("energy_ev").cast(pl.Float64) / hc_in_ev_cm,
-                    parity=pl.when(pl.col("parity").str.strip_chars() == "odd").then(1).otherwise(0),
-                    g=pl.col("g").cast(pl.Float64),
-                    levelname=pl.format(
-                        "{},{},{}", pl.col("levelid"), pl.col("parity"), pl.col("configuration").str.strip_chars()
-                    ),
-                    levelid=pl.col("levelid").cast(pl.Int64),
-                )
+            dflevels = pl.from_pandas(reader.get_chunk(levelcount)).select(
+                energyabovegsinpercm=pl.col("energy_ev").cast(pl.Float64) / hc_in_ev_cm,
+                parity=pl.when(pl.col("parity").str.strip_chars() == "odd").then(1).otherwise(0),
+                g=pl.col("g").cast(pl.Float64),
+                levelname=pl.format(
+                    "{},{},{}", pl.col("levelid"), pl.col("parity"), pl.col("configuration").str.strip_chars()
+                ),
+                levelid=pl.col("levelid").cast(pl.Int64),
             )
 
-        assert (dflevels.height - 1) == levelcount
+        assert dflevels.height == levelcount
 
         line = fin.readline().strip()
         assert line in ("# Transitions", "# num_u   num_l   wavelength(nm)     g_u*A      log(g_l*f)")
@@ -90,8 +88,8 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
         pl.concat([dftransitions["lowerlevel"], dftransitions["upperlevel"]]).value_counts().iter_rows()
     )
     transition_count_of_level_name = {
-        dflevels["levelname"][levelid]: transition_count_of_levelid.get(levelid, 0)
-        for levelid in dflevels["levelid"][1:]
+        levelname: transition_count_of_levelid.get(levelid, 0)
+        for levelid, levelname in dflevels.select("levelid", "levelname").iter_rows(named=False)
     }
     assert dftransitions.height == transitioncount
 

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -269,10 +269,10 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
     ionization_energy_ev = 4 * ryd_to_ev
     dflevels = pl.DataFrame(
         {
-            "levelid": [0, 1],
-            "energyabovegsinpercm": [None, 0.0],
-            "g": [None, 2.0],
-            "levelname": [None, "s1s  1S,enpercm=0.0,j=0.5"],
+            "levelid": [1],
+            "energyabovegsinpercm": [0.0],
+            "g": [2.0],
+            "levelname": ["s1s  1S,enpercm=0.0,j=0.5"],
         }
     )
     args = argparse.Namespace(nphixspoints=100, phixsnuincrement=0.03, optimaltemperature=6000)
@@ -285,21 +285,21 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
         args=args,
     )
 
-    assert thresholds[1] == ionization_energy_ev
-    assert targetfractions[1] == [(1, 1.0)]
+    assert thresholds[0] == ionization_energy_ev
+    assert targetfractions[0] == [(1, 1.0)]
 
     expected_threshold_mb = rhd.get_hydrogenic_n_phixstable(rhd.hc_in_ev_angstrom / ionization_energy_ev, 1)[0][1]
     assert abs(expected_threshold_mb - 6.3067 / 4) < 1e-3  # exact hydrogenic value for He II 1s
     # the downsampled first point is a bin average, so allow a few percent
-    assert abs(crosssections[1][0] / expected_threshold_mb - 1) < 0.05
+    assert abs(crosssections[0][0] / expected_threshold_mb - 1) < 0.05
 
     # levels above the ionization energy must be skipped rather than dividing by a negative threshold
     dflevels_unbound = pl.DataFrame(
         {
-            "levelid": [0, 1],
-            "energyabovegsinpercm": [None, 2 * ionization_energy_ev / hc_in_ev_cm],
-            "g": [None, 2.0],
-            "levelname": [None, "s1s  1S,enpercm=0.0,j=0.5"],
+            "levelid": [1],
+            "energyabovegsinpercm": [2 * ionization_energy_ev / hc_in_ev_cm],
+            "g": [2.0],
+            "levelname": ["s1s  1S,enpercm=0.0,j=0.5"],
         }
     )
     crosssections, targetfractions, thresholds = artisatomic.match_hydrogenic_phixs(
@@ -309,9 +309,9 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
         ion_handler="kurucz",
         args=args,
     )
-    assert thresholds[1] == 0.0
-    assert targetfractions[1] == []
-    assert np.all(crosssections[1] == 0.0)
+    assert thresholds[0] == 0.0
+    assert targetfractions[0] == []
+    assert np.all(crosssections[0] == 0.0)
 
 
 def test_read_coldata_term_to_j_redistribution():
@@ -338,7 +338,7 @@ def test_read_coldata_term_to_j_redistribution():
             _, energy_levels, _, _, _ = readhillierdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
             upsilondict = readhillierdata.read_coldata(atomic_number, ion_stage, energy_levels, flog, args)
         levelids_of_term = defaultdict(list)
-        for levelid, level in enumerate(energy_levels[1:], 1):
+        for levelid, level in enumerate(energy_levels, 1):
             levelids_of_term[level.levelname.split("[")[0]].append(levelid)
         return energy_levels, upsilondict, levelids_of_term
 
@@ -346,7 +346,7 @@ def test_read_coldata_term_to_j_redistribution():
 
     lower_ids = levelids_of_term["2s2_2p2_3Pe"]  # J = 0, 1, 2 with g = 1, 3, 5
     upper_ids = levelids_of_term["2s_2p3_3Do"]
-    assert [energy_levels[i].g for i in lower_ids] == [1.0, 3.0, 5.0]
+    assert [energy_levels[i - 1].g for i in lower_ids] == [1.0, 3.0, 5.0]
 
     sums_from_lower = [
         sum(upsilondict[(i, j)] for j in upper_ids if upsilondict.get((i, j), -1.0) > 0.0) for i in lower_ids
@@ -481,9 +481,9 @@ def test_read_adf04():
         (PYDIR / ".." / "atomic-data-qub" / "co_tyndall_test_sample" / "adf04_v1").resolve(), 27, 3, flog
     )
     assert abs(ionization_energy_ev - 40.964007) < 1e-5
-    assert len(energylevels) - 1 == 262
+    assert len(energylevels) == 262
     assert len(upsilondict) == 235
-    level1 = energylevels[1]
+    level1 = energylevels[0]
     assert level1 is not None
     assert level1.levelname == "3s23p63d7(4F)_4Fe[9/2]_id=1"
     assert level1.energyabovegsinpercm == 0.0
@@ -501,7 +501,7 @@ def test_read_nahar_energy_level_file_missing():
         nahar_configurations,
         nahar_ionization_potential_rydberg,
     ) = readnahardata.read_nahar_energy_level_file("does/not/exist.en.ls.txt", 26, 2, flog)
-    assert nahar_energy_levels == [None]
+    assert nahar_energy_levels == []
     assert nahar_core_states == []
     assert nahar_level_index_of_state == {}
     assert nahar_configurations == {}
@@ -510,15 +510,11 @@ def test_read_nahar_energy_level_file_missing():
 
 
 def test_nahar_get_photoiontargetfractions():
-    dflower = pl.DataFrame(
-        {"levelid": [0, 1], "energyabovegsinpercm": [None, 0.0], "g": [None, 9.0], "levelname": [None, "gs"]}
-    )
-    dfupper = pl.DataFrame(
-        {"levelid": [0, 1], "energyabovegsinpercm": [None, 0.0], "g": [None, 10.0], "levelname": [None, "gs2"]}
-    )
-    nahar_core_states = [None, readnahardata.NaharCoreState(1, "3d6", "5De", 0.0)]
+    dflower = pl.DataFrame({"levelid": [1], "energyabovegsinpercm": [0.0], "g": [9.0], "levelname": ["gs"]})
+    dfupper = pl.DataFrame({"levelid": [1], "energyabovegsinpercm": [0.0], "g": [10.0], "levelname": ["gs2"]})
+    nahar_core_states = [readnahardata.NaharCoreState(1, "3d6", "5De", 0.0)]
     targetlist = readnahardata.get_photoiontargetfractions(dflower, dfupper, nahar_core_states, {}, io.StringIO())
-    assert targetlist[1] == [(1, 1.0)]
+    assert targetlist[0] == [(1, 1.0)]
 
 
 def test_get_level_valence_n():

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -269,7 +269,7 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
     ionization_energy_ev = 4 * ryd_to_ev
     dflevels = pl.DataFrame(
         {
-            "levelid": [1],
+            "levelid": [0],
             "energyabovegsinpercm": [0.0],
             "g": [2.0],
             "levelname": ["s1s  1S,enpercm=0.0,j=0.5"],
@@ -286,7 +286,7 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
     )
 
     assert thresholds[0] == ionization_energy_ev
-    assert targetfractions[0] == [(1, 1.0)]
+    assert targetfractions[0] == [(0, 1.0)]  # the upper ion's ground state
 
     expected_threshold_mb = rhd.get_hydrogenic_n_phixstable(rhd.hc_in_ev_angstrom / ionization_energy_ev, 1)[0][1]
     assert abs(expected_threshold_mb - 6.3067 / 4) < 1e-3  # exact hydrogenic value for He II 1s
@@ -296,7 +296,7 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
     # levels above the ionization energy must be skipped rather than dividing by a negative threshold
     dflevels_unbound = pl.DataFrame(
         {
-            "levelid": [1],
+            "levelid": [0],
             "energyabovegsinpercm": [2 * ionization_energy_ev / hc_in_ev_cm],
             "g": [2.0],
             "levelname": ["s1s  1S,enpercm=0.0,j=0.5"],
@@ -338,7 +338,7 @@ def test_read_coldata_term_to_j_redistribution():
             _, energy_levels, _, _, _ = readhillierdata.read_levels_and_transitions(atomic_number, ion_stage, flog)
             upsilondict = readhillierdata.read_coldata(atomic_number, ion_stage, energy_levels, flog, args)
         levelids_of_term = defaultdict(list)
-        for levelid, level in enumerate(energy_levels, 1):
+        for levelid, level in enumerate(energy_levels):
             levelids_of_term[level.levelname.split("[")[0]].append(levelid)
         return energy_levels, upsilondict, levelids_of_term
 
@@ -346,7 +346,7 @@ def test_read_coldata_term_to_j_redistribution():
 
     lower_ids = levelids_of_term["2s2_2p2_3Pe"]  # J = 0, 1, 2 with g = 1, 3, 5
     upper_ids = levelids_of_term["2s_2p3_3Do"]
-    assert [energy_levels[i - 1].g for i in lower_ids] == [1.0, 3.0, 5.0]
+    assert [energy_levels[i].g for i in lower_ids] == [1.0, 3.0, 5.0]
 
     sums_from_lower = [
         sum(upsilondict[(i, j)] for j in upper_ids if upsilondict.get((i, j), -1.0) > 0.0) for i in lower_ids
@@ -510,11 +510,11 @@ def test_read_nahar_energy_level_file_missing():
 
 
 def test_nahar_get_photoiontargetfractions():
-    dflower = pl.DataFrame({"levelid": [1], "energyabovegsinpercm": [0.0], "g": [9.0], "levelname": ["gs"]})
-    dfupper = pl.DataFrame({"levelid": [1], "energyabovegsinpercm": [0.0], "g": [10.0], "levelname": ["gs2"]})
+    dflower = pl.DataFrame({"levelid": [0], "energyabovegsinpercm": [0.0], "g": [9.0], "levelname": ["gs"]})
+    dfupper = pl.DataFrame({"levelid": [0], "energyabovegsinpercm": [0.0], "g": [10.0], "levelname": ["gs2"]})
     nahar_core_states = [readnahardata.NaharCoreState(1, "3d6", "5De", 0.0)]
     targetlist = readnahardata.get_photoiontargetfractions(dflower, dfupper, nahar_core_states, {}, io.StringIO())
-    assert targetlist[0] == [(1, 1.0)]
+    assert targetlist[0] == [(0, 1.0)]  # the upper ion's ground state
 
 
 def test_get_level_valence_n():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "requests>=2.34.0",
     "scipy>=1.15.3",
     "tables>=3.11.1",
-    "tqdm>=4.67.3",
+    "tqdm>=4.70.0",
     "xopen>=2.1.0",
 ]
 
@@ -54,6 +54,7 @@ dev = [
     "ty>=0.0.65",
     "types-pytz>=2025.2.0.20250809",
     "types-requests>=2.32.0.20241016",
+    "types-tqdm>=4.70.0.20260731",
 ]
 
 [project.urls]
@@ -95,13 +96,11 @@ project-excludes = [
 python-interpreter-path = ".venv/bin/python3"
 
 [tool.pyrefly.errors]
-missing-import = false
-unbound-name = false
-unsupported-operation = false
-implicit-any-lambda = false
-implicit-any-empty-container = false
+# these stay off because they fire in the hundreds on unannotated function parameters and
+# lambdas, which ruff's ANN001 also allows; everything else in the strict preset is enabled
+# and individual exceptions are suppressed at the line that needs them
 implicit-any-parameter = false
-implicit-any-type-argument = false
+implicit-any-lambda = false
 
 [tool.pyright]
 deprecateTypingAliases = true
@@ -116,16 +115,17 @@ exclude = [
     '**/_version.py',
     '.venv',
 ]
-reportAttributeAccessIssue = false
-reportCallIssue = false
+reportAttributeAccessIssue = true
+reportCallIssue = true
 reportDeprecated = true
-reportMissingImports = false
-reportMissingTypeStubs = false
-reportOptionalMemberAccess = false
-reportPossiblyUnboundVariable = false
+reportMissingImports = true
+reportMissingTypeStubs = true
+reportOptionalMemberAccess = true
+reportPossiblyUnboundVariable = true
 reportUnnecessaryTypeIgnoreComment = true
+# the untyped parts of the pandas/numpy/polars APIs make this ~450 errors of pure noise
 reportUnknownVariableType = false
-reportUnreachable = false
+reportUnreachable = true
 typeCheckingMode = "standard"
 useLibraryCodeForTypes = true
 pythonVersion = "3.12"

--- a/recombination_rates/recombinationrateintegrals.py
+++ b/recombination_rates/recombinationrateintegrals.py
@@ -42,7 +42,7 @@ E_thresholdinev = 54.801  # Fe I level 200
 nu_edge = E_thresholdinev * EV / H
 phixslist = []
 phixsintegral = 0.0
-lastpoint = []
+lastpoint: list[float] = []
 
 print(f"Z={atomicnumber:d},fromionstage={ionstage:d},fromlevel={levelnumber:d}")
 with open("example_run/phixsdata.txt", encoding="utf-8") as filein:

--- a/uv.lock
+++ b/uv.lock
@@ -81,6 +81,7 @@ dev = [
     { name = "ty" },
     { name = "types-pytz" },
     { name = "types-requests" },
+    { name = "types-tqdm" },
 ]
 
 [package.metadata]
@@ -95,7 +96,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.34.0" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "tables", specifier = ">=3.11.1" },
-    { name = "tqdm", specifier = ">=4.67.3" },
+    { name = "tqdm", specifier = ">=4.70.0" },
     { name = "xopen", specifier = ">=2.1.0" },
 ]
 
@@ -114,6 +115,7 @@ dev = [
     { name = "ty", specifier = ">=0.0.65" },
     { name = "types-pytz", specifier = ">=2025.2.0.20250809" },
     { name = "types-requests", specifier = ">=2.32.0.20241016" },
+    { name = "types-tqdm", specifier = ">=4.70.0.20260731" },
 ]
 
 [[package]]
@@ -1901,6 +1903,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/db/51/703318f7b7be8bee126ec13bf615050f932d0179b8784420f3a0199cc769/types_requests-2.33.0.20260712.tar.gz", hash = "sha256:2141b67ab534a5c5cd2dac5034f2a35f42e699c5bf185eee608c5246a069d7fb", size = 25084, upload-time = "2026-07-12T05:14:20.455Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/e7/010c87f559e216d83f9dc51e939633fd0d0ead3377340181ab0e223cd3b5/types_requests-2.33.0.20260712-py3-none-any.whl", hash = "sha256:de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb", size = 21392, upload-time = "2026-07-12T05:14:19.616Z" },
+]
+
+[[package]]
+name = "types-tqdm"
+version = "4.70.0.20260731"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/00/8992629b9ce59e80c8ac486f80c691d2ff4e8aba8c4f5afe02fef72c05eb/types_tqdm-4.70.0.20260731.tar.gz", hash = "sha256:6b02430954866dbb87b4ada1a16f396775508d0cafbe4c694673d65645e1984e", size = 19061, upload-time = "2026-07-31T05:22:09.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/f3/2b6b01a9c815411566b5c5dba03bb537d8fbf374f76289bacbd2c16204e6/types_tqdm-4.70.0.20260731-py3-none-any.whl", hash = "sha256:d2a8b4ced62afecc84b89d75e40397c22a228ca273eb778899713981e9b323dc", size = 25137, upload-time = "2026-07-31T05:22:08.555Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

Level ids are now **zero-based everywhere in memory**, and the 1-based numbering of the output format is applied only at the point the files are written.

Previously the energy level lists carried a placeholder `None` at index 0 so that list positions lined up with the 1-based ids used by the output files. Every consumer had to remember to skip it (`energy_levels[1:]`, `len(...) - 1`, `height - 1`), the padding leaked into length arithmetic and log counts, and a forgotten offset produced a *valid but wrong* index rather than an error.

This lands in two steps:

1. **Remove the dummy entry.** The lists become ordinary 0-indexed sequences and `add_dummy_zero_level()` is deleted.
2. **Push the 1-based numbering out to the boundary.** The `levelid` column, transition endpoints, collision-strength dict keys and photoionisation target ids are all zero-based; `write_adata()`, `write_transition_data()` and `write_phixs_data()` add the `+ 1`.

Readers whose input files number levels from one (`tanakajplt`, the adf04 files in `readqubdata`) subtract the offset as they parse, so the conversion happens once at the edge. Readers whose files are already zero-based (`floers25`, `boyle`) no longer add one just to have it taken off again. Where a level number appears in a log message *about an input file*, the file's own numbering is kept.

Touched across `__init__.py` and all eleven readers, plus the test suite.

Other points worth noting:

- `leveltuples_to_pldataframe()` is now the single place the `levelid` column is assigned, and `readkuruczdata` calls it instead of re-implementing the assignment.
- That helper now **validates that level ids are contiguous and start at zero** rather than assuming it. This matters for `readtanakajpltdata`, which derives ids from its input files — a gap there would previously have silently shifted every positional lookup past the gap. It raises `ValueError` rather than asserting, matching the repo's convention for input validation that must survive `python -O`.
- **Restores a check the dummy was silently providing.** The adf04 readers rejected out-of-range level ids only as a side effect of a bad id landing on the `None` placeholder; without the padding, an id of 0 would instead wrap to the *last* level via negative indexing and quietly corrupt transition counts. There is now an explicit check.
- `read_phixs_tables`'s `lowerlevelid` actually held a list index and is renamed `lowerlevelindex`, so it no longer reads like the 1-based ids used elsewhere in that file.

## Verification

**The data files are byte-for-byte identical.** All four locally-runnable CI configurations (`cmfgen`, `kurucz`, `qub`, `floers25`) were generated before the change and after each step, and diffed:

- `adata.txt`, `transitiondata.txt`, `phixsdata_v2.txt`, `compositiondata.txt` — identical, and matching the committed `tests/*/checksums.txt`.
- A separate before/after run of a `dream` + `gsnist` config was also identical.
- `tanakajplt` has no data checked in locally, so it was exercised against a synthetic input file; the `test jplt` CI job covers the real dataset.

`pytest` 20/20 pass; `ruff check`, `ruff format`, `pyrefly`, `basedpyright` and `ty` are all clean.

## For the reviewer — log output changes

No data file changes, but **three log messages do change**, all because they report in-memory level ids or counts. Worth a look in case you would rather they kept the file numbering:

1. `Writing N phixs tables to 'phixsdata2.txt'` previously counted the padding row, so it reported one more table than were actually written (Co II now logs 2747 instead of 2748). The new number is the correct one.
2. `WARNING: Swapping transition levels A [i] -> B [j]` and `ERROR: Duplicate collisional transition ...` in `read_coldata()` now print zero-based ids. This accounts for ~9600 changed lines across `co4.txt`, `fe1.txt`, `fe3.txt`, `fe4.txt` in the `cmfgen` run — the level *names* and every numeric result are unchanged, only the bracketed ids shift by one. If you would rather these stayed comparable with `adata.txt`, they can print `id + 1`.

A fourth, currently unreachable change: the Nahar core-state id bound tightened from `N + 1` to `N`, since the old comparison was against a dummy-padded length. An energy file referencing core state `N + 1` is now clamped to 1 with a warning instead of being stored as an id pointing past the table. `get_naharphotoion_upperlevelids()` hardcodes `core_state_id = 1` (an existing "temporary fix"), so nothing exercises it, and the new bound is the correct one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
