### PR TITLE
Give each Boyle level its own parity, so its transitions are not all forbidden

### DIFF
--- a/artisatomic/readboyledata.py
+++ b/artisatomic/readboyledata.py
@@ -86,14 +86,34 @@ def read_levels_data(atomic_number, ion_stage):
     energy_levels: list[EnergyLevelRow] = []
 
     for rowtuple in levels_data:  # pyright: ignore[reportGeneralTypeIssues]
-        _atomic_num, _ion_number, level_number, energyabovegsinpercm, _g, _metastable = rowtuple
-        # the six unpacked columns plus three more make up the nine fields, which the type
-        # checkers cannot count through the star-unpacking
-        energy_level = EnergyLevelRow(*rowtuple, energyabovegsinpercm, 0, f"level{level_number:05d}")  # pyrefly: ignore [bad-argument-count] # ty:ignore[too-many-positional-arguments] # pyright: ignore[reportCallIssue]
+        atomic_num, ion_number, level_number, energyabovegsinpercm, g, metastable = rowtuple
 
-        if int(energy_level.atomic_number) != atomic_number or int(energy_level.ion_number) != ion_stage - 1:
+        if int(atomic_num) != atomic_number or int(ion_number) != ion_stage - 1:
             continue
-        energy_levels.append(energy_level)
+
+        # named rather than *rowtuple plus three positional extras, which no type checker could
+        # count through (it needed three suppressions) and which is how a bare 0 came to be the
+        # parity of every level
+        energy_levels.append(
+            EnergyLevelRow(
+                atomic_number=atomic_num,
+                ion_number=ion_number,
+                level_number=level_number,
+                energy=energyabovegsinpercm,
+                g=g,
+                metastable=metastable,
+                energyabovegsinpercm=energyabovegsinpercm,
+                # A DISTINCT parity per level. This data set supplies none, and
+                # add_level_ids_forbidden() marks a transition forbidden when its two levels share
+                # one, so a fixed 0 made every transition of the ion forbidden (coll_str -2) when
+                # helium has plenty of permitted ones. readlisbondata and readkuruczdata use the
+                # negated level id for the same reason.
+                parity=-int(level_number),
+                # int() as read_lines_data() does, so the two agree on the name whatever dtype the
+                # file stores the level number in
+                levelname=f"level{int(level_number):05d}",
+            )
+        )
 
     return energy_levels
 

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -9,6 +9,7 @@ import polars as pl
 import pytest
 
 from artisatomic import add_handler_if_not_set
+from artisatomic import add_level_ids_forbidden
 from artisatomic import hc_in_ev_cm
 from artisatomic import interpret_configuration
 from artisatomic import leveltuples_to_pldataframe
@@ -595,6 +596,86 @@ def test_read_coldata_term_to_j_redistribution():
     # Fe II collision data is already J-resolved, so every value passes through unscaled
     _, upsilondict_fe2, _ = read_ion(26, 2)
     assert sum(1 for v in upsilondict_fe2.values() if v > 0.0) == 10601
+
+
+def test_readboyledata_levels_get_distinct_parities(monkeypatch):
+    """The AOIFE data set supplies no parities, so no transition may come out forbidden.
+
+    add_level_ids_forbidden() marks a transition forbidden when its two levels share a parity, so
+    giving every level the same parity made every transition of the ion forbidden — and helium has
+    plenty of permitted ones. readlisbondata and readkuruczdata use the negated level id for
+    exactly this reason.
+
+    The aoife.hdf5 in the repository is a placeholder (the real file is gitignored, fetched per
+    its README), so this builds the three tables the reader wants in memory.
+    """
+    import h5py  # pyright: ignore[reportMissingTypeStubs]
+
+    from artisatomic import readboyledata
+
+    # compound dtypes, as a real HDF5 table has: the integer columns must stay integers, or the
+    # level names format differently in the two readers below
+    levels_dtype = [("atomic_number", "i8"), ("ion_number", "i8"), ("level_number", "i8")]
+    levels_dtype += [("energy", "f8"), ("g", "f8"), ("metastable", "i8")]
+    lines_dtype = [("line_id", "i8"), ("wavelength", "f8"), ("atomic_number", "i8"), ("ion_number", "i8")]
+    lines_dtype += [("f_ul", "f8"), ("f_lu", "f8"), ("level_number_lower", "i8"), ("level_number_upper", "i8")]
+    lines_dtype += [("nu", "f8"), ("B_lu", "f8"), ("B_ul", "f8"), ("A_ul", "f8")]
+
+    # He I: three levels, and two lines between them
+    levels_data = np.array(
+        [
+            (2, 0, 0, 0.0, 1.0, 0),
+            (2, 0, 1, 159856.0, 3.0, 1),
+            (2, 0, 2, 166278.0, 1.0, 0),
+            (2, 1, 0, 0.0, 2.0, 0),  # He II, must be filtered out
+        ],
+        dtype=levels_dtype,
+    )
+    lines_data = np.array(
+        [
+            (0, 584.0, 2, 0, 0.1, 0.3, 0, 2, 0.0, 0.0, 0.0, 1.8e9),
+            (1, 10830.0, 2, 0, 0.2, 0.6, 1, 2, 0.0, 0.0, 0.0, 1.0e7),
+        ],
+        dtype=lines_dtype,
+    )
+
+    with h5py.File("aoife-test", "w", driver="core", backing_store=False) as fakefile:
+        fakefile.create_dataset("/levels_data", data=levels_data)
+        fakefile.create_dataset("/lines_data", data=lines_data)
+        monkeypatch.setattr(readboyledata, "get_aoife_dataset", lambda: fakefile)
+
+        energy_levels = readboyledata.read_levels_data(2, 1)
+        transitions, transition_count_of_level_name = readboyledata.read_lines_data(2, 1)
+
+    # the other ion's level is filtered out
+    assert len(energy_levels) == 3
+
+    # every level gets its own parity, so no pair of them can compare equal
+    assert len({level.parity for level in energy_levels}) == len(energy_levels)
+
+    dflevels = leveltuples_to_pldataframe(
+        pl.DataFrame(
+            {
+                "levelname": [level.levelname for level in energy_levels],
+                "energyabovegsinpercm": [level.energyabovegsinpercm for level in energy_levels],
+                "g": [level.g for level in energy_levels],
+                "parity": [level.parity for level in energy_levels],
+            }
+        )
+    )
+    dftransitions = pl.DataFrame(
+        {
+            "lowerlevel": [t.lowerlevel for t in transitions],
+            "upperlevel": [t.upperlevel for t in transitions],
+            "A": [t.A for t in transitions],
+        }
+    )
+    assert not any(add_level_ids_forbidden(dflevels, dftransitions)["forbidden"].to_list())
+
+    # the two readers must agree on the level names, or the adata.txt transition counts land on
+    # levels that do not exist: one formatted the number through int() and the other did not
+    assert set(transition_count_of_level_name) <= {level.levelname for level in energy_levels}
+    assert transition_count_of_level_name[energy_levels[2].levelname] == 2
 
 
 def test_readlisbondata_maps_file_indices_to_energy_sorted_ids():


### PR DESCRIPTION
Item #1 from the remaining-issues list. All five `tests/*/` sets stay **byte-identical** — no matrix entry uses this handler, which is why it went unnoticed.

## The bug

`read_levels_data()` passed `0` as the parity of **every** level. `add_level_ids_forbidden()` marks a transition forbidden when its two levels share a parity, so every transition of every Boyle ion came out forbidden and was written with `coll_str = -2` instead of `-1`. Helium has plenty of permitted transitions.

```
boyle-style (all parity 0):   forbidden = [True, True]
lisbon/kurucz-style (unique): forbidden = [False, False]
```

The AOIFE data set supplies no parities, so this uses the negated level number — each level gets its own value and nothing comes out forbidden. `readlisbondata` and `readkuruczdata` already do exactly this (`parity=-levelid`), for the same reason; Boyle was the outlier.

## Two things that came out of it

**The level is now built with named fields.** It was `*rowtuple` plus three positional extras, which no type checker could count through — it carried a suppression for each of pyrefly, ty and pyright, **all three now gone** — and which is precisely how a bare `0` came to sit in the parity slot unnoticed. The ion filter also moved ahead of construction, so discarded rows are no longer built.

**A second latent bug:** `read_lines_data()` formatted the level number through `int()` and `read_levels_data()` did not. A file storing it as a float would either crash on the `d` format code or produce names the two functions disagree about — which would put the `adata.txt` transition counts on levels that do not exist. Both cast now. (I hit exactly this while writing the test.)

## Testing

This handler had **no** test coverage, and cannot get end-to-end coverage: the `aoife.hdf5` in the repository is an 800-byte placeholder with no top-level keys, and the real file is gitignored and fetched per its README — so it fails identically on `main` today.

So the test builds the three tables the reader wants in memory, with the compound dtypes a real HDF5 table has (integer columns must stay integers, or the two readers format the names differently). It asserts the parities are distinct, that `add_level_ids_forbidden` marks nothing forbidden, and that the two readers agree on the level names.

Verified to fail on the old code, on the parity specifically:

```
E  AssertionError: assert 1 == 3
E   +  where 1 = len({0})
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)