### PR TITLE
Speed up the build: 33s to 11.5s on the cmfgen set

### DIFF
--- a/artisatomic/base.py
+++ b/artisatomic/base.py
@@ -1,5 +1,6 @@
 """Element data, physical constants, and small utilities shared by the data-source readers."""
 
+import atexit
 import contextlib
 import itertools
 import multiprocessing as mp
@@ -7,6 +8,7 @@ import sys
 import typing as t
 from collections.abc import Callable
 from collections.abc import Iterable
+from concurrent.futures import ProcessPoolExecutor
 from functools import lru_cache
 from pathlib import Path
 
@@ -232,6 +234,27 @@ def get_nist_ionization_energies_ev() -> dict[tuple[int, int], float]:
     return dictioniz
 
 
+_process_pool: ProcessPoolExecutor | None = None
+
+
+def get_process_pool() -> ProcessPoolExecutor:
+    """Get the one process pool for the whole run, creating it on first use.
+
+    Building a pool costs about 0.6 s however small the batch, because "spawn" makes every worker
+    re-import this package and its numpy/polars/pandas dependencies. A build asks for one pool per
+    ion per photoionisation file, so a pool per call spent most of its time starting up. Peak
+    memory is unchanged (the same workers, alive for longer).
+    """
+    global _process_pool
+    if _process_pool is None:
+        # an explicit spawn context rather than mp.set_start_method(force=True), which reached
+        # outside this function to change the default for the whole process
+        _process_pool = ProcessPoolExecutor(mp_context=mp.get_context("spawn"))
+        atexit.register(_process_pool.shutdown, wait=False, cancel_futures=True)
+
+    return _process_pool
+
+
 def parallel_map[ResultType](
     fn: Callable[..., ResultType],
     *iterables: Iterable[t.Any],
@@ -246,24 +269,25 @@ def parallel_map[ResultType](
     lists = [list(iterable) for iterable in iterables]
     nitems = min((len(x) for x in lists), default=0)
 
-    # Spawning a process pool costs a few hundred ms, because "spawn" makes every worker re-import
-    # the package. That dwarfs a handful of cross-section tables (readqubdata reduces four at a
-    # time), so do small batches in this process.
+    # even with the pool already up, handing a handful of items to it costs more in IPC than doing
+    # them here (readqubdata reduces four cross-section tables at a time)
     if nitems <= 32:
         return list(itertools.starmap(fn, zip(*lists, strict=True)))
 
-    if use_multiprocessing:
-        mp.set_start_method("spawn", force=True)
-        from tqdm.contrib.concurrent import process_map
+    # without a chunk size, items go to the workers one at a time and the IPC per item costs more
+    # than the work; tqdm warns about it above 1000 items
+    chunksize = kwargs.pop("chunksize", max(1, nitems // (mp.cpu_count() * 4)))
 
-        # without this, items are handed to the workers one at a time and the IPC per item costs
-        # more than the work; tqdm warns about it above 1000 items
-        kwargs.setdefault("chunksize", max(1, nitems // (mp.cpu_count() * 4)))
-        results = process_map(fn, *lists, **kwargs)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
+    if use_multiprocessing:
+        from tqdm import tqdm
+
+        results = list(
+            tqdm(get_process_pool().map(fn, *lists, chunksize=chunksize), total=nitems, **kwargs)  # ty:ignore[no-matching-overload]
+        )
     else:
         from tqdm.contrib.concurrent import thread_map
 
-        results = thread_map(fn, *lists, **kwargs)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
+        results = thread_map(fn, *lists, chunksize=chunksize, **kwargs)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
 
     assert isinstance(results, list)
     return results

--- a/artisatomic/base.py
+++ b/artisatomic/base.py
@@ -1,6 +1,7 @@
 """Element data, physical constants, and small utilities shared by the data-source readers."""
 
 import contextlib
+import itertools
 import multiprocessing as mp
 import sys
 import typing as t
@@ -169,9 +170,14 @@ def path_for_log(filepath: str | Path) -> str:
 
 
 def isfloat(value: t.Any) -> bool:
-    """Whether a string parses as a float, accepting Fortran's D exponent (1.5D-3)."""
+    """Whether a string parses as a float, accepting Fortran's D exponent (1.5D-3).
+
+    Called once per field of every line of the CMFGEN oscillator files (5.3M times for the cmfgen
+    test set), so the replace() is done only when there is a D to replace rather than allocating
+    a copy of every field.
+    """
     try:
-        float(value.replace("D", "E"))
+        float(value.replace("D", "E") if "D" in value else value)
     except ValueError:
         return False
 
@@ -235,15 +241,29 @@ def parallel_map[ResultType](
     # use a thread pool if we have no GIL (free threading)
     use_multiprocessing = sys._is_gil_enabled()  # ruff: ignore[private-member-access]
 
+    # materialise so the work can be sized: the chunk size and the serial cutoff below both need
+    # a length, and the callers pass views and generators
+    lists = [list(iterable) for iterable in iterables]
+    nitems = min((len(x) for x in lists), default=0)
+
+    # Spawning a process pool costs a few hundred ms, because "spawn" makes every worker re-import
+    # the package. That dwarfs a handful of cross-section tables (readqubdata reduces four at a
+    # time), so do small batches in this process.
+    if nitems <= 32:
+        return list(itertools.starmap(fn, zip(*lists, strict=True)))
+
     if use_multiprocessing:
         mp.set_start_method("spawn", force=True)
         from tqdm.contrib.concurrent import process_map
 
-        results = process_map(fn, *iterables, **kwargs)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
+        # without this, items are handed to the workers one at a time and the IPC per item costs
+        # more than the work; tqdm warns about it above 1000 items
+        kwargs.setdefault("chunksize", max(1, nitems // (mp.cpu_count() * 4)))
+        results = process_map(fn, *lists, **kwargs)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
     else:
         from tqdm.contrib.concurrent import thread_map
 
-        results = thread_map(fn, *iterables, **kwargs)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
+        results = thread_map(fn, *lists, **kwargs)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
 
     assert isinstance(results, list)
     return results

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -357,8 +357,9 @@ def write_phixs_data(
                 )
                 raise ValueError(msg)
 
-        for crosssection in photoionization_crosssections[lowerlevelid]:
-            fphixs.write(f"{crosssection:16.8E}\n")
+        # one writelines() per table rather than a write() per point: nphixspoints lines per level,
+        # 1.5M of them for the cmfgen set
+        fphixs.writelines(f"{crosssection:16.8E}\n" for crosssection in photoionization_crosssections[lowerlevelid])
 
     if skipped_no_threshold > 0:
         log_and_print(

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -123,16 +123,26 @@ def write_output_files(atomic_number: int, iondatalist: list[IonData], args: arg
                 dftransitions_ion = pl.concat([dftransitions_ion, dfupsilon_only_transitions], how="diagonal_relaxed")
 
             if not dftransitions_ion.is_empty():
-                dftransitions_ion = dftransitions_ion.with_columns(
-                    pl.struct(["lowerlevel", "upperlevel", "forbidden"])
-                    .map_elements(
-                        lambda row, upsilondict=upsilondict: upsilondict.get(  # type: ignore[misc]
-                            (row["lowerlevel"], row["upperlevel"]),
-                            -2.0 if row["forbidden"] else -1.0,
-                        ),
-                        return_dtype=pl.Float64,
+                # a left join rather than a per-row map_elements(): this runs over every
+                # transition of the ion (2.6M of them for the cmfgen set), where a Python callback
+                # per row costs more than the whole rest of the write. upsilondict's keys are
+                # unique, so the join cannot duplicate rows, and maintain_order keeps the frame in
+                # the order the reader produced it.
+                dfupsilon = pl.DataFrame(
+                    [(lower, upper, upsilon) for (lower, upper), upsilon in upsilondict.items()],
+                    schema={"lowerlevel": pl.Int64, "upperlevel": pl.Int64, "upsilon": pl.Float64},
+                    orient="row",
+                )
+                dftransitions_ion = (
+                    dftransitions_ion.with_columns(
+                        pl.col("lowerlevel").cast(pl.Int64), pl.col("upperlevel").cast(pl.Int64)
                     )
-                    .alias("coll_str")
+                    .join(dfupsilon, on=["lowerlevel", "upperlevel"], how="left", maintain_order="left")
+                    .with_columns(
+                        # no upsilon for this transition: -2 marks it forbidden, -1 unknown
+                        coll_str=pl.col("upsilon").fill_null(pl.when(pl.col("forbidden")).then(-2.0).otherwise(-1.0))
+                    )
+                    .drop("upsilon")
                 )
 
             with (outdir / "adata.txt").open("a", encoding="utf-8") as fatommodels:
@@ -246,13 +256,15 @@ def write_transition_data(
     ftransitiondata.write(f"{atomic_number:7d}{ion_stage:7d}{dftransitions_ion.height:12d}\n")
 
     if not dftransitions_ion.is_empty():
-        for levelid_lower, levelid_upper, A, coll_str, forbidden in dftransitions_ion[
-            ["lowerlevel", "upperlevel", "A", "coll_str", "forbidden"]
-        ].iter_rows():
-            # level ids are zero-based in memory, but the output format numbers them from one
-            ftransitiondata.write(
-                f"{levelid_lower + 1:4d} {levelid_upper + 1:4d} {float(A):11.5e} {coll_str:9.2e} {forbidden:d}\n"
-            )
+        # writelines() over a generator, not a write() per row: this loop runs 2.6M times for the
+        # cmfgen set, where the per-call overhead is a measurable part of the whole run
+        # level ids are zero-based in memory, but the output format numbers them from one
+        ftransitiondata.writelines(
+            f"{levelid_lower + 1:4d} {levelid_upper + 1:4d} {float(A):11.5e} {coll_str:9.2e} {forbidden:d}\n"
+            for levelid_lower, levelid_upper, A, coll_str, forbidden in dftransitions_ion[
+                ["lowerlevel", "upperlevel", "A", "coll_str", "forbidden"]
+            ].iter_rows()
+        )
 
     ftransitiondata.write("\n")
 

--- a/artisatomic/phixs.py
+++ b/artisatomic/phixs.py
@@ -1,13 +1,10 @@
 """Downsample photoionization cross-section tables and estimate hydrogenic ones where none exist."""
 
-import math
 from functools import partial
 
 import numpy as np
 import numpy.typing as npt
 import polars as pl
-from scipy import integrate  # pyright: ignore[reportMissingTypeStubs]
-from scipy import interpolate  # pyright: ignore[reportMissingTypeStubs]
 
 from artisatomic import readfacdata
 from artisatomic import readfloers25data
@@ -132,12 +129,7 @@ def reduce_phixs_tables_worker(
     """
     ryd_to_hz = 3289841960250880.5
     h_over_kb_in_K_sec = 4.799243073366221e-11
-
-    def integrand(nu):
-        """Weight for averaging the cross section: proportional to the recombination rate."""
-        return (nu**2) * math.exp(-h_over_kb_in_K_sec * nu / optimaltemperature)
-
-    integrand_vec = np.vectorize(integrand)
+    minus_h_over_kb_t = -h_over_kb_in_K_sec / optimaltemperature
 
     xgrid = np.linspace(1.0, 1.0 + phixsnuincrement * (nphixspoints + 1), num=nphixspoints + 1, endpoint=False)
 
@@ -147,69 +139,81 @@ def reduce_phixs_tables_worker(
         return np.zeros(nphixspoints)
 
     threshold_old_ryd = tablein[0][0]
-    # tablein is an array of pairs (energy, phixs cross section)
+    # tablein is an array of pairs (energy, phixs cross section). Split once: the loop below reads
+    # both columns per output point, and a strided view of a 2D array is re-sliced every time.
+    tablein_energyryd = np.ascontiguousarray(tablein[:, 0])
+    tablein_sigma = np.ascontiguousarray(tablein[:, 1])
+    table_energy_last = tablein_energyryd[-1]
+    table_sigma_last = tablein_sigma[-1]
 
     arr_sigma_out = np.empty(nphixspoints)
     # x is nu/nu_edge
 
-    sigma_interp = interpolate.interp1d(tablein[:, 0], tablein[:, 1], kind="linear", assume_sorted=True)
+    # the interval edges depend only on the grid, so compute all of them at once
+    arr_enlow = 0.5 * (xgrid[np.maximum(np.arange(nphixspoints) - 1, 0)] + xgrid[:-1]) * threshold_old_ryd
+    arr_enhigh = 0.5 * (xgrid[:-1] + xgrid[1:]) * threshold_old_ryd
+    # the table is sorted by energy (interp1d was called with assume_sorted), so each interval's
+    # slice can be bisected rather than rebuilding a boolean mask over the whole column per point
+    arr_startindex = np.searchsorted(tablein_energyryd, arr_enlow, side="left")
+    arr_endindex = np.searchsorted(tablein_energyryd, arr_enhigh, side="right")
 
-    for i, _ in enumerate(xgrid[:-1]):
-        iprevious = max(i - 1, 0)
-        enlow = 0.5 * (xgrid[iprevious] + xgrid[i]) * threshold_old_ryd
-        enhigh = 0.5 * (xgrid[i] + xgrid[i + 1]) * threshold_old_ryd
+    for i in range(nphixspoints):
+        enlow = arr_enlow[i]
+        enhigh = arr_enhigh[i]
 
         # start of interval interpolated point, input data points, and end of interval interpolated point
-        samples_in_interval = tablein[(enlow <= tablein[:, 0]) & (tablein[:, 0] <= enhigh)]
+        sample_energyryd = tablein_energyryd[arr_startindex[i] : arr_endindex[i]]
+        sample_sigma = tablein_sigma[arr_startindex[i] : arr_endindex[i]]
 
-        if len(samples_in_interval) == 0 or ((samples_in_interval[0, 0] - enlow) / enlow) > 1e-20:
-            if i == 0 and len(samples_in_interval) != 0:
+        if len(sample_energyryd) == 0 or ((sample_energyryd[0] - enlow) / enlow) > 1e-20:
+            if i == 0 and len(sample_energyryd) != 0:
                 print(
-                    f"adding first point {enlow:.4e} {samples_in_interval[0, 0]:.4e} {(samples_in_interval[0, 0] - enlow) / enlow:.4e}"
+                    f"adding first point {enlow:.4e} {sample_energyryd[0]:.4e} {(sample_energyryd[0] - enlow) / enlow:.4e}"
                 )
-            if enlow <= tablein[-1][0]:
-                new_crosssection = sigma_interp(enlow)
+            if enlow <= table_energy_last:
+                # np.interp, not scipy's interp1d: identical linear interpolation (verified
+                # bit-for-bit) without a scipy call per interval edge
+                new_crosssection = np.interp(enlow, tablein_energyryd, tablein_sigma)
                 if new_crosssection < 0:
                     print("negative extrap")
             else:
                 # assume power law decay after last point
-                new_crosssection = tablein[-1][1] * (tablein[-1][0] / enlow) ** 3
-            samples_in_interval = np.vstack([[enlow, new_crosssection], samples_in_interval])
+                new_crosssection = table_sigma_last * (table_energy_last / enlow) ** 3
+            sample_energyryd = np.concatenate(([enlow], sample_energyryd))
+            sample_sigma = np.concatenate(([new_crosssection], sample_sigma))
 
-        if (
-            len(samples_in_interval) == 0
-            or ((enhigh - samples_in_interval[-1, 0]) / samples_in_interval[-1, 0]) > 1e-20
-        ):
-            if enhigh <= tablein[-1][0]:
-                new_crosssection = sigma_interp(enhigh)
+        if ((enhigh - sample_energyryd[-1]) / sample_energyryd[-1]) > 1e-20:
+            if enhigh <= table_energy_last:
+                new_crosssection = np.interp(enhigh, tablein_energyryd, tablein_sigma)
                 if new_crosssection < 0:
                     print("negative extrap")
             else:
                 new_crosssection = (
-                    tablein[-1][1] * (tablein[-1][0] / enhigh) ** 3
+                    table_sigma_last * (table_energy_last / enhigh) ** 3
                 )  # assume power law decay after last point
 
-            samples_in_interval = np.vstack([samples_in_interval, [enhigh, new_crosssection]])
+            sample_energyryd = np.concatenate((sample_energyryd, [enhigh]))
+            sample_sigma = np.concatenate((sample_sigma, [new_crosssection]))
 
-        nsamples = len(samples_in_interval)
+        nsamples = len(sample_energyryd)
 
-        if nsamples >= 50 or enlow > tablein[-1][0]:
-            arr_energyryd = samples_in_interval[:, 0]
-            arr_sigma_megabarns = samples_in_interval[:, 1]
+        if nsamples >= 50 or enlow > table_energy_last:
+            arr_energyryd = sample_energyryd
+            arr_sigma_megabarns = sample_sigma
         else:
             nsteps = 50  # was 500
             arr_energyryd = np.linspace(enlow, enhigh, num=nsteps, endpoint=False)
-            arr_sigma_megabarns = np.interp(arr_energyryd, tablein[:, 0], tablein[:, 1])
-        assert isinstance(arr_sigma_megabarns, np.ndarray)
+            arr_sigma_megabarns = np.interp(arr_energyryd, tablein_energyryd, tablein_sigma)
 
-        integrand_vals = integrand_vec(arr_energyryd * ryd_to_hz)
+        # the recombination-rate weight nu^2 exp(-h nu / k T), evaluated over the whole interval at
+        # once. np.vectorize() called math.exp() once per sample, which dominated this function.
+        arr_nu = arr_energyryd * ryd_to_hz
+        integrand_vals = arr_nu**2 * np.exp(minus_h_over_kb_t * arr_nu)
         if np.any(integrand_vals):
-            sigma_integrand_vals = [
-                sigma * integrand_val for sigma, integrand_val in zip(arr_sigma_megabarns, integrand_vals, strict=True)
-            ]
+            sigma_integrand_vals = arr_sigma_megabarns * integrand_vals
 
-            integralnosigma = integrate.trapezoid(integrand_vals, arr_energyryd)
-            integralwithsigma = integrate.trapezoid(sigma_integrand_vals, arr_energyryd)
+            integralnosigma = np.trapezoid(integrand_vals, arr_energyryd)
+            integralwithsigma = np.trapezoid(sigma_integrand_vals, arr_energyryd)
 
         else:
             integralnosigma = 1.0
@@ -221,7 +225,7 @@ def reduce_phixs_tables_worker(
             arr_sigma_out[i] = 0.0
         else:
             print("Math error: ", i, nsamples, integralwithsigma, integralnosigma)
-            print(samples_in_interval)
+            print(np.column_stack([sample_energyryd, sample_sigma]))
             arr_sigma_out[i] = 0.0
 
     return arr_sigma_out

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -488,7 +488,12 @@ def read_levels_and_transitions(
             linesplitdash = line.split("-")
             row = (linesplitdash[0] + " " + "-".join(linesplitdash[1:-1]) + " " + linesplitdash[-1]).split()
 
-            if (len(row) == 8 or (len(row) >= 10 and row[-1] == "|")) and all(map(artisatomic.isfloat, row[2:4])):
+            # the two isfloat() calls are spelled out rather than all(map(...)) over a slice: this
+            # runs for every transition line of every ion (2.6M for the cmfgen set), where
+            # building a slice, a map object and an all() call per line is most of the test
+            if (len(row) == 8 or (len(row) >= 10 and row[-1] == "|")) and (
+                artisatomic.isfloat(row[2]) and artisatomic.isfloat(row[3])
+            ):
                 try:
                     lambda_value = float(row[4])
                 except ValueError:
@@ -633,7 +638,12 @@ def read_phixs_tables(
             for line in fhillierphot:
                 row = line.split()
 
-                if len(row) >= 2 and " ".join(row[-4:]) == "!Final state in ion":
+                # Every marker below is a trailing "!..." comment, so a line with no '!' at all
+                # cannot match any of them. 94% of a phot file is two-column cross-section data,
+                # and testing that once here skips seven " ".join() calls per such line.
+                has_marker = "!" in line
+
+                if has_marker and len(row) >= 2 and " ".join(row[-4:]) == "!Final state in ion":
                     # this is not used because the upper ion's levels are not known at this time
                     targetlevelname = row[0]
                     artisatomic.log_and_print(flog, "Photoionisation target: " + targetlevelname)
@@ -645,7 +655,7 @@ def read_phixs_tables(
                         sys.exit(1)
                     phixstargets[filenum] = targetlevelname
 
-                if len(row) >= 2 and " ".join(row[-3:]) == "!Split J levels":
+                if has_marker and len(row) >= 2 and " ".join(row[-3:]) == "!Split J levels":
                     if row[0].lower() == "true":
                         j_splitting_on = True
                         artisatomic.log_and_print(flog, "File specifies J-splitting enabled")
@@ -658,9 +668,10 @@ def read_phixs_tables(
                         print(f'STOP! J-splitting not true or false: "{row[0]}"')
                         sys.exit(1)
 
-                if (len(row) >= 2 and " ".join(row[-2:]) == "!Configuration name") or " ".join(
-                    row[-3:]
-                ) == "!Configuration name [*]":
+                if has_marker and (
+                    (len(row) >= 2 and " ".join(row[-2:]) == "!Configuration name")
+                    or " ".join(row[-3:]) == "!Configuration name [*]"
+                ):
                     lowerlevelname = row[0]
                     # with J splitting the name (including any [J] suffix) maps to exactly one
                     # level; without it, strip the suffix so the table covers the configuration
@@ -682,7 +693,7 @@ def read_phixs_tables(
                         print("ERROR: no upper level name")
                         sys.exit(1)
 
-                if len(row) >= 2 and " ".join(row[-3:]) == "!Screened nuclear charge":
+                if has_marker and len(row) >= 2 and " ".join(row[-3:]) == "!Screened nuclear charge":
                     # CMFGEN's ZION comes from the oscillator file: RDPHOT_GEN_V2 never reads
                     # this field, and the two disagree for 29 shipped files. Keep ion_stage (which
                     # matches the oscillator value for every ion in ions_data) and just report it.
@@ -694,15 +705,22 @@ def read_phixs_tables(
                             f" which disagrees with ion_stage {ion_stage}",
                         )
 
-                if len(row) >= 2 and " ".join(row[1:]) == "!Number of cross-section points":
+                if has_marker and len(row) >= 2 and " ".join(row[1:]) == "!Number of cross-section points":
                     numpointsexpected = int(row[0])
                     pointnumber = 0
 
-                if len(row) >= 2 and " ".join(row[1:]) == "!Cross-section unit" and row[0] != "Megabarns":
+                if (
+                    has_marker
+                    and len(row) >= 2
+                    and " ".join(row[1:]) == "!Cross-section unit"
+                    and row[0] != "Megabarns"
+                ):
                     print(f"Wrong cross-section unit: {row[0]}")
                     sys.exit(1)
 
-                row_is_all_floats = all(map(artisatomic.isfloat, row))
+                # a line carrying a "!..." marker has text in it, so it can never be all floats.
+                # Short-circuiting on that skips the parse attempt on every header line.
+                row_is_all_floats = not has_marker and all(map(artisatomic.isfloat, row))
                 if crosssectiontype == 0:
                     if len(row) == 1 and row_is_all_floats and numpointsexpected > 0:
                         fitcoefficients.append(float(row[0].replace("D", "E")))
@@ -858,7 +876,7 @@ def read_phixs_tables(
                     lowerlevelname = ""
                     numpointsexpected = 0
 
-                if len(row) >= 2 and " ".join(row[1:]) == "!Type of cross-section":
+                if has_marker and len(row) >= 2 and " ".join(row[1:]) == "!Type of cross-section":
                     crosssectiontype = int(row[0])
                     phixs_type_levels[crosssectiontype].add(lowerlevelname)
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1,6 +1,5 @@
 """Read levels, transitions, collision strengths and cross sections from Hillier's CMFGEN data."""
 
-import math
 import os
 import sys
 import typing as t
@@ -1025,36 +1024,36 @@ def get_seaton_phixstable(lambda_angstrom, sigmat, beta, s, nu_o=None):
     so the cross section is zero until the offset threshold.
     """
     energygrid = np.arange(0, 1.0, 0.001)
-    phixstable = np.empty((len(energygrid), 2))
 
     thresholdenergyryd = hc_in_ev_angstrom / lambda_angstrom / ryd_to_ev
 
-    for index, c in enumerate(energygrid):
-        energy_div_threshold = 1 + 20 * (c**2)
+    energy_div_threshold = 1 + 20 * (energygrid**2)
 
-        if nu_o is None:
-            threshold_div_energy = energy_div_threshold**-1
-            crosssection = sigmat * (beta + (1 - beta) * threshold_div_energy) * (threshold_div_energy**s)
-        else:
-            # type 7
-            # include Christian Vogl's python adaption of CMFGEN sub_phot_gen.f:
-            # Altered 07-Oct-2015 : Bug fix for Type 7 (modified Seaton formula).
-            #                       Offset was being added to the current frequency instead
-            #                       of the ionization edge.
+    if nu_o is None:
+        threshold_div_energy = energy_div_threshold**-1
+        crosssection = sigmat * (beta + (1 - beta) * threshold_div_energy) * (threshold_div_energy**s)
+    else:
+        # type 7
+        # include Christian Vogl's python adaption of CMFGEN sub_phot_gen.f:
+        # Altered 07-Oct-2015 : Bug fix for Type 7 (modified Seaton formula).
+        #                       Offset was being added to the current frequency instead
+        #                       of the ionization edge.
 
-            threshold_energy_ev = hc_in_ev_angstrom / lambda_angstrom
-            offset_threshold_div_energy = (energy_div_threshold**-1) * (
-                1 + (nu_o * 1e15 * h_in_ev_seconds) / threshold_energy_ev
-            )
+        threshold_energy_ev = hc_in_ev_angstrom / lambda_angstrom
+        offset_threshold_div_energy = (energy_div_threshold**-1) * (
+            1 + (nu_o * 1e15 * h_in_ev_seconds) / threshold_energy_ev
+        )
 
-            crosssection = (
-                sigmat * (beta + (1 - beta) * offset_threshold_div_energy) * offset_threshold_div_energy**s
-                if offset_threshold_div_energy < 1.0
-                else 0.0
-            )
+        # the cross section is zero until the offset edge is reached. np.where evaluates both
+        # arms, which is safe here: the ratio is positive everywhere, so the discarded arm has
+        # no domain error to raise.
+        crosssection = np.where(
+            offset_threshold_div_energy < 1.0,
+            sigmat * (beta + (1 - beta) * offset_threshold_div_energy) * offset_threshold_div_energy**s,
+            0.0,
+        )
 
-        phixstable[index] = energy_div_threshold * thresholdenergyryd, crosssection
-    return phixstable
+    return np.column_stack([energy_div_threshold * thresholdenergyryd, crosssection])
 
 
 # test: for n = 5, l_start = 4, l_end = 4 (2s2_5g_2Ge level of C II)
@@ -1139,25 +1138,22 @@ def get_hydrogenic_n_phixstable(lambda_angstrom, n):
     Returns (energy in Rydberg, cross section in Megabarns) pairs. The Kramers scale factor
     already accounts for the effective charge, so the result must not be rescaled by the caller.
     """
-    energygrid = hyd_gaunt_energygrid_ryd[n]
-    phixstable = np.empty((len(energygrid), 2))
+    energygrid = np.asarray(hyd_gaunt_energygrid_ryd[n])
 
     thresholdenergyev = hc_in_ev_angstrom / lambda_angstrom
     thresholdenergyryd = thresholdenergyev / ryd_to_ev
 
     scale_factor = 7.91 / thresholdenergyryd / n
 
-    for index, energy_ryd in enumerate(energygrid):
-        energydivthreshold = energy_ryd / energygrid[0]
+    energydivthreshold = energygrid / energygrid[0]
 
-        crosssection = (
-            scale_factor * hyd_gaunt_factor[n][index] / energydivthreshold**3 if energydivthreshold > 0 else 0.0
-        )
+    crosssection = np.where(
+        energydivthreshold > 0,
+        scale_factor * np.asarray(hyd_gaunt_factor[n]) / energydivthreshold**3,
+        0.0,
+    )
 
-        phixstable[index][0] = energydivthreshold * thresholdenergyryd  # / ryd_to_ev
-        phixstable[index][1] = crosssection
-
-    return phixstable
+    return np.column_stack([energydivthreshold * thresholdenergyryd, crosssection])
 
 
 # Peach, Saraph, and Seaton (1988)
@@ -1167,23 +1163,19 @@ def get_opproject_phixstable(lambda_angstrom, a, b, c, d, e):
     Returns (energy in Rydberg, cross section in Megabarns) pairs.
     """
     energygrid = np.arange(0, 1.0, 0.001)
-    phixstable = np.empty((len(energygrid), 2))
 
     thresholdenergyryd = hc_in_ev_angstrom / lambda_angstrom / ryd_to_ev
 
-    for index, cb in enumerate(energygrid):
-        energydivthreshold = 1 + 20 * (cb**2)
-        u = energydivthreshold
+    energydivthreshold = 1 + 20 * (energygrid**2)
+    u = energydivthreshold
 
-        x = math.log10(min(u, e))
+    x = np.log10(np.minimum(u, e))
 
-        crosssection = 10 ** (a + x * (b + x * (c + x * d)))
-        if u > e:
-            crosssection *= (e / u) ** 2
+    crosssection = 10 ** (a + x * (b + x * (c + x * d)))
+    # above the break the fit is continued with a 1/u^2 tail
+    crosssection = np.where(u > e, crosssection * (e / u) ** 2, crosssection)
 
-        phixstable[index] = energydivthreshold * thresholdenergyryd, crosssection
-
-    return phixstable
+    return np.column_stack([energydivthreshold * thresholdenergyryd, crosssection])
 
 
 # only applies to helium
@@ -1196,20 +1188,16 @@ def get_hummer_phixstable(lambda_angstrom, a, b, c, d, e, f, g, h):  # ruff: ign
     below the break at e, a straight line above it.
     """
     energygrid = np.arange(0, 1.0, 0.001)
-    phixstable = np.empty((len(energygrid), 2))
 
     thresholdenergyryd = hc_in_ev_angstrom / lambda_angstrom / ryd_to_ev
 
-    for index, c_en in enumerate(energygrid):
-        energydivthreshold = 1 + 20 * (c_en**2)
+    energydivthreshold = 1 + 20 * (energygrid**2)
 
-        x = math.log10(energydivthreshold)
+    x = np.log10(energydivthreshold)
 
-        crosssection = 10 ** (((d * x + c) * x + b) * x + a) if x < e else 10 ** (f + g * x)
+    crosssection = np.where(x < e, 10 ** (((d * x + c) * x + b) * x + a), 10 ** (f + g * x))
 
-        phixstable[index] = energydivthreshold * thresholdenergyryd, crosssection
-
-    return phixstable
+    return np.column_stack([energydivthreshold * thresholdenergyryd, crosssection])
 
 
 def get_vy95_phixstable(lambda_angstrom, fitcoefficients):
@@ -1221,29 +1209,27 @@ def get_vy95_phixstable(lambda_angstrom, fitcoefficients):
     eV divided by E_0, and each shell after the first is gated on FREQ >= EV_TO_HZ * E_th_eV.
     """
     energygrid = np.arange(0, 1.0, 0.001)
-    phixstable = np.empty((len(energygrid), 2))
     thresholdenergyev = hc_in_ev_angstrom / lambda_angstrom
     thresholdenergyryd = thresholdenergyev / ryd_to_ev
 
-    for index, c in enumerate(energygrid):
-        energydivthreshold = 1 + 20 * (c**2)
-        energy_ev = energydivthreshold * thresholdenergyev
+    energydivthreshold = 1 + 20 * (energygrid**2)
+    energy_ev = energydivthreshold * thresholdenergyev
 
-        crosssection = 0.0
-        for shellnum, params in enumerate(fitcoefficients):
-            # the first shell starts at the level's own ionization edge, later (inner) shells
-            # only contribute above their own threshold
-            if shellnum > 0 and energy_ev < params.E_th_eV:
-                continue
-            y = energy_ev / params.E_0
-            P = params.P
-            Q = 5.5 + params.l - 0.5 * params.P
-            y_a = params.y_a
-            y_w = params.y_w
-            crosssection += params.sigma_0 * ((y - 1) ** 2 + y_w**2) * (y**-Q) * ((1 + math.sqrt(y / y_a)) ** -P)
+    crosssection = np.zeros(len(energygrid))
+    for shellnum, params in enumerate(fitcoefficients):
+        y = energy_ev / params.E_0
+        P = params.P
+        Q = 5.5 + params.l - 0.5 * params.P
+        y_a = params.y_a
+        y_w = params.y_w
+        shellcrosssection = params.sigma_0 * ((y - 1) ** 2 + y_w**2) * (y**-Q) * ((1 + np.sqrt(y / y_a)) ** -P)
+        # the first shell starts at the level's own ionization edge, later (inner) shells
+        # only contribute above their own threshold
+        if shellnum > 0:
+            shellcrosssection = np.where(energy_ev < params.E_th_eV, 0.0, shellcrosssection)
+        crosssection += shellcrosssection
 
-        phixstable[index] = energydivthreshold * thresholdenergyryd, crosssection
-    return phixstable
+    return np.column_stack([energydivthreshold * thresholdenergyryd, crosssection])
 
 
 def read_coldata(atomic_number, ion_stage, dfenergy_levels: pl.DataFrame, flog, args):


### PR DESCRIPTION
The `cmfgen` test set drops from **33.0s to 11.5s** — a **2.9x** speedup — with all five `tests/*/` sets **byte-identical**. Medians of 3 runs each, baseline re-measured back to back on the same machine rather than reused, since this box has variable load.

| | before | after |
| --- | --- | --- |
| cmfgen run | 33.0s | **11.5s** |
| `test cmfgen` CI job | 1m 26s | **1m 4s** |

A caveat on that CI row: almost all of it came from the phixs and parsing work. The shared-pool change is worth ~8s locally on a 14-core machine but only about a second on the CI runner, which has far fewer cores — fewer workers to spawn per pool, and less parallel speedup to buy in the first place. The job also carries fixed checkout, `uv sync` and data-extraction costs that no code change touches.

Every step was chosen by measuring, not guessing. `--nophixs` split the run into a ~21s photoionisation half and a ~9.6s read/write half, and profiling picked the targets in each.

## 1. One process pool instead of eleven

The largest single win. Timing `reduce_phixs_tables()` against batches of 40 and 200 tables gave **the same 0.6s of overhead either way** — so it was not the work, it was building the pool: `"spawn"` makes each of 14 workers re-import the package and its numpy/polars/pandas dependencies.

A build asks for one pool per ion per photoionisation file. For this set that is 11 calls, of batch sizes `5, 107, 383, 417, 444, 499, 557, 567, 1037, 2112, 2324`, so most of that time was startup. `parallel_map()` now builds the pool once and reuses it. Peak memory is unchanged — the same workers, held for longer.

That also let the explicit spawn context replace `mp.set_start_method(force=True)`, which reached outside the function to change the default for the whole process.

## 2. The phixs downsampling worker: 4.2ms → 1.4ms per table

Called once per table, 8452 times. It ran a Python loop per output point:

- `np.vectorize()` calling `math.exp()` once per sample → one array expression
- a boolean mask over the entire energy column, rebuilt 100 times per table → `np.searchsorted` (the column was already assumed sorted — `interp1d` was being passed `assume_sorted=True`)
- `scipy.interpolate.interp1d` called once per interval edge → `np.interp`
- the `sigma * weight` product built as a Python list via `zip()`, and an `np.vstack` per interval → array ops on the two columns, split out once

The five analytic fit evaluators (Seaton, Opacity Project, Hummer, Verner & Yakovlev, hydrogenic n) each ran a **1000-iteration Python loop per level** to build those tables; now array expressions.

`parallel_map` also passed no `chunksize`, so items went to workers one at a time — tqdm warns about this above 1000 items.

## 3. CMFGEN parsing

- `read_phixs_tables()` ran **seven** `" ".join(row[...]) == "!..."` comparisons on every line. 94% of a phot file is two-column data with no `!` in it (50052 of 53344 lines for Fe II), and such a line cannot match any of them, so one `"!" in line` test skips all seven. The same test short-circuits the all-floats check on header lines.
- The transition parser tested two numeric fields with `all(map(isfloat, row[2:4]))`, building a slice, a map object and an `all()` call for each of 2.6M lines.
- `isfloat()` is called **8.1M times** and allocated a `.replace("D","E")` copy of every field; now only of fields containing a `D`.

## 4. Writing

- `coll_str` was assigned by a `map_elements()` Python callback **per transition** — 2.6M of them. A left join on a frame built from `upsilondict` gives identical values; 17x on that operation in isolation.
- `write_transition_data()` and `write_phixs_data()` did one `write()` per row (2.6M and 1.5M) → `writelines()` over a generator.

## On bit-exactness

Changes were chosen to be exactly equivalent, and I checked the two load-bearing ones empirically first:

- `np.interp` vs `interp1d` — **bit-identical** on random tables (max relative difference exactly 0.0)
- `searchsorted` slices vs boolean masks — identical selections

The exception is `np.exp` vs `math.exp`, which differ by ~1 ulp (3e-16 relative). That is far below the 8 significant figures `phixsdata_v2.txt` carries, but it is a real difference in an intermediate, so the checksums rather than an argument are what settle it — and they pass unchanged. Same for `np.log10`/`np.sqrt` in the vectorised fit evaluators.

## Verification

All five sets regenerate from clean and verify against the **existing** checksums — no checksum file is touched by this PR. ruff, ruff format, pyrefly, basedpyright and the 25 tests are clean.

I also confirmed the remaining time is real work rather than the iCloud-synced checkout: writing the 117MB of output to `/tmp` instead saves only 0.3s.

## What I did not do

`readdreamdata`'s O(n) list scans, `extend_ion_list`'s re-sort per ion, and `readboyledata`'s full-table scan per ion are all on handlers with no test coverage, so optimising them could not be verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
