### PR TITLE
Condense the verbose comment blocks

### DIFF
--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -193,9 +193,8 @@ def add_handler_if_not_set(
     return sort_ion_handlers(ion_handlers_out)
 
 
-# The id-keyed transition columns consumed by write_transition_data(). Readers with nothing to
-# report use this schema so an empty frame still carries them; name-keyed reader frames (e.g.
-# Hillier's namefrom/nameto) get lowerlevel/upperlevel joined on later by add_level_ids_forbidden().
+# The id-keyed transition columns write_transition_data() needs, so an empty frame still carries
+# them. Name-keyed frames get lowerlevel/upperlevel from add_level_ids_forbidden() instead.
 empty_transitions_schema = pl.Schema({"lowerlevel": pl.Int64, "upperlevel": pl.Int64, "A": pl.Float64})
 
 
@@ -212,9 +211,8 @@ def leveltuples_to_pldataframe(energy_levels) -> pl.DataFrame:
 
     dflevels = dflevels.with_columns(pl.col("levelid").cast(pl.Int64))
 
-    # lookups elsewhere index this frame by level id, so a reader-supplied levelid column
-    # (e.g. from the tanakajplt data files) must be contiguous and start at zero.
-    # A raise rather than an assert: this can be validating an input file's id column.
+    # the frame is indexed by level id elsewhere, so a reader-supplied levelid must be contiguous
+    # and zero-based. Not an assert: input validation must survive python -O.
     if not dflevels["levelid"].equals(pl.int_range(dflevels.height, dtype=pl.Int64, eager=True)):
         msg = "level ids must be contiguous and start at zero"
         raise ValueError(msg)
@@ -948,9 +946,8 @@ def interpret_configuration(instr_orig: str) -> tuple[list[str], int, int, int, 
     if not instr.startswith("Eqv st"):
         while instr:
             if instr[-1].upper() in lchars:
-                # Orbital with no occupation number, e.g. the '10d' of '3d6(5D)10d_5Pe'.
-                # The digit-letter-letter case keeps its leading digit, so '4sp(3P)_7Po[2]'
-                # yields a pretend orbital '4sp' rather than dropping the 4 (as before).
+                # Orbital with no occupation number, e.g. the '10d' of '3d6(5D)10d_5Pe'. A
+                # digit-letter-letter run keeps its digit, so '4sp(3P)_7Po[2]' gives '4sp'.
                 startpos = (
                     -3
                     if len(instr) >= 3
@@ -967,12 +964,9 @@ def interpret_configuration(instr_orig: str) -> tuple[list[str], int, int, int, 
                 instr = instr[:left_bracket_pos]
             elif str.isdigit(instr[-1]):  # the number of electrons in an orbital
                 if len(instr) >= 2 and instr[-2].upper() in lchars:
-                    # Single-digit occupation. A two-digit n is kept ('10d1') only when the
-                    # digits cannot belong to a preceding orbital: '3d14s2' is genuinely
-                    # ambiguous -- 3d(1) 4s(2) or 3d 14s(2) -- and there the single-digit
-                    # reading wins because an occupation of 1 is common and a two-digit n
-                    # carrying an explicit occupation is not. At the start of the string or
-                    # after a parent term there is no such ambiguity.
+                    # Single-digit occupation. A two-digit n survives ('10d1') only where the
+                    # digits cannot belong to a preceding orbital: '3d14s2' is ambiguous
+                    # (3d1 4s2 or 3d 14s2), and there the occupation-1 reading wins.
                     two_digit_n = (
                         len(instr) >= 4
                         and is_two_digit_n(instr[-4:-2])
@@ -1022,10 +1016,9 @@ def get_parity_from_config(instr) -> int:
         l = lchars_lower.index(orbitalstr[lpos])
         nelec = int(orbitalstr[lpos + 1 :]) if len(orbitalstr[lpos + 1 :]) > 0 else 1
 
-        # An orbital must satisfy l <= n - 1. CMFGEN packs the high-l levels of a shell into one
-        # level whose orbital letter is a merge marker rather than a real l ('2s2_13w_2W',
-        # '2s2_2p3(4So)5z_5Z'), and those fail this test. Such a level spans several l of both
-        # parities, so the marker contributes no definite parity and only the real orbitals count.
+        # An orbital must satisfy l <= n - 1. CMFGEN's merged high-l levels ('2s2_13w_2W',
+        # '2s2_2p3(4So)5z_5Z') fail this: the letter is a merge marker spanning several l of both
+        # parities, so it has no definite parity and only the real orbitals count.
         principalquantumnumber = int(orbitalstr[:lpos]) if orbitalstr[:lpos].isdigit() else 0
         if l >= principalquantumnumber:
             continue
@@ -1287,10 +1280,9 @@ def write_phixs_data(
     reported. Level ids, of this ion and of the upper ion's targets, are zero-based in memory but
     numbered from one in the output.
     """
-    # a level gets a table only if it has photoionisation targets and a threshold energy. The
-    # threshold arrays start as NaN and are only filled in for levels that got a cross-section
-    # table, so NaN means "no data for this level". Every number is a real threshold, including
-    # readqubdata's -1.0, which tells ARTIS to take the threshold from the level energies.
+    # a level gets a table only if it has targets and a threshold energy. The threshold arrays
+    # start as NaN and are filled in only for levels that got a table, so NaN means "no data".
+    # Every number is a real threshold, including readqubdata's -1.0 ("derive it from the levels").
     levelids_with_targets = [
         levelid for levelid, targetlist in enumerate(photoionization_targetfractions) if targetlist
     ]

--- a/artisatomic/makerecombratefile.py
+++ b/artisatomic/makerecombratefile.py
@@ -134,9 +134,8 @@ def main():
                     arr_rrc = ion.RrRate["rate"]
                     ion.drRate()
                     arr_drc = ion.DrRate["rate"]
-                    # the third column is the total recombination rate, matching the RRC(total)
-                    # column used for the Nahar files above, so dielectronic recombination must be
-                    # included rather than computed and discarded
+                    # the third column is the total recombination rate, matching RRC(total) used
+                    # for the Nahar files above, so dielectronic recombination must be included
                     frecombrates.writelines(
                         f"{logT_e:.1f} {-1.0} {arr_rrc[i] + arr_drc[i]}\n" for i, logT_e in enumerate(arr_logT_e)
                     )

--- a/artisatomic/readfacdata.py
+++ b/artisatomic/readfacdata.py
@@ -192,9 +192,8 @@ def read_levels_data(dflevels):
     for index, row in dflevels.iterrows():
         ilev_enlevelindex_map[int(row["Ilev"])] = index
 
-        # Config is not unique (levels of the same configuration differ in J), so append the FAC
-        # level index to make the name unique. The configuration stays first so that
-        # get_level_valence_n() and the adata.txt comment column both still start with it.
+        # Config is not unique (levels of one configuration differ in J), so append the FAC level
+        # index. The configuration stays first, for get_level_valence_n() and the adata.txt comment.
         newlevel = FACEnergyLevel(
             levelname=f"{row['Config']} Ilev={int(row['Ilev'])}",
             parity=row["P"],
@@ -205,9 +204,8 @@ def read_levels_data(dflevels):
 
     energy_levels.sort(key=lambda x: x.energyabovegsinpercm)
 
-    # A duplicated Ilev would silently overwrite its map entry and misroute every transition
-    # that references it (and implies duplicate level names, since Ilev is embedded in them).
-    # Not an assert: this validates an input file and must not disappear under python -O.
+    # a duplicated Ilev would overwrite its map entry and misroute every transition referencing
+    # it. Not an assert: input validation must survive python -O.
     if len(ilev_enlevelindex_map) != len(energy_levels):
         msg = f"Duplicate Ilev values in FAC levels file: {len(energy_levels)} rows but only {len(ilev_enlevelindex_map)} unique Ilev"
         raise ValueError(msg)

--- a/artisatomic/readfloers25data.py
+++ b/artisatomic/readfloers25data.py
@@ -91,17 +91,15 @@ def read_levels_and_transitions(atomic_number: int, ion_stage: int, flog, calibr
         .alias("g")
     )
 
-    # The level table is indexed from zero in file order and the transitions refer to those
-    # indices, so a gap would silently attach transitions to the wrong levels. Not an assert:
-    # this validates an input file and must not disappear under python -O.
+    # the levels are indexed from zero in file order and the transitions refer to those indices,
+    # so a gap would misattach them. Not an assert: input validation must survive python -O.
     if dflevels["Index"].to_list() != list(range(dflevels.height)):
         msg = f"Level indices in {levels_file} are not contiguous and zero-based"
         raise ValueError(msg)
 
-    # Configuration is not unique (levels of the same configuration differ by J), so build a
-    # unique level name from it. Index is contiguous, so including it guarantees uniqueness.
-    # The configuration stays first so that get_level_valence_n() and the adata.txt comment
-    # column both still start with it.
+    # Configuration is not unique (levels of one configuration differ by J), so append the
+    # contiguous index. The configuration stays first, for get_level_valence_n() and the
+    # adata.txt comment.
     dflevels = dflevels.with_columns(
         levelname=pl.format("{} J={} index={}", pl.col("Configuration"), pl.col("J"), pl.col("Index"))
     )
@@ -122,9 +120,8 @@ def read_levels_and_transitions(atomic_number: int, ion_stage: int, flog, calibr
 
     artisatomic.log_and_print(flog, f"Read {dftransitions.height} transitions")
 
-    # Transitions reference levels by zero-based index, and an out-of-range reference would be
-    # silently dropped by the level-id joins in add_level_ids_forbidden(), leaving an incomplete
-    # database. Not an assert: this validates an input file and must not disappear under python -O.
+    # an out-of-range level reference would be silently dropped by the joins in
+    # add_level_ids_forbidden(). Not an assert: input validation must survive python -O.
     if dftransitions.height > 0:
         transition_level_indices = pl.concat([dftransitions["Lower"], dftransitions["Upper"]])
         min_index = t.cast("int", transition_level_indices.min())

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -18,15 +18,13 @@ import artisatomic
 
 # need to also include collision strengths from e.g., o2col.dat
 
-# The level table's columns are read from the header line above it. The oldest oscillator files
-# (those without a "!Format date" line) carry no header, and all of them use the layout below.
-# Its fourth column is the threshold FREQUENCY, not an energy: these files have no eV column.
+# Column layout of the level table in the oldest oscillator files, which carry no header line
+# (no "!Format date"). Its fourth column is a threshold FREQUENCY, not an energy.
 hillier_rowformat_noheader = "levelname g energyabovegsinpercm freqtentothe15hz lambdaangstrom hillierlevelid"
 
 
-# The files disagree on which columns they carry, so only the fields below are kept and every ion
-# read from an oscillator file gets the same frame. parity is not in the file: it is read out of the
-# level name, and decides which transitions are forbidden.
+# The files disagree on which columns they carry, so only these are kept and every ion gets the
+# same frame. parity is not in the file: it is read from the level name and decides forbidden-ness.
 class HillierEnergyLevel(t.NamedTuple):
     """One energy level read from a CMFGEN oscillator file."""
 
@@ -300,15 +298,14 @@ def get_term_as_tuple(config: str) -> tuple[int, int, int]:
         if config[-1] == "o":
             return (-1, -1, 1)
         return (-1, -1, -1)
-    # the whole parse is guarded: a malformed name can fail at the int() or at either index,
-    # and any of those means the term is simply unreadable
+    # a malformed name can fail at the int() or at either index, and any of those just means
+    # the term is unreadable
     try:  # ruff: ignore[too-many-statements-in-try-clause]
         twosplusone = int(config[lposition - 1])  # could this be two digits long?
         if lposition + 1 > len(config) - 1:
-            # No 'e'/'o' suffix to read the parity from. CMFGEN writes its merged high-l levels
-            # this way, with the orbital letter repeated as the term symbol (2s2_13w_2W,
-            # 2s2_2p3(4So)5z_5Z), so the term letter is a merge marker rather than a real L.
-            # Sum l over the occupied orbitals instead of assuming the term is even.
+            # No 'e'/'o' suffix to give the parity. CMFGEN writes its merged high-l levels this
+            # way, repeating the orbital letter as the term symbol (2s2_13w_2W, 2s2_2p3(4So)5z_5Z),
+            # so sum l over the occupied orbitals instead of assuming an even term.
             parity = artisatomic.get_parity_from_config(config)
         elif config[lposition + 1] == "o":
             parity = 1
@@ -570,8 +567,8 @@ def read_phixs_tables(
     levelnames: list[str] = dfenergy_levels["levelname"].to_list()
     lambdaangstroms: list[float] = dfenergy_levels["lambdaangstrom"].to_list()
 
-    # first level index of each name, with and without the [J] suffix: the cross-section tables are
-    # matched to levels by name, and a scan of the level list per table would be O(levels x tables)
+    # first level index of each name, with and without the [J] suffix: tables are matched to levels
+    # by name, and rescanning the level list per table would be O(levels x tables)
     firstlevelindex_of_levelname: dict[str, int] = {}
     firstlevelindex_of_levelnamenoJ: dict[str, int] = {}
     for levelindex, levelname in enumerate(levelnames):
@@ -581,13 +578,12 @@ def read_phixs_tables(
     # this gets partially overwritten anyway
     photoionization_crosssections = np.zeros((levelcount, args.nphixspoints))
     photoionization_thresholds_ev = np.full(levelcount, np.nan)
-    # None means "no photoionisation data for this level". get_photoiontargetfractions() relies on
-    # this to tell those levels apart from levels that do have a cross-section table, so it must
-    # not be initialised to empty lists.
+    # None means "no photoionisation data for this level", which get_photoiontargetfractions()
+    # relies on, so this must not be initialised to empty lists
     photoionization_targetconfig_fractions: list[list[tuple[str, float]] | None] = [None] * levelcount
 
-    # charge of the ion left behind by the photoionisation, i.e. CMFGEN's ZION (= ZXzV, which it
-    # reads from the oscillator file, where it equals the ionisation stage for every ion here)
+    # charge of the ion left behind, i.e. CMFGEN's ZION (= ZXzV from the oscillator file, which
+    # equals the ionisation stage for every ion here)
     zion = ion_stage
     photfilenames = ions_data[atomic_number, ion_stage].photfilenames
     phixstables = [{} for _ in photfilenames]
@@ -650,15 +646,14 @@ def read_phixs_tables(
                     row[-3:]
                 ) == "!Configuration name [*]":
                     lowerlevelname = row[0]
-                    # with J splitting, the name (including any [J] suffix) maps to exactly one
-                    # level, so it must be kept intact. Without J splitting, strip the [J] suffix
-                    # so the table applies to all levels sharing the configuration
+                    # with J splitting the name (including any [J] suffix) maps to exactly one
+                    # level; without it, strip the suffix so the table covers the configuration
                     if not j_splitting_on and "[" in lowerlevelname:
                         lowerlevelname = lowerlevelname.split("[")[0]
                     fitcoefficients = []
                     numpointsexpected = 0
-                    # the zero-based index of the first matching level (without J splitting,
-                    # several matches may differ by J values); no match keeps the old default of 0
+                    # first matching level (without J splitting, several may differ by J);
+                    # no match keeps the old default of 0
                     lowerlevelindex = (
                         firstlevelindex_of_levelname if j_splitting_on else firstlevelindex_of_levelnamenoJ
                     ).get(lowerlevelname, 0)
@@ -668,10 +663,9 @@ def read_phixs_tables(
                     # print(f"Reading level {lowerlevelindex} '{lowerlevelname}'")
 
                 if len(row) >= 2 and " ".join(row[-3:]) == "!Screened nuclear charge":
-                    # CMFGEN's ZION comes from the oscillator file, not from here: RDPHOT_GEN_V2
-                    # never reads this field. The two disagree for 29 files in the shipped
-                    # database, so keep using ion_stage (which matches the oscillator value for
-                    # every ion in ions_data) and only report the discrepancy.
+                    # CMFGEN's ZION comes from the oscillator file: RDPHOT_GEN_V2 never reads
+                    # this field, and the two disagree for 29 shipped files. Keep ion_stage (which
+                    # matches the oscillator value for every ion in ions_data) and just report it.
                     zion_from_photfile = int(float(row[0]))
                     if zion_from_photfile != ion_stage:
                         artisatomic.log_and_print(
@@ -872,10 +866,8 @@ def read_phixs_tables(
                         phixs_type_levels[crosssectiontype].append(lowerlevelname)
 
                 if len(row) == 0:
-                    # For the tabulated types the array is preallocated to the declared row count,
-                    # so a short table leaves trailing zeros behind. Compare the number of points
-                    # actually read instead. (The previous check tested `targetlevelname in
-                    # <2-D float ndarray>`, which is always False, so it never ran.)
+                    # for the tabulated types the array is preallocated to the declared row
+                    # count, so a short table leaves trailing zeros: compare the points read
                     if (
                         crosssectiontype in {20, 21, 22}
                         and lowerlevelname
@@ -921,10 +913,9 @@ def read_phixs_tables(
             try:
                 phixs_at_threshold = reduced_phixstable[np.nonzero(reduced_phixstable)][0]
             except IndexError:
-                # The cross section is zero everywhere on the output grid, so the level is dropped
-                # and gets no photoionization at all. For a type-8 (offset) cross section this
-                # happens whenever the offset edge nu_edge + nu_o lies beyond the end of the
-                # nu/nu_edge grid that reduce_phixs_tables() samples.
+                # The cross section is zero everywhere on the output grid, so the level gets no
+                # photoionization. For type 8 (offset) this happens when the offset edge
+                # nu_edge + nu_o lies beyond the grid that reduce_phixs_tables() samples.
                 num_levelnames_with_zero_crosssection += 1
                 artisatomic.log_and_print(
                     flog, f"WARNING: No non-zero cross section points for {lowerlevelname}, so it will have no phixs"
@@ -987,9 +978,8 @@ def read_phixs_tables(
             # reduced_phixs_dict[lowerlevelname] = reduced_phixstable / (max_factor / factor_sum)
             reduced_phixs_dict[lowerlevelname] = reduced_phixstable  # / (max_factor / factor_sum)
 
-    # now the non-J-split cross sections are mapped onto J-split levels. Without J splitting a
-    # cross-section table matches every level sharing the configuration, so index the level list by
-    # match name once rather than rescanning it for each table.
+    # map the non-J-split cross sections onto J-split levels. A table matches every level sharing
+    # the configuration, so index the level list by match name once rather than rescanning it.
     levelindices_of_matchname: defaultdict[str, list[int]] = defaultdict(list)
     for levelindex, levelname in enumerate(levelnames):
         levelindices_of_matchname[levelname if j_splitting_on else levelname.split("[")[0]].append(levelindex)
@@ -997,9 +987,9 @@ def read_phixs_tables(
     for lowerlevelname_a, phixstable in reduced_phixs_dict.items():
         for levelindex in levelindices_of_matchname[lowerlevelname_a]:
             photoionization_crosssections[levelindex] = phixstable
-            # .get() rather than the defaultdict's __getitem__: a level whose target factors
-            # all came out zero is absent here, and inserting an empty list for it would look
-            # like "has data, no targets" instead of "no data" to get_photoiontargetfractions()
+            # .get() rather than __getitem__: a level whose target factors all came out zero is
+            # absent, and an empty list would look like "has data, no targets" to
+            # get_photoiontargetfractions()
             photoionization_targetconfig_fractions[levelindex] = phixs_targetconfigfractions_of_levelname.get(
                 lowerlevelname_a
             )
@@ -1104,9 +1094,9 @@ def get_hydrogenic_nl_phixstable(lambda_angstrom, n, l_start, l_end, nu_o=None, 
         # energy / (E_o + E_threshold), i.e. U measured from the offset edge rather than the true edge
         u_offset = thresholdenergyev * u_grid / (e_o_ev + thresholdenergyev)
 
-        # CMFGEN interpolates log10(cross section) linearly in log10(U), and the tabulated U grid is
-        # geometric, so this reproduces its RJ = LOG10(U) / L_DEL_U indexing.
-        # u_offset <= u_grid for e_o_ev >= 0, so we never need to extrapolate past the table end.
+        # CMFGEN interpolates log10(cross section) linearly in log10(U) on a geometric U grid,
+        # reproducing its RJ = LOG10(U) / L_DEL_U indexing. u_offset <= u_grid for e_o_ev >= 0,
+        # so the table end is never extrapolated past.
         with np.errstate(divide="ignore"):
             log_sigma = np.log10(arr_sigma_summed_over_l)
         arr_sigma = 10 ** np.interp(np.log10(u_offset), np.log10(u_grid), log_sigma) * scale_factor
@@ -1271,8 +1261,8 @@ def read_coldata(atomic_number, ion_stage, dfenergy_levels: pl.DataFrame, flog, 
         except KeyError:
             level_ids_of_level_name[levelnamenoJ] = [levelid]
 
-    # total statistical weight of each term, used to share a term-resolved collision strength over
-    # its J levels. Depends only on the level list, so build it once rather than per input row.
+    # total statistical weight per term, for sharing a term-resolved collision strength over its
+    # J levels. Depends only on the level list, so build it once.
     g_sum_of_level_name = {
         levelname: sum(gvalues[levelid] for levelid in levelids)
         for levelname, levelids in level_ids_of_level_name.items()
@@ -1346,8 +1336,8 @@ def read_coldata(atomic_number, ion_stage, dfenergy_levels: pl.DataFrame, flog, 
                 upsilon = float(upsilonvalues[temperature_index].replace("D", "E"))
                 coll_lines_in += 1
 
-                # every level lookup below can raise KeyError for a name that is not in the
-                # level list, so the whole block is guarded rather than each lookup
+                # any level lookup below can raise KeyError for a name not in the level list,
+                # so guard the whole block rather than each lookup
                 try:  # ruff: ignore[too-many-statements-in-try-clause]
                     if level_ids_of_level_name[namefrom][0] > level_ids_of_level_name[nameto][0]:
                         artisatomic.log_and_print(
@@ -1369,15 +1359,11 @@ def read_coldata(atomic_number, ion_stage, dfenergy_levels: pl.DataFrame, flog, 
                             if id_upper < id_upper2 and (id_upper, id_upper2) not in upsilondict:
                                 upsilondict[id_upper, id_upper2] = -2.0
 
-                    # When the collision data is given between LS terms but the level list is
-                    # J-split, the term effective collision strength is shared over the J levels
-                    # of both terms in proportion to their statistical weights:
+                    # A term-resolved collision strength is shared over the J levels of both
+                    # terms in proportion to their statistical weights:
                     #     upsilon_ij = upsilon_term * (g_i / g_lower_term) * (g_j / g_upper_term)
-                    # so that sum_ij upsilon_ij = upsilon_term. That invariant is what makes the
-                    # total term-to-term rate come out right, because ARTIS forms the collisional
-                    # excitation rate coefficient as proportional to upsilon_ij / g_i.
-                    # Both sums are over the complete term, so each pair keeps its correct value
-                    # regardless of which pairs happen to be representable as lower id < upper id.
+                    # so that sum_ij upsilon_ij = upsilon_term, which is what makes the total
+                    # term-to-term rate right (ARTIS builds the rate from upsilon_ij / g_i).
                     lower_g_sum = g_sum_of_level_name[namefrom]
                     upper_g_sum = g_sum_of_level_name[nameto]
 
@@ -1389,9 +1375,9 @@ def read_coldata(atomic_number, ion_stage, dfenergy_levels: pl.DataFrame, flog, 
                             upsilonscaled = (
                                 upsilon * (gvalues[id_lower] / lower_g_sum) * (gvalues[id_upper] / upper_g_sum)
                             )
-                            # upsilon is symmetric, and the output wants lower id < upper id. The
-                            # two terms' J levels can interleave in energy, so order the key here
-                            # rather than dropping the pairs that come out the wrong way round.
+                            # upsilon is symmetric and the output wants lower id < upper id; the
+                            # terms' J levels can interleave, so order the key rather than
+                            # dropping the pairs that come out reversed
                             key = (min(id_lower, id_upper), max(id_lower, id_upper))
                             if key in upsilondict and upsilondict[key] >= 0.0:
                                 artisatomic.log_and_print(
@@ -1493,8 +1479,8 @@ def read_hyd_phixsdata():
     get_hydrogenic_*_phixstable(). Thresholds are taken from the H I level list, which is
     therefore required to be indexed by principal quantum number.
     """
-    # the cached (2l+1)-weighted sums are built from the tables filled in below, so a reload
-    # (repeated calls happen in the tests) must not leave sums computed from the previous tables
+    # the cached (2l+1)-weighted sums come from the tables filled in below, so a reload (the
+    # tests call this repeatedly) must not leave sums from the previous tables
     get_hydrogenic_sigma_summed_over_l.cache_clear()
 
     with open(os.devnull, "w", encoding="utf-8") as devnull:

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -45,8 +45,8 @@ class QUBEnergyLevel(t.NamedTuple):
 
 qubpath = (Path(__file__).parent.resolve() / ".." / "atomic-data-qub").resolve()
 
-# the ions that get_default_handler() picks "qub_data" for. Nd II (60, 2) has an adf04 file and is
-# read if the handler is set explicitly, but is deliberately not the default for that ion.
+# the ions get_default_handler() picks "qub_data" for. Nd II (60, 2) has an adf04 file and is read
+# when the handler is set explicitly, but is deliberately not the default.
 default_handler_ions = frozenset(
     {
         (38, 1),
@@ -167,10 +167,9 @@ def read_adf04(
             energylevel = energylevel._replace(g=g, parity=parity, levelname=levelname)
             energylevels.append(energylevel)
 
-            # the transition and upsilon tables index levels by this 1-based id, and the rest of
-            # the code looks up id n at list index n - 1, so a non-contiguous or non-1-based file
-            # would silently attach every transition to the wrong level. Not an assert: this
-            # validates an input file and must not disappear under python -O.
+            # the transition and upsilon tables use these 1-based ids and the rest of the code
+            # looks up id n at index n - 1, so a non-contiguous file would misattach every
+            # transition. Not an assert: input validation must survive python -O.
             if energylevel.qub_id != len(energylevels):
                 msg = (
                     f"adf04 level id {energylevel.qub_id} found at position {len(energylevels)} in {filepath}."
@@ -180,9 +179,8 @@ def read_adf04(
 
         upsilonheader = fleveltrans.readline().split()
         list_tempheaders = [f"upsT={x:}" for x in upsilonheader[2:]]
-        # each collision row is: upper, lower, A-value, one upsilon per temperature, and finally
-        # the infinite-energy (Born) limit. Name that last column so the row width matches and
-        # pandas does not silently drop a column to make the data fit the header.
+        # each collision row is upper, lower, A-value, one upsilon per temperature, then the
+        # infinite-energy (Born) limit. Name that last column so pandas does not drop one to fit.
         list_headers = ["upper", "lower", "avalue", *list_tempheaders, "born_limit"]
         qubupsilondf_alltemps = pd.read_csv(
             fleveltrans,
@@ -327,9 +325,8 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
 
         qub_transitions = []
         transition_count_of_level_name = defaultdict(int)
-        # two passes are needed (the collision strengths are found by line length, which is only
-        # known after seeing every line), so read the lines once rather than rewinding the file:
-        # xopen_check_extension() may hand back a decompressing stream that cannot seek backwards
+        # two passes are needed (collision strengths are found by line length, known only after
+        # seeing every line), so read the lines once: a decompressing stream may not seek back
         with artisatomic.xopen_check_extension(atom_filepath) as ftrans:
             translines = ftrans.readlines()
 
@@ -579,9 +576,8 @@ def read_qub_photoionizations(
                 dict_phixstable, args.optimaltemperature, args.nphixspoints, args.phixsnuincrement
             )["gs"]
 
-        # Unlike the Co II branch above, every level is deliberately given a phixs entry: levels
-        # of the ground quartet get the tabulated cross section, and all higher levels get an
-        # explicit all-zero table (no photoionization) rather than being omitted from the output.
+        # unlike the Co II branch above, every level deliberately gets a phixs entry: the ground
+        # quartet gets the tabulated cross section and higher levels an explicit all-zero table
         for levelid in range(levelcount):
             photoionization_thresholds_ev[levelid] = -1.0
             photoionization_targetfractions[levelid] = [(0, 1.0)]  # the upper ion's ground state

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -58,9 +58,9 @@ def test_get_parity_from_config():
     # wrong (odd) parity here, since 3*14 is even but 3*1 is odd
     assert get_parity_from_config("4f145d96s2") == 0  # 3*14 + 2*9 + 0 = 60
 
-    # CMFGEN packs the high-l levels of a shell into one level whose orbital letter is a merge
-    # marker, not a real l: '5z' would be l=22 and '13w' l=19, both impossible for their n. Such a
-    # level spans several l of both parities, so only the real orbitals decide the parity.
+    # CMFGEN packs a shell's high-l levels into one level whose orbital letter is a merge marker,
+    # not a real l ('5z' would be l=22, '13w' l=19). It spans several l of both parities, so only
+    # the real orbitals decide the parity.
     assert get_parity_from_config("2s2_2p3(4So)5z_5Z") == 1  # 2s2 + 2p3 = 3, the 5z contributes none
     assert get_parity_from_config("2s2_13w_2W") == 0  # 2s2 = 0, the 13w contributes none
 
@@ -224,9 +224,8 @@ def test_hydrogenic_phixs_effective_charge_scaling():
             threshold_ev = atomic_number**2 * ryd_to_ev / n**2
             phixstable = rhd.get_hydrogenic_n_phixstable(rhd.hc_in_ev_angstrom / threshold_ev, n)
 
-            # Kramers: sigma_threshold = 7.91 Mb * n / Z**2 * g_bf, and the gaunt factor at
-            # threshold depends only on n, so the ratio to the n=1 value is exactly n / Z**2
-            # once the n-dependence of g_bf is divided out by comparing at the same n.
+            # Kramers: sigma_threshold = 7.91 Mb * n / Z**2 * g_bf, and g_bf at threshold
+            # depends only on n, so comparing at the same n leaves a ratio of exactly n / Z**2
             same_n_hydrogen = rhd.get_hydrogenic_n_phixstable(rhd.hc_in_ev_angstrom / (ryd_to_ev / n**2), n)
             assert np.isclose(phixstable[0][1], same_n_hydrogen[0][1] / atomic_number**2, rtol=1e-6)
 

--- a/recombination_rates/recombinationrates.py
+++ b/recombination_rates/recombinationrates.py
@@ -64,9 +64,9 @@ for ionindex in range(4):
                     ylist.append(float(row[9]) * weightfactor)
 
                 ylistSS82.append(Arad[ionindex] * (T / 1e4) ** -Xrad[ionindex])
-                # Shull & van Steenberg (1982) dielectronic rate: A_di * T**(-3/2) * exp(-T0/T) *
-                # (1 + B_di * exp(-T1/T)). NB ** binds tighter than /, so T**-3.0 / 2.0 would be
-                # T**-3 / 2, which is ~2e6 times too small at T = 1e4 K.
+                # Shull & van Steenberg (1982) dielectronic rate: A_di * T**(-3/2) * exp(-T0/T)
+                # * (1 + B_di * exp(-T1/T)). NB ** binds tighter than /, so T**-3.0 / 2.0 would
+                # be ~2e6 times too small at T = 1e4 K.
                 alphadSS82 = (
                     Adi[ionindex]
                     * (T**-1.5)


### PR DESCRIPTION
Stacked on #67 — the files overlap heavily, so this targets `cleanup-follow-ups` and will retarget to `main` once that merges.

40 comment blocks had grown into exposition rather than explanation. Each one keeps the fact a reader actually needs and drops the derivation, the restatement of the line below it, and the history that belongs in `git log`.

The largest, in `read_coldata()`, went from nine lines to five while keeping both the sharing formula and the sum rule it preserves:

```
upsilon_ij = upsilon_term * (g_i / g_lower_term) * (g_j / g_upper_term)
```

The boilerplate "Not an assert: this validates an input file and must not disappear under python -O" appeared at five sites in four files, three lines each; it is now one short line at each.

**Left alone deliberately:** commented-out code blocks (disabled code, not prose), and the author's own open questions such as `# what is the h parameter that is not used??` and the adf04 `¯\_(ツ)_/¯` note — those are notes to a future reader, not verbosity.

## Verification

Comments only: the diff contains no non-comment line, checked mechanically. Total comment text across the repo drops from 5575 to 5058 words, concentrated in the 40 blocks touched.

`ruff check`, `ruff format --check`, `pyrefly` and `basedpyright` clean; 22 tests pass; cmfgen, qub, kurucz, floers25 and jplt checksums all match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)