### PR TITLE
Keep full J-split level names when the phot file enables J-splitting

### DIFF
--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -551,15 +551,19 @@ def read_phixs_tables(
                     row[-3:]
                 ) == "!Configuration name [*]":
                     lowerlevelname = row[0]
-                    if "[" in lowerlevelname:
+                    # with J splitting, the name (including any [J] suffix) maps to exactly one
+                    # level, so it must be kept intact. Without J splitting, strip the [J] suffix
+                    # so the table applies to all levels sharing the configuration
+                    if not j_splitting_on and "[" in lowerlevelname:
                         lowerlevelname = lowerlevelname.split("[")[0]
                     fitcoefficients = []
                     numpointsexpected = 0
                     lowerlevelindex = 0
-                    # find the zero-based index of the first matching level (several matches may differ by J values)
+                    # find the zero-based index of the first matching level (without J splitting,
+                    # several matches may differ by J values)
                     for levelindex, energy_level in enumerate(energy_levels):
-                        this_levelnamenoj = energy_level.levelname.split("[")[0]
-                        if this_levelnamenoj == lowerlevelname:
+                        levelname = energy_level.levelname if j_splitting_on else energy_level.levelname.split("[")[0]
+                        if levelname == lowerlevelname:
                             lowerlevelindex = levelindex
                             break
                     if targetlevelname == "":


### PR DESCRIPTION
## What changed

In the CMFGEN photoionization reader (`readhillierdata.py`), the `[J]` suffix is no longer stripped from configuration names when the phot file declares `True !Split J levels`. The level-index lookup now also compares against the full level name in that case. When J-splitting is off, behaviour is unchanged (suffix stripped, table shared by all levels of the configuration).

## Why

With J-splitting enabled, each `[J]`-suffixed name maps to exactly one level, but the reader stripped the suffix unconditionally. Two problems followed:

- Distinct J levels collapsed onto the same cross-section table key. For tabulated types the second level's points were appended into the first level's already-full preallocated array, crashing with `IndexError: index 220 is out of bounds for axis 0 with size 220` on Ne I (`NEON/I/9sep11/fin_phot`).
- The mapping loop that assigns tables to levels compares against the *full* level name when `j_splitting_on` is set, so the stripped keys could never match it.

## Notes for review

- The fix relies on `j_splitting_on` being set before any configuration names are read. Verified: every phot file in `atomic_21jun23` declares `!Split J levels` in the header before the first `!Configuration name` line.
- Verified end-to-end on Ne I + Ne II (the J-split `fin_phot` has 201 distinct `[J]`-suffixed entries): before the fix the run crashes with the IndexError above; after the fix it completes cleanly and writes 201 phixs tables with no duplicate-table errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)