### PR TITLE
Tighten parallel_map's argument handling, and keep the progress bars out of logs

### DIFF
--- a/artisatomic/base.py
+++ b/artisatomic/base.py
@@ -294,16 +294,19 @@ def parallel_map[ResultType](
         # more than the work; tqdm warns about it above 1000 items
         chunksize = max(1, nitems // (mp.cpu_count() * 4))
 
+    # disable=None means "disable on non-TTY": the bar is for someone watching a build, and it
+    # redraws by carriage return, so a redirected run or a CI capture got a line of half-drawn
+    # bars interleaved with the real output for every call. thread_map() forwards this to tqdm.
     if use_multiprocessing:
         from tqdm import tqdm
 
         results = list(
-            tqdm(get_process_pool().map(fn, *lists, chunksize=chunksize), total=nitems)  # ty:ignore[no-matching-overload]
+            tqdm(get_process_pool().map(fn, *lists, chunksize=chunksize), total=nitems, disable=None)  # ty:ignore[no-matching-overload]
         )
     else:
         from tqdm.contrib.concurrent import thread_map
 
-        results = thread_map(fn, *lists, chunksize=chunksize, total=nitems)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
+        results = thread_map(fn, *lists, chunksize=chunksize, total=nitems, disable=None)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
 
     assert isinstance(results, list)
     return results

--- a/artisatomic/base.py
+++ b/artisatomic/base.py
@@ -259,7 +259,6 @@ def parallel_map[ResultType](
     fn: Callable[..., ResultType],
     *iterables: Iterable[t.Any],
     chunksize: int | None = None,
-    **tqdm_kwargs: t.Any,
 ) -> list[ResultType]:
     """Execute a parallel map with a progress bar using either multithreading (for free-threading python) or multiprocessing.
 
@@ -267,9 +266,10 @@ def parallel_map[ResultType](
     as zip() does, so an accidentally short one would silently drop the tail of the work instead
     of failing, and the three paths below would not even drop the same items.
 
-    chunksize is a keyword of its own rather than something popped back out of the display
-    options. Everything else is a tqdm option (desc, unit, ...) and reaches the progress bar
-    unchanged on both pooled paths.
+    The keywords above are all there are. thread_map() absorbs a dozen more that shape the pool
+    it builds (max_workers, timeout, mp_context, ...), none of which the run-wide pool from
+    get_process_pool() can honour, and which tqdm() on the other path rejects: forwarding them
+    would apply the caller's intent on a free-threading build and raise on a stock one.
     """
     # use a thread pool if we have no GIL (free threading)
     use_multiprocessing = sys._is_gil_enabled()  # ruff: ignore[private-member-access]
@@ -284,13 +284,6 @@ def parallel_map[ResultType](
         raise ValueError(msg)
     nitems = lengths[0] if lengths else 0
 
-    # the pool is shared by the whole run and is already built by the time a second call reaches
-    # it, so a per-call worker count cannot be honoured. Rejected rather than forwarded, which
-    # applied it on the thread path and raised TqdmKeyError on the process path.
-    if "max_workers" in tqdm_kwargs:
-        msg = "parallel_map() does not take max_workers: the process pool is shared by the whole run"
-        raise TypeError(msg)
-
     # even with the pool already up, handing a handful of items to it costs more in IPC than doing
     # them here (readqubdata reduces four cross-section tables at a time)
     if nitems <= 32:
@@ -301,20 +294,16 @@ def parallel_map[ResultType](
         # more than the work; tqdm warns about it above 1000 items
         chunksize = max(1, nitems // (mp.cpu_count() * 4))
 
-    # the length is known here, so neither path has to infer the bar's total from its first
-    # iterable, and both show the same one
-    tqdm_kwargs.setdefault("total", nitems)
-
     if use_multiprocessing:
         from tqdm import tqdm
 
         results = list(
-            tqdm(get_process_pool().map(fn, *lists, chunksize=chunksize), **tqdm_kwargs)  # ty:ignore[no-matching-overload]
+            tqdm(get_process_pool().map(fn, *lists, chunksize=chunksize), total=nitems)  # ty:ignore[no-matching-overload]
         )
     else:
         from tqdm.contrib.concurrent import thread_map
 
-        results = thread_map(fn, *lists, chunksize=chunksize, **tqdm_kwargs)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
+        results = thread_map(fn, *lists, chunksize=chunksize, total=nitems)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
 
     assert isinstance(results, list)
     return results

--- a/artisatomic/base.py
+++ b/artisatomic/base.py
@@ -258,36 +258,63 @@ def get_process_pool() -> ProcessPoolExecutor:
 def parallel_map[ResultType](
     fn: Callable[..., ResultType],
     *iterables: Iterable[t.Any],
-    **kwargs: t.Any,
+    chunksize: int | None = None,
+    **tqdm_kwargs: t.Any,
 ) -> list[ResultType]:
-    """Execute a parallel map with a progress bar using either multithreading (for free-threading python) or multiprocessing."""
+    """Execute a parallel map with a progress bar using either multithreading (for free-threading python) or multiprocessing.
+
+    Every iterable must be the same length. Executor.map() and thread_map() stop at the shortest,
+    as zip() does, so an accidentally short one would silently drop the tail of the work instead
+    of failing, and the three paths below would not even drop the same items.
+
+    chunksize is a keyword of its own rather than something popped back out of the display
+    options. Everything else is a tqdm option (desc, unit, ...) and reaches the progress bar
+    unchanged on both pooled paths.
+    """
     # use a thread pool if we have no GIL (free threading)
     use_multiprocessing = sys._is_gil_enabled()  # ruff: ignore[private-member-access]
 
     # materialise so the work can be sized: the chunk size and the serial cutoff below both need
     # a length, and the callers pass views and generators
     lists = [list(iterable) for iterable in iterables]
-    nitems = min((len(x) for x in lists), default=0)
+    lengths = [len(x) for x in lists]
+    # not an assert: this decides how much of the work is done, so it must survive python -O
+    if len(set(lengths)) > 1:
+        msg = f"parallel_map() was given iterables of different lengths: {lengths}"
+        raise ValueError(msg)
+    nitems = lengths[0] if lengths else 0
+
+    # the pool is shared by the whole run and is already built by the time a second call reaches
+    # it, so a per-call worker count cannot be honoured. Rejected rather than forwarded, which
+    # applied it on the thread path and raised TqdmKeyError on the process path.
+    if "max_workers" in tqdm_kwargs:
+        msg = "parallel_map() does not take max_workers: the process pool is shared by the whole run"
+        raise TypeError(msg)
 
     # even with the pool already up, handing a handful of items to it costs more in IPC than doing
     # them here (readqubdata reduces four cross-section tables at a time)
     if nitems <= 32:
         return list(itertools.starmap(fn, zip(*lists, strict=True)))
 
-    # without a chunk size, items go to the workers one at a time and the IPC per item costs more
-    # than the work; tqdm warns about it above 1000 items
-    chunksize = kwargs.pop("chunksize", max(1, nitems // (mp.cpu_count() * 4)))
+    if chunksize is None:
+        # without a chunk size, items go to the workers one at a time and the IPC per item costs
+        # more than the work; tqdm warns about it above 1000 items
+        chunksize = max(1, nitems // (mp.cpu_count() * 4))
+
+    # the length is known here, so neither path has to infer the bar's total from its first
+    # iterable, and both show the same one
+    tqdm_kwargs.setdefault("total", nitems)
 
     if use_multiprocessing:
         from tqdm import tqdm
 
         results = list(
-            tqdm(get_process_pool().map(fn, *lists, chunksize=chunksize), total=nitems, **kwargs)  # ty:ignore[no-matching-overload]
+            tqdm(get_process_pool().map(fn, *lists, chunksize=chunksize), **tqdm_kwargs)  # ty:ignore[no-matching-overload]
         )
     else:
         from tqdm.contrib.concurrent import thread_map
 
-        results = thread_map(fn, *lists, chunksize=chunksize, **kwargs)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
+        results = thread_map(fn, *lists, chunksize=chunksize, **tqdm_kwargs)  # type: ignore[arg-type] # zuban: ignore[no-untyped-call]
 
     assert isinstance(results, list)
     return results

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -2,6 +2,7 @@
 """Tests for the artisatomic readers, parsers and output writers."""
 
 import io
+import operator
 import typing as t
 
 import numpy as np
@@ -787,44 +788,33 @@ def test_parent_elevel_zero_normalisation_is_anchored():
     assert all(float(before) == float(after) for before, after in zip(parent_elevels, normalised, strict=True))
 
 
-def multiply_for_parallel_map(factor: int, value: int) -> int:
-    """Multiply two numbers, at module level so that the "spawn" workers can import it."""
-    return factor * value
-
-
-def test_parallel_map_rejects_arguments_it_cannot_honour():
-    """Iterables of different lengths, and a per-call worker count, are refused rather than obeyed in part."""
+def test_parallel_map_rejects_iterables_of_different_lengths():
+    """A short iterable is refused, whichever path the call would otherwise have taken."""
     from artisatomic import parallel_map
 
-    # Executor.map() and thread_map() stop at the shortest iterable while the serial path's
-    # zip(strict=True) raises, so a short one must be caught here rather than quietly costing
-    # the caller the tail of its work on one path and not another.
-    for nitems in (4, 40):  # either side of the serial cutoff
-        with pytest.raises(ValueError, match=r"different lengths"):
-            parallel_map(multiply_for_parallel_map, range(nitems), range(nitems - 1))
-
-    # the pool is shared by the whole run, so this could only ever have applied to the thread path
-    with pytest.raises(TypeError, match=r"max_workers"):
-        parallel_map(multiply_for_parallel_map, range(4), range(4), max_workers=2)
-
-
-def test_parallel_map_matches_starmap_on_both_sides_of_the_serial_cutoff():
-    """The serial shortcut and the pooled path return exactly what itertools.starmap() would."""
-    import itertools
-
-    from artisatomic import parallel_map
-
-    # 4 items takes the serial shortcut, 40 goes to the pool. Both consume two iterables, so
-    # each argument has to reach the right parameter, and both must keep the input order.
+    # Executor.map() and thread_map() stop at the shortest iterable while the serial shortcut's
+    # zip(strict=True) raises, so the check has to happen before the path is chosen. 4 items takes
+    # the shortcut and 40 the pool, and neither may quietly do less work than it was asked for.
     for nitems in (4, 40):
-        factors = list(range(nitems))
-        values = list(range(100, 100 + nitems))
-        expected = list(itertools.starmap(multiply_for_parallel_map, zip(factors, values, strict=True)))
+        with pytest.raises(ValueError, match=r"different lengths"):
+            parallel_map(operator.sub, range(nitems), range(nitems - 1))
 
-        assert parallel_map(multiply_for_parallel_map, factors, values) == expected
+
+def test_parallel_map_matches_serial_results_on_both_sides_of_the_cutoff():
+    """Both paths apply fn to one item of each iterable, in the order they were given."""
+    from artisatomic import parallel_map
+
+    # 4 items takes the serial shortcut, 40 goes to the pool. Subtraction does not commute, so
+    # the results also pin which iterable reaches which parameter.
+    for nitems in (4, 40):
+        minuends = list(range(nitems))
+        subtrahends = list(range(100, 100 + nitems))
+        expected = [minuend - subtrahend for minuend, subtrahend in zip(minuends, subtrahends, strict=True)]
+
+        assert parallel_map(operator.sub, minuends, subtrahends) == expected
 
     # a generator is consumed once and has no length, so it must survive being materialised
-    assert parallel_map(multiply_for_parallel_map, (i for i in range(4)), [2] * 4) == [0, 2, 4, 6]
+    assert parallel_map(operator.sub, (i for i in range(4)), [1] * 4) == [-1, 0, 1, 2]
 
 
 def test_split_element_ionstage_str():

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -787,6 +787,46 @@ def test_parent_elevel_zero_normalisation_is_anchored():
     assert all(float(before) == float(after) for before, after in zip(parent_elevels, normalised, strict=True))
 
 
+def multiply_for_parallel_map(factor: int, value: int) -> int:
+    """Multiply two numbers, at module level so that the "spawn" workers can import it."""
+    return factor * value
+
+
+def test_parallel_map_rejects_arguments_it_cannot_honour():
+    """Iterables of different lengths, and a per-call worker count, are refused rather than obeyed in part."""
+    from artisatomic import parallel_map
+
+    # Executor.map() and thread_map() stop at the shortest iterable while the serial path's
+    # zip(strict=True) raises, so a short one must be caught here rather than quietly costing
+    # the caller the tail of its work on one path and not another.
+    for nitems in (4, 40):  # either side of the serial cutoff
+        with pytest.raises(ValueError, match=r"different lengths"):
+            parallel_map(multiply_for_parallel_map, range(nitems), range(nitems - 1))
+
+    # the pool is shared by the whole run, so this could only ever have applied to the thread path
+    with pytest.raises(TypeError, match=r"max_workers"):
+        parallel_map(multiply_for_parallel_map, range(4), range(4), max_workers=2)
+
+
+def test_parallel_map_matches_starmap_on_both_sides_of_the_serial_cutoff():
+    """The serial shortcut and the pooled path return exactly what itertools.starmap() would."""
+    import itertools
+
+    from artisatomic import parallel_map
+
+    # 4 items takes the serial shortcut, 40 goes to the pool. Both consume two iterables, so
+    # each argument has to reach the right parameter, and both must keep the input order.
+    for nitems in (4, 40):
+        factors = list(range(nitems))
+        values = list(range(100, 100 + nitems))
+        expected = list(itertools.starmap(multiply_for_parallel_map, zip(factors, values, strict=True)))
+
+        assert parallel_map(multiply_for_parallel_map, factors, values) == expected
+
+    # a generator is consumed once and has no length, so it must survive being materialised
+    assert parallel_map(multiply_for_parallel_map, (i for i in range(4)), [2] * 4) == [0, 2, 4, 6]
+
+
 def test_split_element_ionstage_str():
     """'FeII' splits into element and ion stage, including the symbols made only of Roman numeral letters."""
     from artisatomic import split_element_ionstage_str


### PR DESCRIPTION
Follow-up to #77, which replaced tqdm's `process_map` with a run-wide pool. All
five `tests/*/` sets stay **byte-identical** — the one caller passes a single
iterable and no keywords, which is why none of this had been noticed.

## Unequal iterable lengths meant three paths and two behaviours

The serial shortcut's `zip(strict=True)` raised, while `Executor.map()` and
`thread_map()` both stopped at the shortest and returned 39 results for 40 items
with no error:

```
Executor.map results: 39 of 40
thread_map results:   39 of 40
```

So a caller lost the tail of its work or not, depending only on how much work it
had — the cutoff is 32 items. `nitems` took `min()` of the lengths, which built
that in. The lengths must now match, and the message names them.

## `max_workers` was a special case where the general fix was available

The first pass rejected `max_workers` by name. That was one level too shallow:
`tqdm.contrib.concurrent._executor_map` absorbs a dozen keywords that shape the
pool it builds — `max_workers`, `timeout`, `buffersize`, `mp_context`,
`thread_name_prefix`, `max_tasks_per_child`, `tqdm_class`, `lock_name` — and the
run-wide pool from `get_process_pool()` can honour none of them. Naming one left
the rest with exactly the split the check existed to remove: honoured on a
free-threading build, `TqdmKeyError` on a stock one.

Nothing has ever passed a display option either, so `**kwargs` goes entirely and
the interpreter rejects all of them uniformly, before the iterables are
materialised rather than after:

```
parallel_map() got an unexpected keyword argument 'max_workers'
parallel_map() got an unexpected keyword argument 'mp_context'
```

`chunksize` becomes a keyword of its own, and `total` is passed at both call
sites instead of going into a dict the caller could also write to — the function
knows the length exactly, so there was no reason to let anyone override it.

## The progress bars no longer land in redirected output

tqdm redraws by carriage return, so a redirected run or a CI capture got a line
of half-drawn bars interleaved with the real output for every call — 10 such
lines in the cmfgen build log, each packing three to five redraws. `disable=None`
is tqdm's own switch for this: drawn on a TTY, suppressed everywhere else.

| log | redraws before | after |
|---|---|---|
| cmfgen | 26 | 0 |
| jplt | 7 | 0 |
| kurucz | 5 | 0 |
| floers25, qub | 0 | 0 |

The per-ion logs under `atomic_data_logs/` were never affected: those go through
`log_and_print()`, and tqdm writes to stderr.

## Testing

Two tests. One that a short iterable is refused on either side of the serial
cutoff — which pins that the validation happens *before* the path is chosen,
the property that makes the paths agree. One that both paths return the serial
result, using `operator.sub`: it is already picklable, so it needs no bespoke
module-level helper, and it does not commute, so the two-iterable case really
does pin which iterable reaches which parameter.

The bar behaviour was verified under a pty — a real one with a window size set.
tqdm asks the terminal for its width, and a 0x0 pty makes it draw an *empty* bar
that is indistinguishable from a disabled one, so the `disable=False`/`True`
controls are what make the result meaningful:

```
plain tqdm disable=False (control, want bar)   bar=True  redraws=8
plain tqdm disable=True  (control, want none)  bar=False redraws=0
plain tqdm disable=None  (want bar on a tty)   bar=True  redraws=8
parallel_map on a tty    (want bar)            bar=True  redraws=4
```

and absent through a pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)