### PR TITLE
Cleanup follow-ups: compressed-file handling, phixs threshold sentinels, and shorter comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ build
 
 # coverage
 coverage.xml
-# .coverage plus the per-worker ".coverage.<host>.<pid>" and duplicate ".coverage 2" forms
+# .coverage plus the per-worker ".coverage.<host>.<pid>" and duplicate ".coverage 2" forms,
+# but not the .coveragerc config file that the glob would otherwise swallow
 .coverage*
+!.coveragerc
 htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,14 @@ recombination_rates/phixs.pdf
 .tags*
 testoutput
 testoutput/*
+# written by the checksum verification runs in tests/*/
+tests/*/output/
 _version.py
 build
 .venv
 
 # coverage
 coverage.xml
-.coverage
+# .coverage plus the per-worker ".coverage.<host>.<pid>" and duplicate ".coverage 2" forms
+.coverage*
 htmlcov/

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -193,9 +193,8 @@ def add_handler_if_not_set(
     return sort_ion_handlers(ion_handlers_out)
 
 
-# The id-keyed transition columns consumed by write_transition_data(). Readers with nothing to
-# report use this schema so an empty frame still carries them; name-keyed reader frames (e.g.
-# Hillier's namefrom/nameto) get lowerlevel/upperlevel joined on later by add_level_ids_forbidden().
+# The id-keyed transition columns write_transition_data() needs, so an empty frame still carries
+# them. Name-keyed frames get lowerlevel/upperlevel from add_level_ids_forbidden() instead.
 empty_transitions_schema = pl.Schema({"lowerlevel": pl.Int64, "upperlevel": pl.Int64, "A": pl.Float64})
 
 
@@ -212,9 +211,8 @@ def leveltuples_to_pldataframe(energy_levels) -> pl.DataFrame:
 
     dflevels = dflevels.with_columns(pl.col("levelid").cast(pl.Int64))
 
-    # lookups elsewhere index this frame by level id, so a reader-supplied levelid column
-    # (e.g. from the tanakajplt data files) must be contiguous and start at zero.
-    # A raise rather than an assert: this can be validating an input file's id column.
+    # the frame is indexed by level id elsewhere, so a reader-supplied levelid must be contiguous
+    # and zero-based. Not an assert: input validation must survive python -O.
     if not dflevels["levelid"].equals(pl.int_range(dflevels.height, dtype=pl.Int64, eager=True)):
         msg = "level ids must be contiguous and start at zero"
         raise ValueError(msg)
@@ -948,9 +946,8 @@ def interpret_configuration(instr_orig: str) -> tuple[list[str], int, int, int, 
     if not instr.startswith("Eqv st"):
         while instr:
             if instr[-1].upper() in lchars:
-                # Orbital with no occupation number, e.g. the '10d' of '3d6(5D)10d_5Pe'.
-                # The digit-letter-letter case keeps its leading digit, so '4sp(3P)_7Po[2]'
-                # yields a pretend orbital '4sp' rather than dropping the 4 (as before).
+                # Orbital with no occupation number, e.g. the '10d' of '3d6(5D)10d_5Pe'. A
+                # digit-letter-letter run keeps its digit, so '4sp(3P)_7Po[2]' gives '4sp'.
                 startpos = (
                     -3
                     if len(instr) >= 3
@@ -967,12 +964,9 @@ def interpret_configuration(instr_orig: str) -> tuple[list[str], int, int, int, 
                 instr = instr[:left_bracket_pos]
             elif str.isdigit(instr[-1]):  # the number of electrons in an orbital
                 if len(instr) >= 2 and instr[-2].upper() in lchars:
-                    # Single-digit occupation. A two-digit n is kept ('10d1') only when the
-                    # digits cannot belong to a preceding orbital: '3d14s2' is genuinely
-                    # ambiguous -- 3d(1) 4s(2) or 3d 14s(2) -- and there the single-digit
-                    # reading wins because an occupation of 1 is common and a two-digit n
-                    # carrying an explicit occupation is not. At the start of the string or
-                    # after a parent term there is no such ambiguity.
+                    # Single-digit occupation. A two-digit n survives ('10d1') only where the
+                    # digits cannot belong to a preceding orbital: '3d14s2' is ambiguous
+                    # (3d1 4s2 or 3d 14s2), and there the occupation-1 reading wins.
                     two_digit_n = (
                         len(instr) >= 4
                         and is_two_digit_n(instr[-4:-2])
@@ -1022,10 +1016,9 @@ def get_parity_from_config(instr) -> int:
         l = lchars_lower.index(orbitalstr[lpos])
         nelec = int(orbitalstr[lpos + 1 :]) if len(orbitalstr[lpos + 1 :]) > 0 else 1
 
-        # An orbital must satisfy l <= n - 1. CMFGEN packs the high-l levels of a shell into one
-        # level whose orbital letter is a merge marker rather than a real l ('2s2_13w_2W',
-        # '2s2_2p3(4So)5z_5Z'), and those fail this test. Such a level spans several l of both
-        # parities, so the marker contributes no definite parity and only the real orbitals count.
+        # An orbital must satisfy l <= n - 1. CMFGEN's merged high-l levels ('2s2_13w_2W',
+        # '2s2_2p3(4So)5z_5Z') fail this: the letter is a merge marker spanning several l of both
+        # parities, so it has no definite parity and only the real orbitals count.
         principalquantumnumber = int(orbitalstr[:lpos]) if orbitalstr[:lpos].isdigit() else 0
         if l >= principalquantumnumber:
             continue
@@ -1287,10 +1280,9 @@ def write_phixs_data(
     reported. Level ids, of this ion and of the upper ion's targets, are zero-based in memory but
     numbered from one in the output.
     """
-    # a level gets a table only if it has photoionisation targets and a threshold energy. The
-    # threshold arrays start as NaN and are only filled in for levels that got a cross-section
-    # table, so NaN means "no data for this level". Every number is a real threshold, including
-    # readqubdata's -1.0, which tells ARTIS to take the threshold from the level energies.
+    # a level gets a table only if it has targets and a threshold energy. The threshold arrays
+    # start as NaN and are filled in only for levels that got a table, so NaN means "no data".
+    # Every number is a real threshold, including readqubdata's -1.0 ("derive it from the levels").
     levelids_with_targets = [
         levelid for levelid, targetlist in enumerate(photoionization_targetfractions) if targetlist
     ]

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -1284,8 +1284,13 @@ def write_phixs_data(
     # start as NaN and are filled in only for levels that got a table, so NaN means "no data".
     # A negative value is written deliberately (readqubdata): ARTIS reads it as "no value given"
     # and takes the threshold from the difference of the level energies instead.
+    # the target fractions are filled in per level by the caller, but a reader that found no
+    # photoionization data at all returns the cross-section and threshold arrays still empty, so
+    # bound the ids by what those arrays actually hold rather than indexing off the end
     levelids_with_targets = [
-        levelid for levelid, targetlist in enumerate(photoionization_targetfractions) if targetlist
+        levelid
+        for levelid, targetlist in enumerate(photoionization_targetfractions)
+        if targetlist and levelid < len(photoionization_crosssections) and levelid < len(photoionization_thresholds_ev)
     ]
     levelids_to_write = [
         levelid for levelid in levelids_with_targets if not np.isnan(photoionization_thresholds_ev[levelid])

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -438,7 +438,12 @@ def read_ion_data(
                     photoionization_targetfractions,
                     photoionization_thresholds_ev,
                 ) = readqubdata.read_qub_photoionizations(
-                    atomic_number, ion_stage, levelcount=len(energy_levels), args=args, flog=flog
+                    atomic_number,
+                    ion_stage,
+                    energy_levels=energy_levels,
+                    ionization_energy_ev=ionization_energy_ev,
+                    args=args,
+                    flog=flog,
                 )
 
         elif handler == "nahar":
@@ -614,6 +619,19 @@ def get_nist_ionization_energies_ev() -> dict[tuple[int, int], float]:
             ion_stage = int(ion_charge) + 1
             dictioniz[int(atomic_number), ion_stage] = ioniz_ev
     return dictioniz
+
+
+def photoionization_thresholds_ev_of_levels(energy_levels, ionization_energy_ev: float) -> npt.NDArray[np.float64]:
+    """Photoionization threshold of every level: the ionization energy less its excitation energy.
+
+    A level at or above the ionization energy has nothing to ionize from, so it gets NaN, which
+    write_phixs_data() skips. Use this wherever the threshold is not read from a data file, so
+    that phixsdata_v2.txt only ever carries positive threshold energies.
+    """
+    dflevels = leveltuples_to_pldataframe(energy_levels)
+    thresholds_ev = ionization_energy_ev - hc_in_ev_cm * dflevels["energyabovegsinpercm"].to_numpy()
+
+    return np.where(thresholds_ev > 0.0, thresholds_ev, np.nan)
 
 
 def match_hydrogenic_phixs(
@@ -1282,7 +1300,6 @@ def write_phixs_data(
     """
     # a level gets a table only if it has targets and a threshold energy. The threshold arrays
     # start as NaN and are filled in only for levels that got a table, so NaN means "no data".
-    # Every number is a real threshold, including readqubdata's -1.0 ("derive it from the levels").
     levelids_with_targets = [
         levelid for levelid, targetlist in enumerate(photoionization_targetfractions) if targetlist
     ]
@@ -1290,6 +1307,17 @@ def write_phixs_data(
         levelid for levelid in levelids_with_targets if not np.isnan(photoionization_thresholds_ev[levelid])
     ]
     skipped_no_threshold = len(levelids_with_targets) - len(levelids_to_write)
+
+    # ARTIS reads this column as a photoionization edge, so a non-positive value is meaningless.
+    # Not an assert: this guards the output file and must survive python -O.
+    nonpositive = [levelid for levelid in levelids_to_write if photoionization_thresholds_ev[levelid] <= 0.0]
+    if nonpositive:
+        msg = (
+            f"Z={atomic_number} ion_stage={ion_stage}: {len(nonpositive)} levels have a non-positive"
+            f" photoionization threshold energy, e.g. level {nonpositive[0] + 1} with"
+            f" {photoionization_thresholds_ev[nonpositive[0]]:.6e} eV"
+        )
+        raise ValueError(msg)
 
     log_and_print(flog, f"Writing {len(levelids_to_write)} phixs tables to 'phixsdata2.txt'")
     flog.write(

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -184,16 +184,13 @@ def add_handler_if_not_set(
             if ion_stage not in [get_ion_stage(x) for x in list_ions_handlers_out]:
                 # add an ion that is not present in the element's list
                 list_ions_handlers_out.append((ion_stage, handler))
-                list_ions_handlers_out.sort(key=get_ion_stage)
         ion_handlers_out.append((tmp_atomic_number, list_ions_handlers_out))
 
     if not found_element:
         new_element_ions: list[int | tuple[int, str]] = [(ion_stage, handler)]
         ion_handlers_out.append((atomic_number, new_element_ions))
 
-    ion_handlers_out.sort(key=operator.itemgetter(0))
-
-    return ion_handlers_out
+    return sort_ion_handlers(ion_handlers_out)
 
 
 # The id-keyed transition columns consumed by write_transition_data(). Readers with nothing to
@@ -567,6 +564,18 @@ def isfloat(value: t.Any) -> bool:
     return True
 
 
+compression_extensions = ("", ".zst", ".gz", ".xz")
+
+
+def find_file_check_extension(filename: str | Path) -> Path | None:
+    """Find a data file by its plain name, accepting any of the compressed variants of that name.
+
+    Returns None if neither the plain name nor any compressed form exists, so that callers which
+    treat a missing file as "no data for this ion" can say so without opening it.
+    """
+    return next((path for ext in compression_extensions if (path := Path(f"{filename}{ext}")).is_file()), None)
+
+
 def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO[t.Any]:
     """Open a data file, trying the compressed variants of the name if it does not exist.
 
@@ -575,15 +584,13 @@ def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO[t.Any]:
     """
     from xopen import xopen
 
-    extensions = ["", ".zst", ".gz", ".xz"]
-    filepaths = [f"{filename}{ext}" for ext in extensions]
-    for filepath in filepaths:
-        try:
-            return xopen(filepath, **kwargs)
-        except FileNotFoundError:
-            continue
-    msg = f"Could not find any of the following files:\n  {'\n  '.join(filepaths)}."
-    raise FileNotFoundError(msg)
+    filepath = find_file_check_extension(filename)
+    if filepath is None:
+        filepaths = [f"{filename}{ext}" for ext in compression_extensions]
+        msg = f"Could not find any of the following files:\n  {'\n  '.join(filepaths)}."
+        raise FileNotFoundError(msg)
+
+    return xopen(filepath, **kwargs)
 
 
 # split a list into evenly sized chunks
@@ -639,7 +646,7 @@ def match_hydrogenic_phixs(
 
     photoionization_crosssections = np.zeros((energy_levels.height, args.nphixspoints))
     photoionization_targetfractions: list[list[tuple[int, float]]] = [[] for _ in range(energy_levels.height)]
-    photoionization_thresholds_ev = np.zeros(energy_levels.height)
+    photoionization_thresholds_ev = np.full(energy_levels.height, np.nan)
     phixstables = {}
     for levelindex, level in enumerate(energy_levels.iter_rows(named=True)):
         if levelindex >= 100:
@@ -1281,14 +1288,16 @@ def write_phixs_data(
     numbered from one in the output.
     """
     # a level gets a table only if it has photoionisation targets and a threshold energy. The
-    # threshold arrays start as zeros and are only filled in for levels that got a cross-section
-    # table, so a threshold of exactly zero means "no data for this level". (A negative threshold
-    # is a deliberate sentinel used by readqubdata, so keep those.)
+    # threshold arrays start as NaN and are only filled in for levels that got a cross-section
+    # table, so NaN means "no data for this level". Every number is a real threshold, including
+    # readqubdata's -1.0, which tells ARTIS to take the threshold from the level energies.
     levelids_with_targets = [
         levelid for levelid, targetlist in enumerate(photoionization_targetfractions) if targetlist
     ]
-    levelids_to_write = [levelid for levelid in levelids_with_targets if photoionization_thresholds_ev[levelid] != 0.0]
-    skipped_zero_threshold = len(levelids_with_targets) - len(levelids_to_write)
+    levelids_to_write = [
+        levelid for levelid in levelids_with_targets if not np.isnan(photoionization_thresholds_ev[levelid])
+    ]
+    skipped_no_threshold = len(levelids_with_targets) - len(levelids_to_write)
 
     log_and_print(flog, f"Writing {len(levelids_to_write)} phixs tables to 'phixsdata2.txt'")
     flog.write(
@@ -1329,10 +1338,10 @@ def write_phixs_data(
         for crosssection in photoionization_crosssections[lowerlevelid]:
             fphixs.write(f"{crosssection:16.8E}\n")
 
-    if skipped_zero_threshold > 0:
+    if skipped_no_threshold > 0:
         log_and_print(
             flog,
-            f"Skipped {skipped_zero_threshold} levels with no photoionization threshold energy",
+            f"Skipped {skipped_no_threshold} levels with no photoionization threshold energy",
         )
 
 

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -438,12 +438,7 @@ def read_ion_data(
                     photoionization_targetfractions,
                     photoionization_thresholds_ev,
                 ) = readqubdata.read_qub_photoionizations(
-                    atomic_number,
-                    ion_stage,
-                    energy_levels=energy_levels,
-                    ionization_energy_ev=ionization_energy_ev,
-                    args=args,
-                    flog=flog,
+                    atomic_number, ion_stage, levelcount=len(energy_levels), args=args, flog=flog
                 )
 
         elif handler == "nahar":
@@ -619,19 +614,6 @@ def get_nist_ionization_energies_ev() -> dict[tuple[int, int], float]:
             ion_stage = int(ion_charge) + 1
             dictioniz[int(atomic_number), ion_stage] = ioniz_ev
     return dictioniz
-
-
-def photoionization_thresholds_ev_of_levels(energy_levels, ionization_energy_ev: float) -> npt.NDArray[np.float64]:
-    """Photoionization threshold of every level: the ionization energy less its excitation energy.
-
-    A level at or above the ionization energy has nothing to ionize from, so it gets NaN, which
-    write_phixs_data() skips. Use this wherever the threshold is not read from a data file, so
-    that phixsdata_v2.txt only ever carries positive threshold energies.
-    """
-    dflevels = leveltuples_to_pldataframe(energy_levels)
-    thresholds_ev = ionization_energy_ev - hc_in_ev_cm * dflevels["energyabovegsinpercm"].to_numpy()
-
-    return np.where(thresholds_ev > 0.0, thresholds_ev, np.nan)
 
 
 def match_hydrogenic_phixs(
@@ -1300,6 +1282,8 @@ def write_phixs_data(
     """
     # a level gets a table only if it has targets and a threshold energy. The threshold arrays
     # start as NaN and are filled in only for levels that got a table, so NaN means "no data".
+    # A negative value is written deliberately (readqubdata): ARTIS reads it as "no value given"
+    # and takes the threshold from the difference of the level energies instead.
     levelids_with_targets = [
         levelid for levelid, targetlist in enumerate(photoionization_targetfractions) if targetlist
     ]
@@ -1307,17 +1291,6 @@ def write_phixs_data(
         levelid for levelid in levelids_with_targets if not np.isnan(photoionization_thresholds_ev[levelid])
     ]
     skipped_no_threshold = len(levelids_with_targets) - len(levelids_to_write)
-
-    # ARTIS reads this column as a photoionization edge, so a non-positive value is meaningless.
-    # Not an assert: this guards the output file and must survive python -O.
-    nonpositive = [levelid for levelid in levelids_to_write if photoionization_thresholds_ev[levelid] <= 0.0]
-    if nonpositive:
-        msg = (
-            f"Z={atomic_number} ion_stage={ion_stage}: {len(nonpositive)} levels have a non-positive"
-            f" photoionization threshold energy, e.g. level {nonpositive[0] + 1} with"
-            f" {photoionization_thresholds_ev[nonpositive[0]]:.6e} eV"
-        )
-        raise ValueError(msg)
 
     log_and_print(flog, f"Writing {len(levelids_to_write)} phixs tables to 'phixsdata2.txt'")
     flog.write(

--- a/artisatomic/makerecombratefile.py
+++ b/artisatomic/makerecombratefile.py
@@ -134,9 +134,8 @@ def main():
                     arr_rrc = ion.RrRate["rate"]
                     ion.drRate()
                     arr_drc = ion.DrRate["rate"]
-                    # the third column is the total recombination rate, matching the RRC(total)
-                    # column used for the Nahar files above, so dielectronic recombination must be
-                    # included rather than computed and discarded
+                    # the third column is the total recombination rate, matching RRC(total) used
+                    # for the Nahar files above, so dielectronic recombination must be included
                     frecombrates.writelines(
                         f"{logT_e:.1f} {-1.0} {arr_rrc[i] + arr_drc[i]}\n" for i, logT_e in enumerate(arr_logT_e)
                     )

--- a/artisatomic/readfacdata.py
+++ b/artisatomic/readfacdata.py
@@ -192,9 +192,8 @@ def read_levels_data(dflevels):
     for index, row in dflevels.iterrows():
         ilev_enlevelindex_map[int(row["Ilev"])] = index
 
-        # Config is not unique (levels of the same configuration differ in J), so append the FAC
-        # level index to make the name unique. The configuration stays first so that
-        # get_level_valence_n() and the adata.txt comment column both still start with it.
+        # Config is not unique (levels of one configuration differ in J), so append the FAC level
+        # index. The configuration stays first, for get_level_valence_n() and the adata.txt comment.
         newlevel = FACEnergyLevel(
             levelname=f"{row['Config']} Ilev={int(row['Ilev'])}",
             parity=row["P"],
@@ -205,9 +204,8 @@ def read_levels_data(dflevels):
 
     energy_levels.sort(key=lambda x: x.energyabovegsinpercm)
 
-    # A duplicated Ilev would silently overwrite its map entry and misroute every transition
-    # that references it (and implies duplicate level names, since Ilev is embedded in them).
-    # Not an assert: this validates an input file and must not disappear under python -O.
+    # a duplicated Ilev would overwrite its map entry and misroute every transition referencing
+    # it. Not an assert: input validation must survive python -O.
     if len(ilev_enlevelindex_map) != len(energy_levels):
         msg = f"Duplicate Ilev values in FAC levels file: {len(energy_levels)} rows but only {len(ilev_enlevelindex_map)} unique Ilev"
         raise ValueError(msg)

--- a/artisatomic/readfloers25data.py
+++ b/artisatomic/readfloers25data.py
@@ -91,17 +91,15 @@ def read_levels_and_transitions(atomic_number: int, ion_stage: int, flog, calibr
         .alias("g")
     )
 
-    # The level table is indexed from zero in file order and the transitions refer to those
-    # indices, so a gap would silently attach transitions to the wrong levels. Not an assert:
-    # this validates an input file and must not disappear under python -O.
+    # the levels are indexed from zero in file order and the transitions refer to those indices,
+    # so a gap would misattach them. Not an assert: input validation must survive python -O.
     if dflevels["Index"].to_list() != list(range(dflevels.height)):
         msg = f"Level indices in {levels_file} are not contiguous and zero-based"
         raise ValueError(msg)
 
-    # Configuration is not unique (levels of the same configuration differ by J), so build a
-    # unique level name from it. Index is contiguous, so including it guarantees uniqueness.
-    # The configuration stays first so that get_level_valence_n() and the adata.txt comment
-    # column both still start with it.
+    # Configuration is not unique (levels of one configuration differ by J), so append the
+    # contiguous index. The configuration stays first, for get_level_valence_n() and the
+    # adata.txt comment.
     dflevels = dflevels.with_columns(
         levelname=pl.format("{} J={} index={}", pl.col("Configuration"), pl.col("J"), pl.col("Index"))
     )
@@ -122,9 +120,8 @@ def read_levels_and_transitions(atomic_number: int, ion_stage: int, flog, calibr
 
     artisatomic.log_and_print(flog, f"Read {dftransitions.height} transitions")
 
-    # Transitions reference levels by zero-based index, and an out-of-range reference would be
-    # silently dropped by the level-id joins in add_level_ids_forbidden(), leaving an incomplete
-    # database. Not an assert: this validates an input file and must not disappear under python -O.
+    # an out-of-range level reference would be silently dropped by the joins in
+    # add_level_ids_forbidden(). Not an assert: input validation must survive python -O.
     if dftransitions.height > 0:
         transition_level_indices = pl.concat([dftransitions["Lower"], dftransitions["Upper"]])
         min_index = t.cast("int", transition_level_indices.min())

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -580,7 +580,7 @@ def read_phixs_tables(
 
     # this gets partially overwritten anyway
     photoionization_crosssections = np.zeros((levelcount, args.nphixspoints))
-    photoionization_thresholds_ev = np.zeros(levelcount)
+    photoionization_thresholds_ev = np.full(levelcount, np.nan)
     # None means "no photoionisation data for this level". get_photoiontargetfractions() relies on
     # this to tell those levels apart from levels that do have a cross-section table, so it must
     # not be initialised to empty lists.
@@ -1520,7 +1520,7 @@ def read_hyd_phixsdata():
     max_n = -1
     l_start_u = 0.0
     l_del_u = 0.0
-    with open(hyd_filename, encoding="utf-8") as fhyd:
+    with artisatomic.xopen_check_extension(hyd_filename) as fhyd:
         for line in fhyd:
             row = line.split()
             if " ".join(row[1:]) == "!Maximum principal quantum number":
@@ -1568,7 +1568,7 @@ def read_hyd_phixsdata():
     max_n = -1
     n_start_u = 0.0
     n_del_u = 0.0
-    with open(hyd_filename, encoding="utf-8") as fhyd:
+    with artisatomic.xopen_check_extension(hyd_filename) as fhyd:
         for line in fhyd:
             row = line.split()
             if " ".join(row[1:]) == "!Maximum principal quantum number":

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -993,7 +993,9 @@ def read_phixs_tables(
             photoionization_targetconfig_fractions[levelindex] = phixs_targetconfigfractions_of_levelname.get(
                 lowerlevelname_a
             )
-            photoionization_thresholds_ev[levelindex] = hc_in_ev_angstrom / lambdaangstroms[levelindex]
+            # abs() as at the phixs-fit sites above: CMFGEN writes a negative Lam(A) for some
+            # levels, and the sign must not reach the threshold energy
+            photoionization_thresholds_ev[levelindex] = hc_in_ev_angstrom / abs(lambdaangstroms[levelindex])
 
     return photoionization_crosssections, photoionization_targetconfig_fractions, photoionization_thresholds_ev
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -18,15 +18,13 @@ import artisatomic
 
 # need to also include collision strengths from e.g., o2col.dat
 
-# The level table's columns are read from the header line above it. The oldest oscillator files
-# (those without a "!Format date" line) carry no header, and all of them use the layout below.
-# Its fourth column is the threshold FREQUENCY, not an energy: these files have no eV column.
+# Column layout of the level table in the oldest oscillator files, which carry no header line
+# (no "!Format date"). Its fourth column is a threshold FREQUENCY, not an energy.
 hillier_rowformat_noheader = "levelname g energyabovegsinpercm freqtentothe15hz lambdaangstrom hillierlevelid"
 
 
-# The files disagree on which columns they carry, so only the fields below are kept and every ion
-# read from an oscillator file gets the same frame. parity is not in the file: it is read out of the
-# level name, and decides which transitions are forbidden.
+# The files disagree on which columns they carry, so only these are kept and every ion gets the
+# same frame. parity is not in the file: it is read from the level name and decides forbidden-ness.
 class HillierEnergyLevel(t.NamedTuple):
     """One energy level read from a CMFGEN oscillator file."""
 
@@ -300,15 +298,14 @@ def get_term_as_tuple(config: str) -> tuple[int, int, int]:
         if config[-1] == "o":
             return (-1, -1, 1)
         return (-1, -1, -1)
-    # the whole parse is guarded: a malformed name can fail at the int() or at either index,
-    # and any of those means the term is simply unreadable
+    # a malformed name can fail at the int() or at either index, and any of those just means
+    # the term is unreadable
     try:  # ruff: ignore[too-many-statements-in-try-clause]
         twosplusone = int(config[lposition - 1])  # could this be two digits long?
         if lposition + 1 > len(config) - 1:
-            # No 'e'/'o' suffix to read the parity from. CMFGEN writes its merged high-l levels
-            # this way, with the orbital letter repeated as the term symbol (2s2_13w_2W,
-            # 2s2_2p3(4So)5z_5Z), so the term letter is a merge marker rather than a real L.
-            # Sum l over the occupied orbitals instead of assuming the term is even.
+            # No 'e'/'o' suffix to give the parity. CMFGEN writes its merged high-l levels this
+            # way, repeating the orbital letter as the term symbol (2s2_13w_2W, 2s2_2p3(4So)5z_5Z),
+            # so sum l over the occupied orbitals instead of assuming an even term.
             parity = artisatomic.get_parity_from_config(config)
         elif config[lposition + 1] == "o":
             parity = 1
@@ -570,8 +567,8 @@ def read_phixs_tables(
     levelnames: list[str] = dfenergy_levels["levelname"].to_list()
     lambdaangstroms: list[float] = dfenergy_levels["lambdaangstrom"].to_list()
 
-    # first level index of each name, with and without the [J] suffix: the cross-section tables are
-    # matched to levels by name, and a scan of the level list per table would be O(levels x tables)
+    # first level index of each name, with and without the [J] suffix: tables are matched to levels
+    # by name, and rescanning the level list per table would be O(levels x tables)
     firstlevelindex_of_levelname: dict[str, int] = {}
     firstlevelindex_of_levelnamenoJ: dict[str, int] = {}
     for levelindex, levelname in enumerate(levelnames):
@@ -581,13 +578,12 @@ def read_phixs_tables(
     # this gets partially overwritten anyway
     photoionization_crosssections = np.zeros((levelcount, args.nphixspoints))
     photoionization_thresholds_ev = np.full(levelcount, np.nan)
-    # None means "no photoionisation data for this level". get_photoiontargetfractions() relies on
-    # this to tell those levels apart from levels that do have a cross-section table, so it must
-    # not be initialised to empty lists.
+    # None means "no photoionisation data for this level", which get_photoiontargetfractions()
+    # relies on, so this must not be initialised to empty lists
     photoionization_targetconfig_fractions: list[list[tuple[str, float]] | None] = [None] * levelcount
 
-    # charge of the ion left behind by the photoionisation, i.e. CMFGEN's ZION (= ZXzV, which it
-    # reads from the oscillator file, where it equals the ionisation stage for every ion here)
+    # charge of the ion left behind, i.e. CMFGEN's ZION (= ZXzV from the oscillator file, which
+    # equals the ionisation stage for every ion here)
     zion = ion_stage
     photfilenames = ions_data[atomic_number, ion_stage].photfilenames
     phixstables = [{} for _ in photfilenames]
@@ -650,15 +646,14 @@ def read_phixs_tables(
                     row[-3:]
                 ) == "!Configuration name [*]":
                     lowerlevelname = row[0]
-                    # with J splitting, the name (including any [J] suffix) maps to exactly one
-                    # level, so it must be kept intact. Without J splitting, strip the [J] suffix
-                    # so the table applies to all levels sharing the configuration
+                    # with J splitting the name (including any [J] suffix) maps to exactly one
+                    # level; without it, strip the suffix so the table covers the configuration
                     if not j_splitting_on and "[" in lowerlevelname:
                         lowerlevelname = lowerlevelname.split("[")[0]
                     fitcoefficients = []
                     numpointsexpected = 0
-                    # the zero-based index of the first matching level (without J splitting,
-                    # several matches may differ by J values); no match keeps the old default of 0
+                    # first matching level (without J splitting, several may differ by J);
+                    # no match keeps the old default of 0
                     lowerlevelindex = (
                         firstlevelindex_of_levelname if j_splitting_on else firstlevelindex_of_levelnamenoJ
                     ).get(lowerlevelname, 0)
@@ -668,10 +663,9 @@ def read_phixs_tables(
                     # print(f"Reading level {lowerlevelindex} '{lowerlevelname}'")
 
                 if len(row) >= 2 and " ".join(row[-3:]) == "!Screened nuclear charge":
-                    # CMFGEN's ZION comes from the oscillator file, not from here: RDPHOT_GEN_V2
-                    # never reads this field. The two disagree for 29 files in the shipped
-                    # database, so keep using ion_stage (which matches the oscillator value for
-                    # every ion in ions_data) and only report the discrepancy.
+                    # CMFGEN's ZION comes from the oscillator file: RDPHOT_GEN_V2 never reads
+                    # this field, and the two disagree for 29 shipped files. Keep ion_stage (which
+                    # matches the oscillator value for every ion in ions_data) and just report it.
                     zion_from_photfile = int(float(row[0]))
                     if zion_from_photfile != ion_stage:
                         artisatomic.log_and_print(
@@ -872,10 +866,8 @@ def read_phixs_tables(
                         phixs_type_levels[crosssectiontype].append(lowerlevelname)
 
                 if len(row) == 0:
-                    # For the tabulated types the array is preallocated to the declared row count,
-                    # so a short table leaves trailing zeros behind. Compare the number of points
-                    # actually read instead. (The previous check tested `targetlevelname in
-                    # <2-D float ndarray>`, which is always False, so it never ran.)
+                    # for the tabulated types the array is preallocated to the declared row
+                    # count, so a short table leaves trailing zeros: compare the points read
                     if (
                         crosssectiontype in {20, 21, 22}
                         and lowerlevelname
@@ -921,10 +913,9 @@ def read_phixs_tables(
             try:
                 phixs_at_threshold = reduced_phixstable[np.nonzero(reduced_phixstable)][0]
             except IndexError:
-                # The cross section is zero everywhere on the output grid, so the level is dropped
-                # and gets no photoionization at all. For a type-8 (offset) cross section this
-                # happens whenever the offset edge nu_edge + nu_o lies beyond the end of the
-                # nu/nu_edge grid that reduce_phixs_tables() samples.
+                # The cross section is zero everywhere on the output grid, so the level gets no
+                # photoionization. For type 8 (offset) this happens when the offset edge
+                # nu_edge + nu_o lies beyond the grid that reduce_phixs_tables() samples.
                 num_levelnames_with_zero_crosssection += 1
                 artisatomic.log_and_print(
                     flog, f"WARNING: No non-zero cross section points for {lowerlevelname}, so it will have no phixs"
@@ -987,9 +978,8 @@ def read_phixs_tables(
             # reduced_phixs_dict[lowerlevelname] = reduced_phixstable / (max_factor / factor_sum)
             reduced_phixs_dict[lowerlevelname] = reduced_phixstable  # / (max_factor / factor_sum)
 
-    # now the non-J-split cross sections are mapped onto J-split levels. Without J splitting a
-    # cross-section table matches every level sharing the configuration, so index the level list by
-    # match name once rather than rescanning it for each table.
+    # map the non-J-split cross sections onto J-split levels. A table matches every level sharing
+    # the configuration, so index the level list by match name once rather than rescanning it.
     levelindices_of_matchname: defaultdict[str, list[int]] = defaultdict(list)
     for levelindex, levelname in enumerate(levelnames):
         levelindices_of_matchname[levelname if j_splitting_on else levelname.split("[")[0]].append(levelindex)
@@ -997,9 +987,9 @@ def read_phixs_tables(
     for lowerlevelname_a, phixstable in reduced_phixs_dict.items():
         for levelindex in levelindices_of_matchname[lowerlevelname_a]:
             photoionization_crosssections[levelindex] = phixstable
-            # .get() rather than the defaultdict's __getitem__: a level whose target factors
-            # all came out zero is absent here, and inserting an empty list for it would look
-            # like "has data, no targets" instead of "no data" to get_photoiontargetfractions()
+            # .get() rather than __getitem__: a level whose target factors all came out zero is
+            # absent, and an empty list would look like "has data, no targets" to
+            # get_photoiontargetfractions()
             photoionization_targetconfig_fractions[levelindex] = phixs_targetconfigfractions_of_levelname.get(
                 lowerlevelname_a
             )
@@ -1104,9 +1094,9 @@ def get_hydrogenic_nl_phixstable(lambda_angstrom, n, l_start, l_end, nu_o=None, 
         # energy / (E_o + E_threshold), i.e. U measured from the offset edge rather than the true edge
         u_offset = thresholdenergyev * u_grid / (e_o_ev + thresholdenergyev)
 
-        # CMFGEN interpolates log10(cross section) linearly in log10(U), and the tabulated U grid is
-        # geometric, so this reproduces its RJ = LOG10(U) / L_DEL_U indexing.
-        # u_offset <= u_grid for e_o_ev >= 0, so we never need to extrapolate past the table end.
+        # CMFGEN interpolates log10(cross section) linearly in log10(U) on a geometric U grid,
+        # reproducing its RJ = LOG10(U) / L_DEL_U indexing. u_offset <= u_grid for e_o_ev >= 0,
+        # so the table end is never extrapolated past.
         with np.errstate(divide="ignore"):
             log_sigma = np.log10(arr_sigma_summed_over_l)
         arr_sigma = 10 ** np.interp(np.log10(u_offset), np.log10(u_grid), log_sigma) * scale_factor
@@ -1271,8 +1261,8 @@ def read_coldata(atomic_number, ion_stage, dfenergy_levels: pl.DataFrame, flog, 
         except KeyError:
             level_ids_of_level_name[levelnamenoJ] = [levelid]
 
-    # total statistical weight of each term, used to share a term-resolved collision strength over
-    # its J levels. Depends only on the level list, so build it once rather than per input row.
+    # total statistical weight per term, for sharing a term-resolved collision strength over its
+    # J levels. Depends only on the level list, so build it once.
     g_sum_of_level_name = {
         levelname: sum(gvalues[levelid] for levelid in levelids)
         for levelname, levelids in level_ids_of_level_name.items()
@@ -1346,8 +1336,8 @@ def read_coldata(atomic_number, ion_stage, dfenergy_levels: pl.DataFrame, flog, 
                 upsilon = float(upsilonvalues[temperature_index].replace("D", "E"))
                 coll_lines_in += 1
 
-                # every level lookup below can raise KeyError for a name that is not in the
-                # level list, so the whole block is guarded rather than each lookup
+                # any level lookup below can raise KeyError for a name not in the level list,
+                # so guard the whole block rather than each lookup
                 try:  # ruff: ignore[too-many-statements-in-try-clause]
                     if level_ids_of_level_name[namefrom][0] > level_ids_of_level_name[nameto][0]:
                         artisatomic.log_and_print(
@@ -1369,15 +1359,11 @@ def read_coldata(atomic_number, ion_stage, dfenergy_levels: pl.DataFrame, flog, 
                             if id_upper < id_upper2 and (id_upper, id_upper2) not in upsilondict:
                                 upsilondict[id_upper, id_upper2] = -2.0
 
-                    # When the collision data is given between LS terms but the level list is
-                    # J-split, the term effective collision strength is shared over the J levels
-                    # of both terms in proportion to their statistical weights:
+                    # A term-resolved collision strength is shared over the J levels of both
+                    # terms in proportion to their statistical weights:
                     #     upsilon_ij = upsilon_term * (g_i / g_lower_term) * (g_j / g_upper_term)
-                    # so that sum_ij upsilon_ij = upsilon_term. That invariant is what makes the
-                    # total term-to-term rate come out right, because ARTIS forms the collisional
-                    # excitation rate coefficient as proportional to upsilon_ij / g_i.
-                    # Both sums are over the complete term, so each pair keeps its correct value
-                    # regardless of which pairs happen to be representable as lower id < upper id.
+                    # so that sum_ij upsilon_ij = upsilon_term, which is what makes the total
+                    # term-to-term rate right (ARTIS builds the rate from upsilon_ij / g_i).
                     lower_g_sum = g_sum_of_level_name[namefrom]
                     upper_g_sum = g_sum_of_level_name[nameto]
 
@@ -1389,9 +1375,9 @@ def read_coldata(atomic_number, ion_stage, dfenergy_levels: pl.DataFrame, flog, 
                             upsilonscaled = (
                                 upsilon * (gvalues[id_lower] / lower_g_sum) * (gvalues[id_upper] / upper_g_sum)
                             )
-                            # upsilon is symmetric, and the output wants lower id < upper id. The
-                            # two terms' J levels can interleave in energy, so order the key here
-                            # rather than dropping the pairs that come out the wrong way round.
+                            # upsilon is symmetric and the output wants lower id < upper id; the
+                            # terms' J levels can interleave, so order the key rather than
+                            # dropping the pairs that come out reversed
                             key = (min(id_lower, id_upper), max(id_lower, id_upper))
                             if key in upsilondict and upsilondict[key] >= 0.0:
                                 artisatomic.log_and_print(
@@ -1493,8 +1479,8 @@ def read_hyd_phixsdata():
     get_hydrogenic_*_phixstable(). Thresholds are taken from the H I level list, which is
     therefore required to be indexed by principal quantum number.
     """
-    # the cached (2l+1)-weighted sums are built from the tables filled in below, so a reload
-    # (repeated calls happen in the tests) must not leave sums computed from the previous tables
+    # the cached (2l+1)-weighted sums come from the tables filled in below, so a reload (the
+    # tests call this repeatedly) must not leave sums from the previous tables
     get_hydrogenic_sigma_summed_over_l.cache_clear()
 
     with open(os.devnull, "w", encoding="utf-8") as devnull:

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -994,7 +994,7 @@ def read_phixs_tables(
                 lowerlevelname_a
             )
             # abs() as at the phixs-fit sites above: CMFGEN writes a negative Lam(A) for some
-            # levels, and the sign must not reach the threshold energy
+            # levels, and that sign would read as readqubdata's "no threshold value" sentinel
             photoionization_thresholds_ev[levelindex] = hc_in_ev_angstrom / abs(lambdaangstroms[levelindex])
 
     return photoionization_crosssections, photoionization_targetconfig_fractions, photoionization_thresholds_ev

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -994,8 +994,11 @@ def read_phixs_tables(
                 lowerlevelname_a
             )
             # abs() as at the phixs-fit sites above: CMFGEN writes a negative Lam(A) for some
-            # levels, and that sign would read as readqubdata's "no threshold value" sentinel
-            photoionization_thresholds_ev[levelindex] = hc_in_ev_angstrom / abs(lambdaangstroms[levelindex])
+            # levels, and that sign would read as readqubdata's "no threshold value" sentinel.
+            # A zero Lam(A) gives no threshold at all rather than dividing by zero; the level
+            # keeps its NaN and write_phixs_data() skips it.
+            if lambdaangstroms[levelindex] != 0.0:
+                photoionization_thresholds_ev[levelindex] = hc_in_ev_angstrom / abs(lambdaangstroms[levelindex])
 
     return photoionization_crosssections, photoionization_targetconfig_fractions, photoionization_thresholds_ev
 

--- a/artisatomic/readnahardata.py
+++ b/artisatomic/readnahardata.py
@@ -1,6 +1,5 @@
 """Read levels, configurations and photoionization cross sections from Nahar's NORAD data."""
 
-import os
 import sys
 import typing as t
 from collections import defaultdict
@@ -91,7 +90,7 @@ def build_nahar_levels_and_phixs(
 
     if nahar_phixs_tables:
         photoionization_crosssections = np.zeros((dfenergy_levels.height, args.nphixspoints))
-        photoionization_thresholds_ev = np.zeros(dfenergy_levels.height)
+        photoionization_thresholds_ev = np.full(dfenergy_levels.height, np.nan)
 
         if not args.nophixs:
             reduced_phixs_dict = artisatomic.reduce_phixs_tables(
@@ -109,7 +108,10 @@ def build_nahar_levels_and_phixs(
                 matching_levelindices = levelindices_of_state.get(state_tuple, [])
                 for levelindex in matching_levelindices:
                     photoionization_crosssections[levelindex] = phixstable
-                    photoionization_thresholds_ev[levelindex] = thresholds_ev_dict[state_tuple]
+                    # a state right at the ionization threshold has nothing to ionize from, so
+                    # leave it with no threshold energy and let write_phixs_data() skip it
+                    if thresholds_ev_dict[state_tuple] > 0.0:
+                        photoionization_thresholds_ev[levelindex] = thresholds_ev_dict[state_tuple]
 
                 if not matching_levelindices:
                     twosplusone, l, parity, indexinsymmetry = state_tuple
@@ -142,11 +144,13 @@ def read_nahar_energy_level_file(
     nahar_core_states: list[NaharCoreState] = []
     nahar_ionization_potential_rydberg = -1.0
 
-    if not os.path.isfile(path_nahar_energy_file):
+    # the plain name may not be on disk when the compressed form is, so ask the same resolver that
+    # xopen_check_extension() uses rather than testing the plain name with os.path.isfile()
+    if artisatomic.find_file_check_extension(path_nahar_energy_file) is None:
         artisatomic.log_and_print(flog, f"{artisatomic.path_for_log(path_nahar_energy_file)} does not exist")
     else:
         artisatomic.log_and_print(flog, f"Reading {artisatomic.path_for_log(path_nahar_energy_file)}")
-        with open(path_nahar_energy_file, encoding="utf-8") as fenlist:
+        with artisatomic.xopen_check_extension(path_nahar_energy_file) as fenlist:
             nahar_core_states = read_nahar_core_states(fenlist)
 
             nahar_configurations, nahar_ionization_potential_rydberg = read_nahar_configurations(fenlist, flog)
@@ -319,7 +323,7 @@ def read_nahar_phixs_tables(path_nahar_px_file, atomic_number, ion_stage, args):
     """
     nahar_phixs_tables = {}
     thresholds_ev_dict = {}
-    with open(path_nahar_px_file, encoding="utf-8") as fenlist:
+    with artisatomic.xopen_check_extension(path_nahar_px_file) as fenlist:
         while True:
             line = fenlist.readline()
             if not line:

--- a/artisatomic/readnahardata.py
+++ b/artisatomic/readnahardata.py
@@ -106,12 +106,13 @@ def build_nahar_levels_and_phixs(
 
             for state_tuple, phixstable in reduced_phixs_dict.items():
                 matching_levelindices = levelindices_of_state.get(state_tuple, [])
+                # a state right at the ionization threshold has nothing to ionize from, so leave
+                # it with no threshold energy and let write_phixs_data() skip it
+                threshold_ev = thresholds_ev_dict[state_tuple]
                 for levelindex in matching_levelindices:
                     photoionization_crosssections[levelindex] = phixstable
-                    # a state right at the ionization threshold has nothing to ionize from, so
-                    # leave it with no threshold energy and let write_phixs_data() skip it
-                    if thresholds_ev_dict[state_tuple] > 0.0:
-                        photoionization_thresholds_ev[levelindex] = thresholds_ev_dict[state_tuple]
+                    if threshold_ev > 0.0:
+                        photoionization_thresholds_ev[levelindex] = threshold_ev
 
                 if not matching_levelindices:
                     twosplusone, l, parity, indexinsymmetry = state_tuple

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -398,7 +398,7 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
 
 
 def read_qub_photoionizations(
-    atomic_number, ion_stage, energy_levels, ionization_energy_ev: float, args, flog
+    atomic_number, ion_stage, levelcount: int, args, flog
 ) -> tuple[npt.NDArray[np.float64], list[list[tuple[int, float]]], npt.NDArray[np.float64]]:
     """Read QUB photoionization cross sections for one ion, downsampled onto the output grid.
 
@@ -406,13 +406,10 @@ def read_qub_photoionizations(
     energies, all indexed by zero-based level id. Levels with no data keep an empty target list,
     which is how write_phixs_data() knows to skip them.
     """
-    levelcount = len(energy_levels)
     photoionization_crosssections = np.zeros((levelcount, args.nphixspoints))
     # levels stay empty (write_phixs_data() skips them) unless real data is assigned below
     photoionization_targetfractions: list[list[tuple[int, float]]] = [[] for _ in range(levelcount)]
     photoionization_thresholds_ev = np.full(levelcount, np.nan)
-    # these files give no threshold energy of their own, so it comes from the level energies
-    level_thresholds_ev = artisatomic.photoionization_thresholds_ev_of_levels(energy_levels, ionization_energy_ev)
 
     if atomic_number == 27 and ion_stage == 2:
         for lowerlevelid in range(8):
@@ -452,7 +449,9 @@ def read_qub_photoionizations(
             target_scalefactors = [x if (x / scalefactorsum > 0.02) else 0.0 for x in target_scalefactors]
             scalefactorsum = sum(target_scalefactors)
 
-            photoionization_thresholds_ev[lowerlevelid] = level_thresholds_ev[lowerlevelid]
+            # -1.0 sentinel: the threshold energy comes from the level energies, not from the
+            # first energy point of the cross-section table
+            photoionization_thresholds_ev[lowerlevelid] = -1.0
             for upperlevelid, target_scalefactor in enumerate(target_scalefactors):
                 target_fraction = target_scalefactor / scalefactorsum
                 if target_fraction > 0.001:
@@ -580,7 +579,7 @@ def read_qub_photoionizations(
         # unlike the Co II branch above, every level deliberately gets a phixs entry: the ground
         # quartet gets the tabulated cross section and higher levels an explicit all-zero table
         for levelid in range(levelcount):
-            photoionization_thresholds_ev[levelid] = level_thresholds_ev[levelid]
+            photoionization_thresholds_ev[levelid] = -1.0
             photoionization_targetfractions[levelid] = [(0, 1.0)]  # the upper ion's ground state
             if levelid < 4:
                 photoionization_crosssections[levelid] = phixsvalues

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -398,7 +398,7 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
 
 
 def read_qub_photoionizations(
-    atomic_number, ion_stage, levelcount: int, args, flog
+    atomic_number, ion_stage, energy_levels, ionization_energy_ev: float, args, flog
 ) -> tuple[npt.NDArray[np.float64], list[list[tuple[int, float]]], npt.NDArray[np.float64]]:
     """Read QUB photoionization cross sections for one ion, downsampled onto the output grid.
 
@@ -406,10 +406,13 @@ def read_qub_photoionizations(
     energies, all indexed by zero-based level id. Levels with no data keep an empty target list,
     which is how write_phixs_data() knows to skip them.
     """
+    levelcount = len(energy_levels)
     photoionization_crosssections = np.zeros((levelcount, args.nphixspoints))
     # levels stay empty (write_phixs_data() skips them) unless real data is assigned below
     photoionization_targetfractions: list[list[tuple[int, float]]] = [[] for _ in range(levelcount)]
     photoionization_thresholds_ev = np.full(levelcount, np.nan)
+    # these files give no threshold energy of their own, so it comes from the level energies
+    level_thresholds_ev = artisatomic.photoionization_thresholds_ev_of_levels(energy_levels, ionization_energy_ev)
 
     if atomic_number == 27 and ion_stage == 2:
         for lowerlevelid in range(8):
@@ -449,9 +452,7 @@ def read_qub_photoionizations(
             target_scalefactors = [x if (x / scalefactorsum > 0.02) else 0.0 for x in target_scalefactors]
             scalefactorsum = sum(target_scalefactors)
 
-            # -1.0 sentinel: the threshold energy comes from the level energies, not from the
-            # first energy point of the cross-section table
-            photoionization_thresholds_ev[lowerlevelid] = -1.0
+            photoionization_thresholds_ev[lowerlevelid] = level_thresholds_ev[lowerlevelid]
             for upperlevelid, target_scalefactor in enumerate(target_scalefactors):
                 target_fraction = target_scalefactor / scalefactorsum
                 if target_fraction > 0.001:
@@ -579,7 +580,7 @@ def read_qub_photoionizations(
         # unlike the Co II branch above, every level deliberately gets a phixs entry: the ground
         # quartet gets the tabulated cross section and higher levels an explicit all-zero table
         for levelid in range(levelcount):
-            photoionization_thresholds_ev[levelid] = -1.0
+            photoionization_thresholds_ev[levelid] = level_thresholds_ev[levelid]
             photoionization_targetfractions[levelid] = [(0, 1.0)]  # the upper ion's ground state
             if levelid < 4:
                 photoionization_crosssections[levelid] = phixsvalues

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -322,74 +322,74 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
         ionization_energy_ev = 54.9000015
 
     elif (atomic_number, ion_stage) in new_qub_calculations:
-        atom_file = f"{atomic_number}_{ion_stage}.adf04"
-        ionization_energy_ev, qub_energylevels, upsilondict = read_adf04(
-            Path("atomic-data-qub", atom_file), atomic_number, ion_stage, flog
-        )
+        atom_filepath = Path("atomic-data-qub", f"{atomic_number}_{ion_stage}.adf04")
+        ionization_energy_ev, qub_energylevels, upsilondict = read_adf04(atom_filepath, atomic_number, ion_stage, flog)
 
         qub_transitions = []
         transition_count_of_level_name = defaultdict(int)
-        with open(Path("atomic-data-qub", atom_file), encoding="utf-8") as ftrans:
-            ftrans.seek(0)
-            atom_group_note = False
-            longest_line_length = 0
-            # Use the length of lines to locate collision strengths
-            # Ignoring notes section between C- markers
-            for line in ftrans:
-                if line.startswith("C-"):
-                    atom_group_note = not atom_group_note
-                    continue
-                if atom_group_note:
-                    continue
-                longest_line_length = max(longest_line_length, len(line))
-            ftrans.seek(0)
-            for line in ftrans:
-                if line.startswith("C-"):
-                    atom_group_note = not atom_group_note
-                    continue
-                if atom_group_note:
-                    continue
+        # two passes are needed (the collision strengths are found by line length, which is only
+        # known after seeing every line), so read the lines once rather than rewinding the file:
+        # xopen_check_extension() may hand back a decompressing stream that cannot seek backwards
+        with artisatomic.xopen_check_extension(atom_filepath) as ftrans:
+            translines = ftrans.readlines()
 
-                rowlen = line
-                row = line.split()
+        atom_group_note = False
+        longest_line_length = 0
+        # Use the length of lines to locate collision strengths
+        # Ignoring notes section between C- markers
+        for line in translines:
+            if line.startswith("C-"):
+                atom_group_note = not atom_group_note
+                continue
+            if atom_group_note:
+                continue
+            longest_line_length = max(longest_line_length, len(line))
 
-                if len(rowlen) == longest_line_length:
-                    # W II file has the first two columns swapped around from the standard order
-                    if atomic_number == 74 and ion_stage == 2:
-                        id_upper = int(row[1])
-                        id_lower = int(row[0])
+        for line in translines:
+            if line.startswith("C-"):
+                atom_group_note = not atom_group_note
+                continue
+            if atom_group_note:
+                continue
+
+            rowlen = line
+            row = line.split()
+
+            if len(rowlen) == longest_line_length:
+                # W II file has the first two columns swapped around from the standard order
+                if atomic_number == 74 and ion_stage == 2:
+                    id_upper = int(row[1])
+                    id_lower = int(row[0])
+                else:
+                    id_upper = int(row[0])
+                    id_lower = int(row[1])
+                A = float(row[2].replace("-", "E-").replace("+", "E+"))
+                if A > 2e-30:
+                    # a raise rather than an assert: this validates an input file, and a
+                    # non-positive id would otherwise wrap to the wrong level via negative indexing
+                    if id_lower < 1 or id_upper < 1:
+                        msg = f"non-positive transition level ids {id_lower}, {id_upper} in {atom_filepath}"
+                        raise ValueError(msg)
+                    # the file numbers levels from one; level ids are zero-based in memory
+                    id_lower -= 1
+                    id_upper -= 1
+                    level_upper = qub_energylevels[id_upper]
+                    level_lower = qub_energylevels[id_lower]
+                    namefrom = level_upper.levelname
+                    nameto = level_lower.levelname
+                    forbidden = check_forbidden(level_upper, level_lower)
+                    transition_count_of_level_name[namefrom] += 1
+                    transition_count_of_level_name[nameto] += 1
+                    delta_percm = level_upper.energyabovegsinpercm - level_lower.energyabovegsinpercm
+                    lamdaangstrom = 1.0e8 / delta_percm if delta_percm != 0.0 else -1.0
+                    if (id_lower, id_upper) in upsilondict:
+                        coll_str = upsilondict[id_lower, id_upper]
+                    elif forbidden:
+                        coll_str = -2.0
                     else:
-                        id_upper = int(row[0])
-                        id_lower = int(row[1])
-                    A = float(row[2].replace("-", "E-").replace("+", "E+"))
-                    if A > 2e-30:
-                        # a raise rather than an assert: this validates an input file, and a
-                        # non-positive id would otherwise wrap to the wrong level via negative indexing
-                        if id_lower < 1 or id_upper < 1:
-                            msg = f"non-positive transition level ids {id_lower}, {id_upper} in {atom_file}"
-                            raise ValueError(msg)
-                        # the file numbers levels from one; level ids are zero-based in memory
-                        id_lower -= 1
-                        id_upper -= 1
-                        level_upper = qub_energylevels[id_upper]
-                        level_lower = qub_energylevels[id_lower]
-                        namefrom = level_upper.levelname
-                        nameto = level_lower.levelname
-                        forbidden = check_forbidden(level_upper, level_lower)
-                        transition_count_of_level_name[namefrom] += 1
-                        transition_count_of_level_name[nameto] += 1
-                        delta_percm = level_upper.energyabovegsinpercm - level_lower.energyabovegsinpercm
-                        lamdaangstrom = 1.0e8 / delta_percm if delta_percm != 0.0 else -1.0
-                        if (id_lower, id_upper) in upsilondict:
-                            coll_str = upsilondict[id_lower, id_upper]
-                        elif forbidden:
-                            coll_str = -2.0
-                        else:
-                            coll_str = -1.0
-                        transition = qub_transition_row(
-                            id_lower, id_upper, A, namefrom, nameto, lamdaangstrom, coll_str
-                        )
-                        qub_transitions.append(transition)
+                        coll_str = -1.0
+                    transition = qub_transition_row(id_lower, id_upper, A, namefrom, nameto, lamdaangstrom, coll_str)
+                    qub_transitions.append(transition)
 
     else:
         msg = f"No QUB data available for Z={atomic_number} ion_stage {ion_stage}"
@@ -412,7 +412,7 @@ def read_qub_photoionizations(
     photoionization_crosssections = np.zeros((levelcount, args.nphixspoints))
     # levels stay empty (write_phixs_data() skips them) unless real data is assigned below
     photoionization_targetfractions: list[list[tuple[int, float]]] = [[] for _ in range(levelcount)]
-    photoionization_thresholds_ev = np.zeros(levelcount)
+    photoionization_thresholds_ev = np.full(levelcount, np.nan)
 
     if atomic_number == 27 and ion_stage == 2:
         for lowerlevelid in range(8):

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -45,8 +45,8 @@ class QUBEnergyLevel(t.NamedTuple):
 
 qubpath = (Path(__file__).parent.resolve() / ".." / "atomic-data-qub").resolve()
 
-# the ions that get_default_handler() picks "qub_data" for. Nd II (60, 2) has an adf04 file and is
-# read if the handler is set explicitly, but is deliberately not the default for that ion.
+# the ions get_default_handler() picks "qub_data" for. Nd II (60, 2) has an adf04 file and is read
+# when the handler is set explicitly, but is deliberately not the default.
 default_handler_ions = frozenset(
     {
         (38, 1),
@@ -167,10 +167,9 @@ def read_adf04(
             energylevel = energylevel._replace(g=g, parity=parity, levelname=levelname)
             energylevels.append(energylevel)
 
-            # the transition and upsilon tables index levels by this 1-based id, and the rest of
-            # the code looks up id n at list index n - 1, so a non-contiguous or non-1-based file
-            # would silently attach every transition to the wrong level. Not an assert: this
-            # validates an input file and must not disappear under python -O.
+            # the transition and upsilon tables use these 1-based ids and the rest of the code
+            # looks up id n at index n - 1, so a non-contiguous file would misattach every
+            # transition. Not an assert: input validation must survive python -O.
             if energylevel.qub_id != len(energylevels):
                 msg = (
                     f"adf04 level id {energylevel.qub_id} found at position {len(energylevels)} in {filepath}."
@@ -180,9 +179,8 @@ def read_adf04(
 
         upsilonheader = fleveltrans.readline().split()
         list_tempheaders = [f"upsT={x:}" for x in upsilonheader[2:]]
-        # each collision row is: upper, lower, A-value, one upsilon per temperature, and finally
-        # the infinite-energy (Born) limit. Name that last column so the row width matches and
-        # pandas does not silently drop a column to make the data fit the header.
+        # each collision row is upper, lower, A-value, one upsilon per temperature, then the
+        # infinite-energy (Born) limit. Name that last column so pandas does not drop one to fit.
         list_headers = ["upper", "lower", "avalue", *list_tempheaders, "born_limit"]
         qubupsilondf_alltemps = pd.read_csv(
             fleveltrans,
@@ -327,9 +325,8 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
 
         qub_transitions = []
         transition_count_of_level_name = defaultdict(int)
-        # two passes are needed (the collision strengths are found by line length, which is only
-        # known after seeing every line), so read the lines once rather than rewinding the file:
-        # xopen_check_extension() may hand back a decompressing stream that cannot seek backwards
+        # two passes are needed (collision strengths are found by line length, known only after
+        # seeing every line), so read the lines once: a decompressing stream may not seek back
         with artisatomic.xopen_check_extension(atom_filepath) as ftrans:
             translines = ftrans.readlines()
 
@@ -579,9 +576,8 @@ def read_qub_photoionizations(
                 dict_phixstable, args.optimaltemperature, args.nphixspoints, args.phixsnuincrement
             )["gs"]
 
-        # Unlike the Co II branch above, every level is deliberately given a phixs entry: levels
-        # of the ground quartet get the tabulated cross section, and all higher levels get an
-        # explicit all-zero table (no photoionization) rather than being omitted from the output.
+        # unlike the Co II branch above, every level deliberately gets a phixs entry: the ground
+        # quartet gets the tabulated cross section and higher levels an explicit all-zero table
         for levelid in range(levelcount):
             photoionization_thresholds_ev[levelid] = -1.0
             photoionization_targetfractions[levelid] = [(0, 1.0)]  # the upper ion's ground state

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -362,10 +362,14 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
                     id_lower = int(row[1])
                 A = float(row[2].replace("-", "E-").replace("+", "E+"))
                 if A > 2e-30:
-                    # a raise rather than an assert: this validates an input file, and a
-                    # non-positive id would otherwise wrap to the wrong level via negative indexing
-                    if id_lower < 1 or id_upper < 1:
-                        msg = f"non-positive transition level ids {id_lower}, {id_upper} in {atom_filepath}"
+                    # a raise rather than an assert: this validates an input file. A non-positive
+                    # id would wrap to the wrong level via negative indexing, and one past the end
+                    # would raise a bare IndexError naming neither the file nor the transition.
+                    if not 1 <= id_lower <= len(qub_energylevels) or not 1 <= id_upper <= len(qub_energylevels):
+                        msg = (
+                            f"transition level ids {id_lower}, {id_upper} in {atom_filepath} are outside"
+                            f" the file's {len(qub_energylevels)} levels"
+                        )
                         raise ValueError(msg)
                     # the file numbers levels from one; level ids are zero-based in memory
                     id_lower -= 1

--- a/artisatomic/readstoreydata.py
+++ b/artisatomic/readstoreydata.py
@@ -14,7 +14,7 @@ def read_storey_2016_upsilondata(flog) -> dict[tuple[int, int], float]:
     filename = "atomic-data-storey/storetetal2016-co-ii.txt"
     artisatomic.log_and_print(flog, f"Reading effective collision strengths from {artisatomic.path_for_log(filename)}")
 
-    with open(filename, encoding="utf-8") as fstoreydata:
+    with artisatomic.xopen_check_extension(filename) as fstoreydata:
         found_tablestart = False
         while True:
             line = fstoreydata.readline()

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -58,9 +58,9 @@ def test_get_parity_from_config():
     # wrong (odd) parity here, since 3*14 is even but 3*1 is odd
     assert get_parity_from_config("4f145d96s2") == 0  # 3*14 + 2*9 + 0 = 60
 
-    # CMFGEN packs the high-l levels of a shell into one level whose orbital letter is a merge
-    # marker, not a real l: '5z' would be l=22 and '13w' l=19, both impossible for their n. Such a
-    # level spans several l of both parities, so only the real orbitals decide the parity.
+    # CMFGEN packs a shell's high-l levels into one level whose orbital letter is a merge marker,
+    # not a real l ('5z' would be l=22, '13w' l=19). It spans several l of both parities, so only
+    # the real orbitals decide the parity.
     assert get_parity_from_config("2s2_2p3(4So)5z_5Z") == 1  # 2s2 + 2p3 = 3, the 5z contributes none
     assert get_parity_from_config("2s2_13w_2W") == 0  # 2s2 = 0, the 13w contributes none
 
@@ -224,9 +224,8 @@ def test_hydrogenic_phixs_effective_charge_scaling():
             threshold_ev = atomic_number**2 * ryd_to_ev / n**2
             phixstable = rhd.get_hydrogenic_n_phixstable(rhd.hc_in_ev_angstrom / threshold_ev, n)
 
-            # Kramers: sigma_threshold = 7.91 Mb * n / Z**2 * g_bf, and the gaunt factor at
-            # threshold depends only on n, so the ratio to the n=1 value is exactly n / Z**2
-            # once the n-dependence of g_bf is divided out by comparing at the same n.
+            # Kramers: sigma_threshold = 7.91 Mb * n / Z**2 * g_bf, and g_bf at threshold
+            # depends only on n, so comparing at the same n leaves a ratio of exactly n / Z**2
             same_n_hydrogen = rhd.get_hydrogenic_n_phixstable(rhd.hc_in_ev_angstrom / (ryd_to_ev / n**2), n)
             assert np.isclose(phixstable[0][1], same_n_hydrogen[0][1] / atomic_number**2, rtol=1e-6)
 

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -300,6 +300,37 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
     assert np.all(crosssections[0] == 0.0)
 
 
+def test_write_phixs_data_with_no_phixs_arrays():
+    """A reader that found no photoionization data must not make write_phixs_data() index off the end.
+
+    write_output_files() fills a target list for every level whenever the reader supplied none, and
+    readnahardata.get_photoiontargetfractions() always gives at least the ground state. If the
+    reader also left the cross-section and threshold arrays empty (no usable .ptpx tables), the
+    level ids from those target lists have nothing behind them.
+    """
+    import argparse
+
+    import artisatomic
+
+    args = argparse.Namespace(nphixspoints=100, phixsnuincrement=0.03, optimaltemperature=6000)
+    flog = io.StringIO()
+    fphixs = io.StringIO()
+
+    artisatomic.write_phixs_data(
+        fphixs,
+        atomic_number=26,
+        ion_stage=1,
+        photoionization_crosssections=np.empty((0, args.nphixspoints)),
+        photoionization_targetfractions=[[(0, 1.0)] for _ in range(3)],
+        photoionization_thresholds_ev=np.empty(0),
+        args=args,
+        flog=flog,
+    )
+
+    assert not fphixs.getvalue()
+    assert "Writing 0 phixs tables" in flog.getvalue()
+
+
 def test_read_coldata_term_to_j_redistribution():
     """A term-resolved effective collision strength must be shared over the J levels of BOTH terms.
 

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -10,8 +10,10 @@ import pytest
 
 from artisatomic import add_handler_if_not_set
 from artisatomic import get_default_handler
+from artisatomic import hc_in_ev_cm
 from artisatomic import interpret_configuration
 from artisatomic import leveltuples_to_pldataframe
+from artisatomic import match_hydrogenic_phixs
 from artisatomic import PYDIR
 from artisatomic import readfacdata
 from artisatomic import readfloers25data
@@ -23,6 +25,7 @@ from artisatomic import readqubdata
 from artisatomic import readtanakajpltdata
 from artisatomic import reduce_phixs_tables_worker
 from artisatomic import write_adata
+from artisatomic import write_phixs_data
 
 
 def test_reduce_configuration():
@@ -244,12 +247,9 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
     """
     import argparse
 
-    import artisatomic
-
     rhd.read_hyd_phixsdata()
 
     ryd_to_ev = rhd.ryd_to_ev
-    hc_in_ev_cm = artisatomic.hc_in_ev_cm
 
     # a single hydrogenic n=1 level of a Z=2 ion: threshold is 4 Ryd, so sigma_th = 6.307 / 4 Mb
     ionization_energy_ev = 4 * ryd_to_ev
@@ -263,7 +263,7 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
     )
     args = argparse.Namespace(nphixspoints=100, phixsnuincrement=0.03, optimaltemperature=6000)
 
-    crosssections, targetfractions, thresholds = artisatomic.match_hydrogenic_phixs(
+    crosssections, targetfractions, thresholds = match_hydrogenic_phixs(
         atomic_number=2,
         energy_levels=dflevels,
         ionization_energy_ev=ionization_energy_ev,
@@ -288,7 +288,7 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
             "levelname": ["s1s  1S,enpercm=0.0,j=0.5"],
         }
     )
-    crosssections, targetfractions, thresholds = artisatomic.match_hydrogenic_phixs(
+    crosssections, targetfractions, thresholds = match_hydrogenic_phixs(
         atomic_number=2,
         energy_levels=dflevels_unbound,
         ionization_energy_ev=ionization_energy_ev,
@@ -310,13 +310,11 @@ def test_write_phixs_data_with_no_phixs_arrays():
     """
     import argparse
 
-    import artisatomic
-
     args = argparse.Namespace(nphixspoints=100, phixsnuincrement=0.03, optimaltemperature=6000)
     flog = io.StringIO()
     fphixs = io.StringIO()
 
-    artisatomic.write_phixs_data(
+    write_phixs_data(
         fphixs,
         atomic_number=26,
         ion_stage=1,

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -296,7 +296,7 @@ def test_match_hydrogenic_phixs_is_not_double_scaled():
         ion_handler="kurucz",
         args=args,
     )
-    assert thresholds[0] == 0.0
+    assert np.isnan(thresholds[0])  # NaN is "no threshold energy", which write_phixs_data() skips
     assert targetfractions[0] == []
     assert np.all(crosssections[0] == 0.0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,8 +132,7 @@ preview = true
 select = ["ALL"]
 ignore = [
     # every float comparison here is deliberate: a divide-by-zero guard, a validation of an exact
-    # value read from a data file, or a sentinel against a value that was literally assigned 0.0
-    # (a photoionisation threshold of exactly zero means "no data for this level")
+    # value read from a data file, or a test for a cross section that is zero everywhere
     "float-equality-comparison",
     "missing-type-function-argument",
     "missing-return-type-undocumented-public-function",

--- a/recombination_rates/recombinationrates.py
+++ b/recombination_rates/recombinationrates.py
@@ -64,9 +64,9 @@ for ionindex in range(4):
                     ylist.append(float(row[9]) * weightfactor)
 
                 ylistSS82.append(Arad[ionindex] * (T / 1e4) ** -Xrad[ionindex])
-                # Shull & van Steenberg (1982) dielectronic rate: A_di * T**(-3/2) * exp(-T0/T) *
-                # (1 + B_di * exp(-T1/T)). NB ** binds tighter than /, so T**-3.0 / 2.0 would be
-                # T**-3 / 2, which is ~2e6 times too small at T = 1e4 K.
+                # Shull & van Steenberg (1982) dielectronic rate: A_di * T**(-3/2) * exp(-T0/T)
+                # * (1 + B_di * exp(-T1/T)). NB ** binds tighter than /, so T**-3.0 / 2.0 would
+                # be ~2e6 times too small at T = 1e4 K.
                 alphadSS82 = (
                     Adi[ionindex]
                     * (T**-1.5)

--- a/tests/qub/checksums.txt
+++ b/tests/qub/checksums.txt
@@ -1,4 +1,4 @@
 a0047d3873d5de6d194e75bb540ea41d  adata.txt
 a20943827eba942629179bed717ac222  compositiondata.txt
-017f2ec7d18ad2c5956c94fd83601914  phixsdata_v2.txt
+445b2d2da05988bdb21f5196bfff7c3c  phixsdata_v2.txt
 c10e310384b34f7909c3f5ea9a25dbe4  transitiondata.txt

--- a/tests/qub/checksums.txt
+++ b/tests/qub/checksums.txt
@@ -1,4 +1,4 @@
 a0047d3873d5de6d194e75bb540ea41d  adata.txt
 a20943827eba942629179bed717ac222  compositiondata.txt
-445b2d2da05988bdb21f5196bfff7c3c  phixsdata_v2.txt
+017f2ec7d18ad2c5956c94fd83601914  phixsdata_v2.txt
 c10e310384b34f7909c3f5ea9a25dbe4  transitiondata.txt


### PR DESCRIPTION
Follow-ups from the review of #66, plus the comment pass. Absorbs #68, which was a stacked PR on this branch.

**No output file changes: all five test sets — cmfgen, qub, kurucz, floers25 and jplt — are byte-identical to main.**

## 1. The same adf04 file was opened twice, inconsistently

`read_adf04()` opens `atomic-data-qub/{Z}_{ion}.adf04` through `xopen_check_extension()`, and the next statement re-opened **the same path** with a plain `open()` to scan for collision strengths — so the file was parsed twice, and had it ever shipped compressed the first open would have succeeded and the second raised `FileNotFoundError` six lines later. The lines are now read once and both passes run over the list, which also removes the `seek(0)` rewind that a decompressing stream cannot generally do.

## 2. The last plain `open()` calls on shipped data files

`readnahardata` (both files), `readstoreydata` and `read_hyd_phixsdata()` were the only readers that could not accept a compressed data file. Swapping the `open()` alone was not enough for Nahar, which gates on `os.path.isfile()` first, so a `.gz` would still have been reported missing; the path resolution is now split out as `find_file_check_extension()`, used by both the opener and that check.

## 3. `add_handler_if_not_set()` re-implemented `sort_ion_handlers()`

Same two sorts, same keys — it calls the helper now. This sorts every element's ion list rather than only the one just touched, a no-op on already-sorted input.

## 4. The phixs threshold array carried two sentinels at once

`0.0` meant "no data", purely because the array was allocated with `np.zeros()` and filled in only for levels that got a cross-section table — so a genuine zero threshold would have been indistinguishable from an unfilled slot. Allocating with NaN makes "not filled in" distinct from every real value.

The other sentinel stays as it was: readqubdata writes `-1.0`, which ARTIS reads as "no value given" and takes from the difference of the level energies. An earlier commit on this branch replaced it with a derived value and was reverted in b6fcc57; the qub checksum is back to its original.

One piece of that commit is kept, because it changes no output: `readhillierdata` computed `hc / lambdaangstrom` without the `abs()` used at the phixs-fit sites above it, and CMFGEN writes a negative `Lam(A)` for 735 of the 8106 levels in the first 40 ions — a sign that would read as the "no value" sentinel. I checked end to end (the cmfgen test set, and a full carbon run, C II alone having 208 such levels) and no such level currently reaches the output, so this is a latent hazard rather than a live bug.

## 5. `.gitignore`

`tests/*/output/` is written by every checksum run, and `.coverage` did not match the `.coverage 2` / `.coverage.<host>.<pid>` forms.

## 6. Condensed 40 verbose comment blocks (was #68)

Comment blocks that had grown into exposition — restating the line below, justifying a choice at paragraph length, or recording history that belongs in `git log`. The largest, in `read_coldata()`, drops from nine lines to five while keeping both the sharing formula and the sum rule it preserves. The boilerplate "Not an assert: this validates an input file and must not disappear under python -O" appeared at five sites, three lines each, and is now one line at each. Commented-out code and the author's own open questions were left alone. Total comment text falls from 5575 to 5058 words, and the diff for that commit contains no non-comment line.

## Verification

`ruff check`, `ruff format --check`, `pyrefly` and `basedpyright` clean repo-wide; 22 tests pass; all five test sets match their committed checksums.

One test assertion changed, `test_match_hydrogenic_phixs_is_not_double_scaled`, which pinned the old `0.0` sentinel; its intent (an unbound level gets no threshold and is skipped) is unchanged.

The adf04 branch in item 1 has no matching data on disk, so no checksum run reaches it. It was checked differentially against the real `FeIII.adf04` instead: the old rewind-based and new read-once strategies produce the same `longest_line_length` and the same 52008 lines, line for line, including the `atom_group_note` state carried between passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)