### PR TITLE
Document that hydrogenic phixs only apply to ions with no cross sections

### DIFF
--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -262,7 +262,12 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         parser.add_argument(
             "--use_hydrogenic_for_unknown_phixs",
             action="store_true",
-            help="Use hydrogenic cross sections for ions with unknown cross sections",
+            help=(
+                "Estimate hydrogenic cross sections for ions whose handler supplied none at all."
+                " An ion with even one cross section from its data source is left untouched, so"
+                " this never replaces or extends measured data. Excludes the top ion, which has no"
+                " upper ion to photoionise to."
+            ),
         )
 
         parser.set_defaults(**kwargs)
@@ -502,12 +507,15 @@ def read_ion_data(
 
     dfenergylevels = leveltuples_to_pldataframe(energy_levels)
 
+    # the len() == 0 test is what limits the estimate to ions the handler gave nothing for: an ion
+    # with even one cross-section table is left alone, so measured data is never replaced. The top
+    # ion is excluded because there is no upper ion for it to photoionise to.
     if (
         not is_top_ion
         and not args.nophixs
         and len(photoionization_crosssections) == 0
         and args.use_hydrogenic_for_unknown_phixs
-    ):  # don't get cross sections for top ion
+    ):
         (
             photoionization_crosssections,
             photoionization_targetfractions,
@@ -623,7 +631,12 @@ def match_hydrogenic_phixs(
 
     Applies to any handler, not just one source: a hydrogenic cross section is assigned to each of
     the lowest levels, scaled to that level's own ionisation threshold, with the upper ion's ground
-    state as the only target. Enabled by -use_hydrogenic_for_unknown_phixs.
+    state as the only target. Enabled by --use_hydrogenic_for_unknown_phixs.
+
+    The caller only reaches this for an ion whose handler returned no cross sections at all, so
+    real data is never replaced or extended by an estimate. The granularity is the whole ion: an
+    ion whose handler covered even one level keeps exactly the levels that handler covered, and
+    the rest are left without photoionization rather than filled in hydrogenically.
     """
     dict_get_n_func = {
         "tanakajplt": readtanakajpltdata.get_level_valence_n,


### PR DESCRIPTION
## Why this is documentation and not a new option

The requested behaviour — hydrogenic cross sections only for ions with no existing cross sections — is what `--use_hydrogenic_for_unknown_phixs` already does. The caller gates on `len(photoionization_crosssections) == 0`:

```python
if (
    not is_top_ion
    and not args.nophixs
    and len(photoionization_crosssections) == 0
    and args.use_hydrogenic_for_unknown_phixs
):
```

I verified it rather than trusting the read: running the **cmfgen** set with the flag on produces byte-identical output, because every cmfgen ion already has cross sections from CMFGEN. Adding a second flag would have duplicated this.

What was missing is that nothing said so. The help text read "Use hydrogenic cross sections for ions with unknown cross sections", which does not tell you that an ion with partial data is skipped entirely, nor that the top ion is excluded. The restriction was one `len()` call with no comment — easy to miss, and easy to drop in a refactor.

## Changes

- **`--help`** now states that an ion with even one cross section from its data source is left untouched, so the flag never replaces or extends measured data, and that the top ion is excluded because it has no upper ion to photoionise to.
- **`match_hydrogenic_phixs()`'s docstring** records that the granularity is the whole ion: an ion whose handler covered even one level keeps exactly those levels, and the rest are left without photoionization rather than filled in hydrogenically.
- **A comment at the condition** names `len() == 0` as the thing doing the limiting.
- Fixed the flag spelling in the docstring, which had `-use_hydrogenic_for_unknown_phixs` with one dash instead of two.

## The gap this documents, which is worth knowing about

The granularity being per-ion rather than per-level is a real limitation, not just a detail. In the cmfgen test set, 1998 of 16439 levels in non-top ions have no cross-section table:

| ion | levels | phixs tables | no phixs |
| --- | ---: | ---: | ---: |
| Fe I | 1578 | 1479 | 99 |
| Fe II | 2698 | 2177 | 521 |
| Fe III | 1500 | 1101 | 399 |
| Fe IV | 1000 | 1000 | 0 |
| Co II | 2747 | 2445 | 302 |
| Co III | 3917 | 3240 | 677 |
| Ni II–IV | 2999 | 2999 | 0 |
| **total** | **16439** | **14441** | **1998** |

Those 1998 levels get no photoionization at all, and no flag currently fills them. If you want hydrogenic estimates for *levels* a handler missed within an ion that has partial data, that is a genuinely different feature — say the word and I will open it separately, since it would change `phixsdata_v2.txt` for the cmfgen set substantially.

## Verification

Documentation only. `ruff check`, `ruff format --check`, `pyrefly`, `basedpyright` clean; 23 tests pass; all five test sets byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)