### PR TITLE
Collapse whitespace in Kurucz level labels

### DIFF
--- a/artisatomic/readkuruczdata.py
+++ b/artisatomic/readkuruczdata.py
@@ -116,11 +116,13 @@ def parse_gfall(fname: str) -> pl.LazyFrame:
         for column in double_columns
     )
 
-    # Clean labels
+    # Clean labels. str.replace_all(), not Expr.replace(): the latter swaps whole values that
+    # equal the literal string "\s+", so the internal whitespace runs the gfall columns are padded
+    # with ('s4d  1D') were never collapsed and went into the level names as-is.
     ignored_labels = ["AVERAGE", "ENERGIES", "CONTINUUM"]
     gfall = gfall.with_columns(
-        pl.col("label_lower").str.strip_chars().replace(r"\s+", " "),
-        pl.col("label_upper").str.strip_chars().replace(r"\s+", " "),
+        pl.col("label_lower").str.strip_chars().str.replace_all(r"\s+", " "),
+        pl.col("label_upper").str.strip_chars().str.replace_all(r"\s+", " "),
     ).filter(
         (pl.col("label_lower").is_in(ignored_labels).not_()) & (pl.col("label_upper").is_in(ignored_labels).not_())
     )

--- a/artisatomic/readtanakajpltdata.py
+++ b/artisatomic/readtanakajpltdata.py
@@ -69,8 +69,12 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
                 energyabovegsinpercm=pl.col("energy_ev").cast(pl.Float64) / hc_in_ev_cm,
                 parity=pl.when(pl.col("parity").str.strip_chars() == "odd").then(1).otherwise(0),
                 g=pl.col("g").cast(pl.Float64),
-                # the level name keeps the file's own 1-based number, but the level id is
-                # zero-based like everywhere else in memory
+                # Every expression in one select() reads the INPUT frame, so both columns below
+                # are the file's own values, not the ones being computed alongside them: the name
+                # gets the file's 1-based number rather than the zero-based levelid, and the
+                # 'even'/'odd' text rather than the 0/1 parity. Both are wanted here — the name is
+                # a human-readable comment in adata.txt — and read_fwf() has already stripped the
+                # text, so this is deliberate rather than the shadowing accident it resembles.
                 levelname=pl.format(
                     "{},{},{}", pl.col("levelid"), pl.col("parity"), pl.col("configuration").str.strip_chars()
                 ),

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -818,6 +818,24 @@ def test_write_adata_level_comment():
     assert spaced_line.split(maxsplit=4)[4] == spacedlevelname
 
 
+def test_parse_gfall_collapses_label_whitespace():
+    r"""Kurucz labels are fixed-width padded, so their whitespace runs must be collapsed.
+
+    Expr.replace() swaps whole values equal to a literal, so `.replace(r"\s+", " ")` on a label
+    column matched nothing and every run survived into the level names written to adata.txt.
+    Only `.str.replace_all()` treats the argument as a pattern.
+    """
+    gfall = readkuruczdata.parse_gfall(str(readkuruczdata.find_gfall(38, 0))).collect()
+
+    labels = pl.concat([gfall["label_lower"], gfall["label_upper"]]).unique().to_list()
+    assert labels, "expected some labels for Sr I"
+    # no run of two or more spaces survives, and none is left padded at either end
+    assert not [label for label in labels if "  " in label]
+    assert all(label == label.strip() for label in labels)
+    # the collapse must join the parts rather than delete the separator ('s4d  1D' -> 's4d 1D')
+    assert any(" " in label for label in labels)
+
+
 def test_get_level_valence_n():
     """Each reader's level names yield the valence electron's principal quantum number."""
     # each handler has its own level-name format and parser

--- a/tests/kurucz/checksums.txt
+++ b/tests/kurucz/checksums.txt
@@ -1,4 +1,4 @@
-9cae2dd6603cc10f435801ab19cc1540  adata.txt
+efc5644f7aa07c9db623e60508078837  adata.txt
 628baa697db7a5044ce19088e9000efc  compositiondata.txt
-d3422ff89fbb5648449f91589eb7101c  phixsdata_v2.txt
+fb75c883ba818de33837627c764bbd91  phixsdata_v2.txt
 05f8f2c2cd1292cdbfd3902f2b0f12ec  transitiondata.txt


### PR DESCRIPTION
Follow-up to #75 with the output-changing item that was deliberately left out of it.

## The bug

`parse_gfall()` cleaned its labels with

```python
pl.col("label_lower").str.strip_chars().replace(r"\s+", " ")
```

`Expr.replace()` swaps whole values equal to a literal — it is not the string namespace, and it does not take a pattern. So this matched only a label that was exactly `\s+`, i.e. never. The gfall columns are fixed-width padded, so 22–28 of each ion's labels kept their internal runs and carried them into the level names in `adata.txt`:

```
    2  1.7700456548119703    1.000    1 s5p  3P,enpercm=14276.381,j=0.0
```

`str.replace_all()` is the one that takes a pattern.

## It was not only cosmetic

`get_level_valence_n()` splits the level name on single spaces after collapsing *double* ones, so a **three**-space label (`'d5d   1G'`) left an empty field, fell through to the `n = 1` fallback and printed a warning. Five Sr/Y levels hit this.

One of them matters: **Y I level 94** is a non-top-ion level below its ionization energy, so it gets a hydrogenic cross section — and that was being built for `n = 1` instead of `n = 5`:

| | before | after |
| --- | --- | --- |
| threshold σ | 5.207e+01 Mb | 1.026e+01 Mb |

A factor of 5, which is exactly the `1/n` of the Kramers scaling in `get_hydrogenic_n_phixstable()`, so the new value is the correct one for a 5d orbital. The other four re-parsed levels are in a top ion or above the ionization energy and produce no table.

I left the `.replace("  ", " ")` in `get_level_valence_n()` alone — it is now redundant for Kurucz names but harmless, and removing it would only make the parser more brittle.

## Checksums

Only `tests/kurucz` moves, and only two of its files:

- `adata.txt` — level-name comments only. I checked field by field: `levelid`, energy, `g` and transition count are **byte-identical**, and the file is the same 548 lines.
- `phixsdata_v2.txt` — exactly one of the 152 tables, the Y I level above. Same 152 keys before and after.

`floers25`, `jplt`, `qub` and `cmfgen` are untouched. All five sets were regenerated from clean and verify.

## Also

A comment recording why the neighbouring `readtanakajpltdata` `select()` is *correct*, since it looks like the same class of bug: its `levelname` reads the input frame's `parity` text rather than the 0/1 being computed beside it. I checked the raw files — `read_fwf()` has already stripped that text, so the names are the intended `52,odd,{...}` and need no change. Without the note someone would eventually "fix" it and move the jplt checksums for nothing.

## Testing

`test_parse_gfall_collapses_label_whitespace` asserts no run survives and that the collapse joins rather than deletes. Verified to fail against the old code:

```
E  AssertionError: assert not ['10p  1P', 's4d  3D', 's6d  1D', '7s  3S', ...]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)