### PR TITLE
Parse valence n from the JPLT v2.1 LS-term level names

### DIFF
--- a/artisatomic/readtanakajpltdata.py
+++ b/artisatomic/readtanakajpltdata.py
@@ -1,5 +1,6 @@
 """Read levels and transitions from the Tanaka et al. Japan-Lithuania database."""
 
+import re
 from pathlib import Path
 
 import pandas as pd
@@ -133,8 +134,19 @@ def get_level_valence_n(levelname: str):
 
     Kept separate from the other readers' versions: each data source names its levels
     differently, so a shared parser would have to guess which convention it is looking at.
+
+    data_v2.1 mixes two conventions: the original relativistic one, "{  4s+ 2  4p- 1 }",
+    where the valence orbital heads the last double-space-separated token, and the
+    LS-coupled one of the 2024 Ge-sequence files, "3s(2).3p(6).3d(10).4s.4p(3)2D_3D",
+    where it is the last dot-separated shell before the term label.
     """
-    n = int(levelname.rsplit("  ", maxsplit=1)[-1].split(" ", maxsplit=1)[0].rstrip("spdfg+-"))
+    if "{" in levelname:
+        n = int(levelname.rsplit("  ", maxsplit=1)[-1].split(" ", maxsplit=1)[0].rstrip("spdfg+-"))
+    else:
+        lastshell = levelname.rsplit(" ", maxsplit=1)[-1].rsplit(".", maxsplit=1)[-1].partition("_")[0]
+        nmatch = re.match(r"\d+", lastshell)
+        assert nmatch is not None, f"Could not parse valence n from level name: {levelname}"
+        n = int(nmatch.group())
     assert n >= 0
     assert n < 20
     return n


### PR DESCRIPTION
## Problem

`makeartisatomicfiles` crashed on Z=33 As II (and would on 31 other ions) when the tanakajplt handler hit the hydrogenic photoionization path:

```
ValueError: invalid literal for int() with base 10: '3s(2).3p(6).3d(10).4s(2).4p(2)_3P'
```

`get_level_valence_n` only understood the original JPLT relativistic-orbital level names, e.g. `{  4s+ 2  4p- 1 }`, where the valence orbital heads the last double-space-separated token. The 2024 Kitovienė et al. Ge-isoelectronic-sequence files in `data_v2.1` (32 files: 33_2, 34_2/3, 35_3/4, 36_4/5, 37_5, 38_6, 51_1, 52_2, 53_3, 54_4, 55_5, 58_3/4, 59_2/4, 60_2/3/4, 61_2–70_2, 90_3) instead append an LS-coupled term string like `3s(2).3p(6).3d(10).4s(2).4p(2)_3P`, whose trailing term label survives the old `rstrip("spdfg+-")` and lands in `int()`.

## Fix

Branch on format: names containing `{` keep the original parsing unchanged; otherwise take the leading digits of the last dot-separated shell before the term label (`...4s(2).4p(2)_3P` → `4p(2)` → 4; `...3P2_3P.7p_4D` → `7p` → 7).

## Verification

- Parser sweep over all 180,867 level names in all 80 `data_v2.1` files: zero failures, n in 3–9, both formats covered
- The failing scenario (As II, tanakajplt, hydrogenic phixs) now completes: 78 levels, 868 transitions
- All five test sets (`cmfgen`, `qub`, `kurucz`, `floers25`, `jplt`) regenerated byte-identical to `checksums.txt`
- `ruff check`, `ruff format --check`, `pyrefly`, `basedpyright` clean; 29/29 pytest pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)