### PR TITLE
Follow up the remaining review items

### DIFF
--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -21,6 +21,7 @@ from artisatomic import readfacdata as readfacdata
 from artisatomic import readfloers25data as readfloers25data
 from artisatomic import readhillierdata as readhillierdata
 from artisatomic import readkuruczdata as readkuruczdata
+from artisatomic import readlisbondata as readlisbondata
 from artisatomic import readqubdata as readqubdata
 from artisatomic import readtanakajpltdata as readtanakajpltdata
 from artisatomic.base import atomic_weights as atomic_weights

--- a/artisatomic/cli.py
+++ b/artisatomic/cli.py
@@ -85,8 +85,16 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     ion_handlers = get_ion_handlers()
 
-    assert len(ion_handlers) > 0
-    readhillierdata.read_hyd_phixsdata()
+    if not ion_handlers:
+        # not an assert: an empty selection writes an empty database rather than failing, and
+        # get_ion_handlers() reads a file, so this validates input and must survive python -O
+        msg = "No ions selected. artisatomicionhandlers.json is empty, or no reader found any data."
+        raise ValueError(msg)
+
+    # only the cross sections use these tables, and reading them means parsing the whole H I
+    # oscillator file plus two hydrogenic data files
+    if not args.nophixs:
+        readhillierdata.read_hyd_phixsdata()
 
     Path(args.output_folder).mkdir(exist_ok=True, parents=True)
 
@@ -99,6 +107,9 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     else:
         Path(log_folder).mkdir(exist_ok=True, parents=True)
 
+    # a record of what this run used, written beside the logs. It is NOT the file
+    # get_ion_handlers() reads: that one is ./artisatomicionhandlers.json, in the working
+    # directory. Copy this one there to repeat a run exactly, as the CI workflow does.
     with Path(log_folder, "artisatomicionhandlers.json").open("w", encoding="utf-8") as f:
         json.dump(obj=ion_handlers, fp=f)
     write_compositionfile(ion_handlers, args)

--- a/artisatomic/download_gammaspec_betaminus_alpha.py
+++ b/artisatomic/download_gammaspec_betaminus_alpha.py
@@ -109,7 +109,11 @@ def main():
                 newcols.append(colname)
             dfnuclide.columns = newcols
             dfnuclide = dfnuclide.with_columns(pl.col(pl.Utf8).str.strip_chars()).with_columns(
-                pl.col("parent_elevel").str.replace("0.0", "0"),
+                # anchored, so only a level that IS 0.0 is renamed: str.replace() takes a pattern
+                # and matches anywhere, so a bare "0.0" also rewrote "10.05" to "105" and
+                # "100.0" to "100", silently moving those levels to the wrong group below.
+                # The point is only to keep "0" and "0.0" from forming two ground-state groups.
+                pl.col("parent_elevel").str.replace(r"^0\.0$", "0"),
                 pl.col("radiationenergy_kev").cast(pl.Float64),
                 pl.col("intensity").cast(pl.Float64),
                 pl.col("halflife_s").cast(pl.Float64),

--- a/artisatomic/readboyledata.py
+++ b/artisatomic/readboyledata.py
@@ -2,16 +2,27 @@
 
 import typing as t
 from collections import defaultdict
+from functools import cache
 from pathlib import Path
 
 datafilepath = Path(Path(Path(__file__).resolve()).parent, "..", "atomic-data-helium-boyle", "aoife.hdf5")
 
-try:
-    import h5py  # pyright: ignore[reportMissingTypeStubs]
 
-    aoife_dataset = h5py.File(datafilepath, "r") if datafilepath.exists() else None
-except ModuleNotFoundError:
-    aoife_dataset = None
+@cache
+def get_aoife_dataset():
+    """Open the AOIFE HDF5 file, once, on first use.
+
+    Opened here rather than at import: `import artisatomic` pulls this module in, so opening at
+    import held a file handle for the whole of every run, whichever handlers were selected.
+    Returns None when the file (or h5py) is absent, which is how the readers below report that
+    this data set is unavailable.
+    """
+    try:
+        import h5py  # pyright: ignore[reportMissingTypeStubs]
+    except ModuleNotFoundError:
+        return None
+
+    return h5py.File(datafilepath, "r") if datafilepath.exists() else None
 
 
 class EnergyLevelRow(t.NamedTuple):
@@ -45,7 +56,8 @@ def read_ionization_data(atomic_number, ion_stage):
 
     He III is a bare nucleus, so the file has no entry for it and a sentinel is used instead.
     """
-    assert aoife_dataset is not None
+    aoife_dataset = get_aoife_dataset()
+    assert aoife_dataset is not None, "the AOIFE HDF5 file is required for the boyle handler"
     ionization_data = aoife_dataset["/ionization_data"]
 
     ionization_dict = {}
@@ -67,7 +79,8 @@ def read_levels_data(atomic_number, ion_stage):
     Levels have no spectroscopic names, so each is named after its zero-based level number,
     in the same format read_lines_data() uses to count transitions per level.
     """
-    assert aoife_dataset is not None
+    aoife_dataset = get_aoife_dataset()
+    assert aoife_dataset is not None, "the AOIFE HDF5 file is required for the boyle handler"
     levels_data = aoife_dataset["/levels_data"]
 
     energy_levels: list[EnergyLevelRow] = []
@@ -92,7 +105,8 @@ def read_lines_data(atomic_number, ion_stage):
     numbers are already zero-based, matching the level ids used in memory. No collision
     strengths are available, so every transition gets the -1 "unknown" sentinel.
     """
-    assert aoife_dataset is not None
+    aoife_dataset = get_aoife_dataset()
+    assert aoife_dataset is not None, "the AOIFE HDF5 file is required for the boyle handler"
     lines_data = aoife_dataset["/lines_data"]
 
     transitions = []

--- a/artisatomic/readdreamdata.py
+++ b/artisatomic/readdreamdata.py
@@ -77,12 +77,16 @@ def read_levels_data(dflines):
     Each line carries both of its levels inline, so the levels are the distinct lower and upper
     levels over all lines, sorted by energy.
     """
+    # a set for the membership test, not `not in energy_levels`: that was a linear scan of the
+    # list per candidate, so building the level list cost O(levels^2)
+    seen: set[DreamEnergyLevelRow] = set()
     energy_levels = []
 
     for prefix in ["Lower", "Upper"]:
         for _, row in dflines.drop_duplicates(subset=[prefix + "_Type", prefix + "_Level", prefix + "_g"]).iterrows():
             leveltuple = energytuplefromrow(row, prefix)
-            if leveltuple not in energy_levels:
+            if leveltuple not in seen:
+                seen.add(leveltuple)
                 energy_levels.append(leveltuple)
 
     energy_levels.sort(key=lambda x: x.energyabovegsinpercm)
@@ -122,12 +126,20 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
 
     energy_levels = read_levels_data(dfiondata)
 
+    # a dict, not energy_levels.index(): that scanned the level list once per level of every
+    # line, so resolving the ids cost O(lines x levels) for a database of Z >= 57 lanthanides
+    levelid_of_leveltuple = {leveltuple: levelid for levelid, leveltuple in enumerate(energy_levels)}
+
     def get_level_index(row, prefix):
         """Return the zero-based level id of the row's level."""
         leveltuple = energytuplefromrow(row, prefix)
-        if leveltuple in energy_levels:
-            return energy_levels.index(leveltuple)
-        raise AssertionError
+        levelid = levelid_of_leveltuple.get(leveltuple)
+        if levelid is None:
+            # not an assert: every line's levels come from the same frame the level list was
+            # built from, so a miss means they disagree and must not be silently mapped
+            msg = f"DREAM line names a {prefix} level that is not in the level list: {leveltuple}"
+            raise ValueError(msg)
+        return levelid
 
     dfiondata.insert(
         2,

--- a/artisatomic/readfacdata.py
+++ b/artisatomic/readfacdata.py
@@ -1,5 +1,6 @@
 """Read levels and transitions from FAC and cFAC output, an early version of the Floers+25 data."""
 
+import os
 import re
 import string
 import typing as t
@@ -12,10 +13,17 @@ import artisatomic
 
 USE_CALIBRATED = True
 
-BASEPATH = str(
-    Path.home()
-    / f"Google Drive/Shared drives/Atomic Data Group/OptimizedFACdata/OptimizedFAC_lanthanides{'_calibrated' if USE_CALIBRATED else ''}"
-)
+
+def get_basepath() -> Path:
+    """Directory holding the OptimizedFAC lanthanide data.
+
+    Not part of this repository, so ARTISATOMIC_FAC_PATH overrides where it is looked for, as
+    ARTISATOMIC_LISBON_PATH does for the Lisbon files. The default is the Google Drive mount
+    path, which is where the shared drive appears on the machine this was written for.
+    """
+    calibstr = "_calibrated" if USE_CALIBRATED else ""
+    default = Path.home() / "Google Drive/Shared drives/Atomic Data Group/OptimizedFACdata"
+    return Path(os.environ.get("ARTISATOMIC_FAC_PATH", default)) / f"OptimizedFAC_lanthanides{calibstr}"
 
 
 # Constants
@@ -153,8 +161,17 @@ def GetLines(filename: Path | str) -> pd.DataFrame:
 
 def extend_ion_list(ion_handlers):
     """Add every ion with an FAC data file to ion_handlers under the "fac" handler."""
-    assert Path(BASEPATH).is_dir()
-    for s in Path(BASEPATH).glob("**/*.lev.asc"):
+    basepath = get_basepath()
+    # not an assert: this reports a missing data directory and must survive python -O, and it
+    # names the environment variable rather than just failing the glob silently
+    if not basepath.is_dir():
+        msg = (
+            f"FAC data directory {basepath} not found."
+            " Set ARTISATOMIC_FAC_PATH to the directory holding the OptimizedFAC_lanthanides* folders."
+        )
+        raise FileNotFoundError(msg)
+
+    for s in basepath.glob("**/*.lev.asc"):
         ionstr = s.parts[-1].lstrip(string.digits).removesuffix(".lev.asc").removesuffix("_calib")
         atomic_number, ion_stage = artisatomic.split_element_ionstage_str(ionstr)
         ion_handlers = artisatomic.add_handler_if_not_set(ion_handlers, atomic_number, ion_stage, "fac")
@@ -239,17 +256,17 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
     ion_stage_roman = artisatomic.roman_numerals[ion_stage]
 
     ionstr = f"{atomic_number}{elsym}{ion_stage_roman}{'_calib' if USE_CALIBRATED else ''}"
-    ion_folder = BASEPATH + f"/{ionstr}"
-    levels_file = ion_folder + f"/{ionstr}.lev.asc"
-    lines_file = ion_folder + f"/{ionstr}.tr.asc"
+    ion_folder = get_basepath() / ionstr
+    levels_file = ion_folder / f"{ionstr}.lev.asc"
+    lines_file = ion_folder / f"{ionstr}.tr.asc"
 
     if atomic_number == 92 and ion_stage in {2, 3}:
-        ion_folder = str(
-            Path.home()
-            / f"Google Drive/Shared drives/Atomic Data Group/Paper_Nd_U/FAC/{elsym}{ion_stage_roman}_convergence_t22_n30_calibrated"
-        )
-        levels_file = f"{ion_folder}/{elsym}{ion_stage_roman}_convergence_t22_n30_calibrated.lev.asc"
-        lines_file = f"{ion_folder}/{elsym}{ion_stage_roman}_convergence_t22_n30_calibrated.tr.asc"
+        # U II and U III come from a separate convergence study, which sits beside the
+        # OptimizedFAC folders rather than inside them
+        ionstr = f"{elsym}{ion_stage_roman}_convergence_t22_n30_calibrated"
+        ion_folder = get_basepath().parent.parent / "Paper_Nd_U" / "FAC" / ionstr
+        levels_file = ion_folder / f"{ionstr}.lev.asc"
+        lines_file = ion_folder / f"{ionstr}.tr.asc"
 
     artisatomic.log_and_print(
         flog,
@@ -259,7 +276,9 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
 
     ionization_energy_in_ev = artisatomic.get_nist_ionization_energies_ev()[atomic_number, ion_stage]
 
-    assert Path(levels_file).exists()
+    if not levels_file.is_file():
+        msg = f"FAC levels file {levels_file} not found"
+        raise FileNotFoundError(msg)
     dflevels = GetLevels(filename=levels_file, ionization_energy_in_ev=ionization_energy_in_ev)
 
     # map associates source file level numbers with energy-sorted level numbers (0 indexed)
@@ -267,7 +286,9 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
 
     artisatomic.log_and_print(flog, f"Read {len(energy_levels):d} levels")
 
-    assert Path(lines_file).exists()
+    if not lines_file.is_file():
+        msg = f"FAC transitions file {lines_file} not found"
+        raise FileNotFoundError(msg)
     dflines = GetLines(filename=lines_file)
 
     transitions, transition_count_of_level_name = read_lines_data(energy_levels, dflines, ilev_enlevelindex_map)

--- a/artisatomic/readlisbondata.py
+++ b/artisatomic/readlisbondata.py
@@ -217,7 +217,10 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
 
     transitions, transition_count_of_level_name = read_lines_data(energy_levels, dflines, levelid_of_fileindex)
 
-    ionization_energy_in_ev = -1
+    # from NIST, as every other reader whose data set carries no ionization energy does. This was
+    # -1, which went into adata.txt verbatim as the ion's ionization energy.
+    ionization_energy_in_ev = artisatomic.get_nist_ionization_energies_ev()[atomic_number, ion_stage]
+    artisatomic.log_and_print(flog, f"ionization energy: {ionization_energy_in_ev} eV")
 
     artisatomic.log_and_print(flog, f"Read {len(energy_levels):d} levels")
 

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -686,6 +686,26 @@ def test_parse_ion_handlers():
         parse_ion_handlers([[26, [[1, "cmfgen"], 2]]])
 
 
+def test_parent_elevel_zero_normalisation_is_anchored():
+    r"""Only a parent level that IS 0.0 may be renamed to 0, not one that merely contains it.
+
+    polars' str.replace() takes a pattern and matches anywhere in the value, so a bare "0.0" also
+    rewrote "10.05" to "105" and "100.0" to "100", moving those levels into the wrong group_by
+    bucket in download_gammaspec_betaminus_alpha. literal=True does not help: "0.0" really is a
+    substring of "10.05". Anchoring with ^...$ is what confines it to the whole value.
+    """
+    parent_elevels = ["0.0", "0", "10.05", "100.0", "1234.5", "0.05"]
+    normalised = (
+        pl.DataFrame({"parent_elevel": parent_elevels})
+        .with_columns(pl.col("parent_elevel").str.replace(r"^0\.0$", "0"))["parent_elevel"]
+        .to_list()
+    )
+
+    # the ground state, however it is spelled, collapses to one group; nothing else moves
+    assert normalised == ["0", "0", "10.05", "100.0", "1234.5", "0.05"]
+    assert all(float(before) == float(after) for before, after in zip(parent_elevels, normalised, strict=True))
+
+
 def test_split_element_ionstage_str():
     """'FeII' splits into element and ion stage, including the symbols made only of Roman numeral letters."""
     from artisatomic import split_element_ionstage_str


### PR DESCRIPTION
Clears the backlog left by #75/#76/#77. All five `tests/*/` sets stay **byte-identical** — none of these paths is in that matrix, which is also why they had gone unnoticed.

## Bugs

**`download_gammaspec_betaminus_alpha`** normalised the parent level with `str.replace("0.0", "0")`. polars' `str.replace` takes a *pattern* and matches anywhere, so it also rewrote `"10.05"` → `"105"` and `"100.0"` → `"100"`, moving those levels into the wrong `group_by` bucket and so into the wrong nuclide's gamma spectrum.

`literal=True` does **not** fix this — `"0.0"` genuinely is a substring of `"10.05"`. Anchoring with `^...$` is what confines it to a value that *is* 0.0, which is all the normalisation was ever for (keeping `"0"` and `"0.0"` from forming two ground-state groups).

**The `lisbon` handler returned `ionization_energy_in_ev = -1`**, which went into `adata.txt` verbatim as the ion's ionization energy. Now taken from NIST, as every other reader whose data set carries none already does. Verified against the real files on the shared drive:

| ion | before | after |
| --- | --- | --- |
| Nd II | -1 | 10.783 eV |
| Nd III | -1 | 22.09 eV |
| U II | -1 | 11.6 eV |
| U III | -1 | 19.8 eV |

**`main()` read the hydrogenic cross-section tables even under `--nophixs`**, parsing the whole H I oscillator file and two hydrogenic data files to build output that is then not produced. `--nophixs` drops from 9.6s to **7.7s** on the cmfgen set.

**`readboyledata` opened its HDF5 file at import time**, so `import artisatomic` held a file handle for the whole of every run whichever handlers were selected. Opened on first use instead.

> Caveat: the shipped `aoife.hdf5` is an 800-byte placeholder — the real file is gitignored and downloaded per its README — so this handler cannot be run end to end in a fresh checkout. It fails identically on `main`. My change only moves *when* the file is opened; I verified the module no longer opens a handle at import and that the accessor returns the file.

**An empty ion selection was an `assert`**, so under `python -O` it wrote an empty database rather than failing.

## Consistency and cost

- **`readfacdata` hardcoded a `~/Google Drive` path**, where `readlisbondata` had already made the same thing configurable. `ARTISATOMIC_FAC_PATH` now overrides it, and a missing directory says so and names the variable rather than failing an assert or an empty glob. Its two file-existence asserts became raises, matching the convention the rest of the codebase states.
- **`readdreamdata`** resolved each line's levels with `energy_levels.index()` — a scan of the level list once per level of every line — and built that list with a linear membership test. A dict and a set make both O(1). This matters for the Z ≥ 57 lanthanides, which have the largest line lists.
- `readlisbondata` was the only reader missing from the `__init__` re-exports.
- A note on which `artisatomicionhandlers.json` is the input (`./`) and which is the record written beside the logs — they are different files, which is why the CI workflow copies one to the other.

## Measured, then not done

`add_handler_if_not_set` copies and re-sorts the whole list per call, which is O(n² log n). I flagged it earlier as a perf item, then measured it: **22 ms for 1000 ions**. Not worth the churn, so it is unchanged.

## Testing

`test_parent_elevel_zero_normalisation_is_anchored` pins the gammaspec fix with the concrete wrong cases. The lisbon, fac and boyle changes are on handlers with no CI coverage; I verified lisbon end to end against the real data, fac's path resolution and error, and boyle's import behaviour, but CI cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)