### PR TITLE
Decide the forbidden flag from the E1 selection rules

### DIFF
--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -56,7 +56,9 @@ from artisatomic.ionhandlers import drop_handlers as drop_handlers
 from artisatomic.ionhandlers import get_ion_handlers as get_ion_handlers
 from artisatomic.ionhandlers import parse_ion_handlers as parse_ion_handlers
 from artisatomic.ionhandlers import sort_ion_handlers as sort_ion_handlers
+from artisatomic.levelnames import get_config_parity as get_config_parity
 from artisatomic.levelnames import get_parity_from_config as get_parity_from_config
+from artisatomic.levelnames import has_merged_orbital as has_merged_orbital
 from artisatomic.levelnames import interpret_configuration as interpret_configuration
 from artisatomic.output import add_level_ids_forbidden as add_level_ids_forbidden
 from artisatomic.output import clear_files as clear_files

--- a/artisatomic/__init__.py
+++ b/artisatomic/__init__.py
@@ -57,7 +57,6 @@ from artisatomic.ionhandlers import get_ion_handlers as get_ion_handlers
 from artisatomic.ionhandlers import parse_ion_handlers as parse_ion_handlers
 from artisatomic.ionhandlers import sort_ion_handlers as sort_ion_handlers
 from artisatomic.levelnames import get_config_parity as get_config_parity
-from artisatomic.levelnames import get_parity_from_config as get_parity_from_config
 from artisatomic.levelnames import has_merged_orbital as has_merged_orbital
 from artisatomic.levelnames import interpret_configuration as interpret_configuration
 from artisatomic.output import add_level_ids_forbidden as add_level_ids_forbidden

--- a/artisatomic/levelnames.py
+++ b/artisatomic/levelnames.py
@@ -1,5 +1,7 @@
 """Parse level names: split a configuration into orbitals and a term, and derive the parity."""
 
+import typing as t
+
 alphabets = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ "
 reversedalphabets = "zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA "
 lchars = "SPDFGHIKLMNOPQRSTUVWXYZ"
@@ -119,35 +121,85 @@ def interpret_configuration(instr_orig: str) -> tuple[list[str], int, int, int, 
     return electron_config, term_twosplusone, term_l, term_parity, indexinsymmetry
 
 
-def get_parity_from_config(instr) -> int:
-    """Parity of a level from its configuration: the sum of l over the occupied orbitals, mod 2.
+def _iter_occupied_orbitals(instr, warn: bool) -> t.Iterator[tuple[int, int, bool]]:
+    """Walk the occupied orbitals of a configuration, yielding (l, number of electrons, merged).
 
-    Returns 0 for even and 1 for odd. Parent terms in parentheses are not occupied orbitals and
-    are skipped, as are merge markers (see the l >= n check below).
+    Parent terms in parentheses are not occupied orbitals and are skipped. An orbital must
+    satisfy l <= n - 1; CMFGEN's merged high-l levels ('2s2_13w_2W', '2s2_2p3(4So)5z_5Z') fail
+    this, because the letter is a merge marker spanning several l rather than one orbital. Those
+    are yielded with merged=True so callers can tell the two cases apart.
+
+    One token can hold more than one orbital, because interpret_configuration() keeps a
+    digit-letter-letter run together: '4sp(3P)_7Po' gives '4sp', which is 4s and 4p sharing the
+    one principal quantum number. Each letter is therefore taken in turn, with the digits that
+    follow it as its occupation and 1 where it has none.
     """
-    configsplit = interpret_configuration(instr)[0]
     lchars_lower = lchars.lower()
-    lsum = 0
-    for orbitalstr in configsplit:
+    for orbitalstr in interpret_configuration(instr)[0]:
         if orbitalstr.startswith("("):
             continue  # a parent term such as '(5D)', not an occupied orbital
-        # the orbital letter is the first non-digit, allowing a two-digit principal quantum number
-        lpos = next((pos for pos, char in enumerate(orbitalstr) if char in lchars_lower), None)
-        if lpos is None:
+
+        # the leading digits are the principal quantum number, which may be two digits long
+        nend = 0
+        while nend < len(orbitalstr) and orbitalstr[nend].isdigit():
+            nend += 1
+        principalquantumnumber = int(orbitalstr[:nend]) if nend else 0
+
+        pos = nend
+        foundorbital = False
+        while pos < len(orbitalstr):
+            if orbitalstr[pos] not in lchars_lower:
+                pos += 1
+                continue
+            l = lchars_lower.index(orbitalstr[pos])
+            pos += 1
+            nstart = pos
+            while pos < len(orbitalstr) and orbitalstr[pos].isdigit():
+                pos += 1
+            nelec = int(orbitalstr[nstart:pos]) if pos > nstart else 1
+            foundorbital = True
+            yield l, nelec, l >= principalquantumnumber
+
+        if not foundorbital and warn:
             # don't fail silently: a skipped orbital means the parity (and hence the forbidden
             # flags of every transition involving this level) could come out wrong
             print(f"WARNING: could not read an orbital from '{orbitalstr}' in '{instr}', skipping it for the parity")
-            continue
-        l = lchars_lower.index(orbitalstr[lpos])
-        nelec = int(orbitalstr[lpos + 1 :]) if len(orbitalstr[lpos + 1 :]) > 0 else 1
 
-        # An orbital must satisfy l <= n - 1. CMFGEN's merged high-l levels ('2s2_13w_2W',
-        # '2s2_2p3(4So)5z_5Z') fail this: the letter is a merge marker spanning several l of both
-        # parities, so it has no definite parity and only the real orbitals count.
-        principalquantumnumber = int(orbitalstr[:lpos]) if orbitalstr[:lpos].isdigit() else 0
-        if l >= principalquantumnumber:
-            continue
 
-        lsum += l * nelec
+def has_merged_orbital(instr) -> bool:
+    """Whether the configuration contains a merge marker, i.e. an orbital with l >= n.
 
-    return lsum % 2
+    CMFGEN writes its merged high-l levels this way ('2s2_13w_2W', '10z_2Z'): the letter stands
+    for several l of both parities at once, so the level has no parity rather than an unreadable
+    one, and no suffix on the name can supply it.
+    """
+    return any(merged for _l, _nelec, merged in _iter_occupied_orbitals(instr, warn=False))
+
+
+def get_config_parity(instr) -> int | None:
+    """Parity of a configuration (0 even, 1 odd), or None when it does not determine one.
+
+    None means no orbital in the name had a readable l to sum, as for CMFGEN's merged n-levels
+    '1___' and '13___' (g = 2n^2, every l of that n) and He I's merged '8SNG' and '8TRP'. That is
+    different from the 0 those would otherwise get from an empty sum. Merge markers are left out
+    of the sum as in get_parity_from_config(), so check has_merged_orbital() as well when a level
+    with no definite parity has to be recognised.
+    """
+    lsum = 0
+    readable = False
+    for l, nelec, merged in _iter_occupied_orbitals(instr, warn=True):
+        if not merged:
+            lsum += l * nelec
+            readable = True
+
+    return lsum % 2 if readable else None
+
+
+def get_parity_from_config(instr) -> int:
+    """Parity of a level from its configuration: the sum of l over the occupied orbitals, mod 2.
+
+    Returns 0 for even and 1 for odd. Merge markers have no definite l, so they are left out of
+    the sum rather than making the whole result unknown. Prefer get_config_parity() where a level
+    with no definite parity has to be told apart from an even one.
+    """
+    return sum(l * nelec for l, nelec, merged in _iter_occupied_orbitals(instr, warn=True) if not merged) % 2

--- a/artisatomic/levelnames.py
+++ b/artisatomic/levelnames.py
@@ -7,7 +7,76 @@ reversedalphabets = "zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA "
 lchars = "SPDFGHIKLMNOPQRSTUVWXYZ"
 
 
-def interpret_configuration(instr_orig: str, warn: bool = True) -> tuple[list[str], int, int, int, int]:
+def _split_orbitals(instr: str) -> list[str]:
+    """Split the configuration part of a level name into occupied orbitals and parent terms.
+
+    Parent terms keep their parentheses, so callers can tell them from occupied orbitals. Any
+    term has already been taken off the end by the caller, so all of this is configuration.
+    """
+    max_n = 20  # maximum possible principle quantum number n
+
+    def is_two_digit_n(strn: str) -> bool:
+        """Test whether two digits are a principal quantum number, not one digit of something else.
+
+        n is written 10 to 19 when it takes two digits, so a leading zero rules it out: the '0' of
+        '3d104s' belongs to the occupation number of the 3d shell, giving 4s and not 04s.
+        """
+        return strn.isdigit() and 10 <= int(strn) < max_n
+
+    electron_config: list[str] = []
+    if instr.startswith("Eqv st"):
+        return electron_config
+
+    while instr:
+        if instr[-1].upper() in lchars:
+            # Orbital with no occupation number, e.g. the '10d' of '3d6(5D)10d_5Pe'. A
+            # digit-letter-letter run keeps its digit, so '4sp(3P)_7Po[2]' gives '4sp'.
+            startpos = (
+                -3
+                if len(instr) >= 3
+                and (is_two_digit_n(instr[-3:-1]) or (instr[-3].isdigit() and not instr[-2].isdigit()))
+                else -2
+            )
+
+            electron_config.insert(0, instr[startpos:])
+            instr = instr[:startpos]
+        elif instr[-1] == ")":
+            left_bracket_pos = instr.rfind("(")
+            str_parent_term = instr[left_bracket_pos:].replace(" ", "")
+            electron_config.insert(0, str_parent_term)
+            instr = instr[:left_bracket_pos]
+        elif str.isdigit(instr[-1]):  # the number of electrons in an orbital
+            if len(instr) >= 2 and instr[-2].upper() in lchars:
+                # Single-digit occupation. A two-digit n survives ('10d1') only where the
+                # digits cannot belong to a preceding orbital: '3d14s2' is ambiguous
+                # (3d1 4s2 or 3d 14s2), and there the occupation-1 reading wins.
+                two_digit_n = (
+                    len(instr) >= 4
+                    and is_two_digit_n(instr[-4:-2])
+                    and (len(instr) == 4 or not (instr[-5].isdigit() or instr[-5].upper() in lchars))
+                )
+                startpos = -4 if two_digit_n else -3
+                electron_config.insert(0, instr[startpos:])
+                instr = instr[:startpos]
+            elif len(instr) >= 3 and str.isdigit(instr[-2]) and instr[-3].upper() in lchars:
+                # Two-digit occupation, e.g. the closed shells '3d10' and '4f14'. This is
+                # unambiguous: trailing digits after the orbital letter are the occupation.
+                startpos = -4 if len(instr) >= 4 and str.isdigit(instr[-4]) else -3
+                electron_config.insert(0, instr[startpos:])
+                instr = instr[:startpos]
+            else:
+                instr = instr[:-1]
+        elif instr[-1] in {"_", " "}:
+            instr = instr[:-1]
+        else:
+            instr = instr[:-1]
+
+    return electron_config
+
+
+def interpret_configuration(
+    instr_orig: str, warn: bool = True, hasterm: bool = True
+) -> tuple[list[str], int, int, int, int]:
     """Split a level name into its orbitals and term.
 
     Returns (orbitals, 2S+1, L, parity, index in symmetry), where orbitals is the configuration
@@ -18,10 +87,16 @@ def interpret_configuration(instr_orig: str, warn: bool = True) -> tuple[list[st
     warn=False silences the malformed-name message for callers that expect names this cannot
     split. CMFGEN's merged levels ('1___', '8SNG') are such names by design, and there are
     enough of them to bury a real warning.
+
+    hasterm=False reads the whole string as a configuration, for sources whose level name carries
+    no term. An ADAS adf04 file keeps 2S+1 and L in their own columns, so its '5s2' is an orbital
+    rather than a term to strip, and its '3S2 3P6 3D5 4P1' would otherwise lose the 4P1 that way.
+    All the term components come back as -1, there being no term to read.
     """
-    max_n = 20  # maximum possible principle quantum number n
-    instr = instr_orig
-    instr = instr.split("[")[0]  # remove trailing bracketed J value
+    instr = instr_orig.split("[", maxsplit=1)[0]  # remove trailing bracketed J value
+
+    if not hasterm:
+        return _split_orbitals(instr), -1, -1, -1, -1
 
     if instr[-1] in lchars:
         term_parity = 0  # even
@@ -70,64 +145,10 @@ def interpret_configuration(instr_orig: str, warn: bool = True) -> tuple[list[st
         indexinsymmetry = reversedalphabets.index(instr[-1]) + 1 if term_parity == 1 else alphabets.index(instr[-1]) + 1
         instr = instr[:-1]
 
-    def is_two_digit_n(strn: str) -> bool:
-        """Test whether two digits are a principal quantum number, not one digit of something else.
-
-        n is written 10 to 19 when it takes two digits, so a leading zero rules it out: the '0' of
-        '3d104s' belongs to the occupation number of the 3d shell, giving 4s and not 04s.
-        """
-        return strn.isdigit() and 10 <= int(strn) < max_n
-
-    electron_config: list[str] = []
-    if not instr.startswith("Eqv st"):
-        while instr:
-            if instr[-1].upper() in lchars:
-                # Orbital with no occupation number, e.g. the '10d' of '3d6(5D)10d_5Pe'. A
-                # digit-letter-letter run keeps its digit, so '4sp(3P)_7Po[2]' gives '4sp'.
-                startpos = (
-                    -3
-                    if len(instr) >= 3
-                    and (is_two_digit_n(instr[-3:-1]) or (instr[-3].isdigit() and not instr[-2].isdigit()))
-                    else -2
-                )
-
-                electron_config.insert(0, instr[startpos:])
-                instr = instr[:startpos]
-            elif instr[-1] == ")":
-                left_bracket_pos = instr.rfind("(")
-                str_parent_term = instr[left_bracket_pos:].replace(" ", "")
-                electron_config.insert(0, str_parent_term)
-                instr = instr[:left_bracket_pos]
-            elif str.isdigit(instr[-1]):  # the number of electrons in an orbital
-                if len(instr) >= 2 and instr[-2].upper() in lchars:
-                    # Single-digit occupation. A two-digit n survives ('10d1') only where the
-                    # digits cannot belong to a preceding orbital: '3d14s2' is ambiguous
-                    # (3d1 4s2 or 3d 14s2), and there the occupation-1 reading wins.
-                    two_digit_n = (
-                        len(instr) >= 4
-                        and is_two_digit_n(instr[-4:-2])
-                        and (len(instr) == 4 or not (instr[-5].isdigit() or instr[-5].upper() in lchars))
-                    )
-                    startpos = -4 if two_digit_n else -3
-                    electron_config.insert(0, instr[startpos:])
-                    instr = instr[:startpos]
-                elif len(instr) >= 3 and str.isdigit(instr[-2]) and instr[-3].upper() in lchars:
-                    # Two-digit occupation, e.g. the closed shells '3d10' and '4f14'. This is
-                    # unambiguous: trailing digits after the orbital letter are the occupation.
-                    startpos = -4 if len(instr) >= 4 and str.isdigit(instr[-4]) else -3
-                    electron_config.insert(0, instr[startpos:])
-                    instr = instr[:startpos]
-                else:
-                    instr = instr[:-1]
-            elif instr[-1] in {"_", " "}:
-                instr = instr[:-1]
-            else:
-                instr = instr[:-1]
-
-    return electron_config, term_twosplusone, term_l, term_parity, indexinsymmetry
+    return _split_orbitals(instr), term_twosplusone, term_l, term_parity, indexinsymmetry
 
 
-def _iter_occupied_orbitals(instr, warn: bool) -> Iterator[tuple[int, int, bool]]:
+def _iter_occupied_orbitals(instr, warn: bool, hasterm: bool = True) -> Iterator[tuple[int, int, bool]]:
     """Walk the occupied orbitals of a configuration, yielding (l, number of electrons, merged).
 
     Parent terms in parentheses are not occupied orbitals and are skipped. An orbital must
@@ -141,7 +162,7 @@ def _iter_occupied_orbitals(instr, warn: bool) -> Iterator[tuple[int, int, bool]
     follow it as its occupation and 1 where it has none.
     """
     lchars_lower = lchars.lower()
-    for orbitalstr in interpret_configuration(instr, warn=warn)[0]:
+    for orbitalstr in interpret_configuration(instr, warn=warn, hasterm=hasterm)[0]:
         if orbitalstr.startswith("("):
             continue  # a parent term such as '(5D)', not an occupied orbital
 
@@ -154,10 +175,17 @@ def _iter_occupied_orbitals(instr, warn: bool) -> Iterator[tuple[int, int, bool]
         pos = nend
         foundorbital = False
         while pos < len(orbitalstr):
-            if orbitalstr[pos] not in lchars_lower:
+            # Only a name with a term is read case-sensitively. CMFGEN writes orbitals in lower
+            # case and keeps upper case for terms, so an upper-case letter there is a term symbol
+            # or a parent term, not an orbital: reading '8SNG' (He I's merged singlets) as an 8s
+            # orbital, or the mangled '3H' of '3d4(3H)s44p_x3Io' as a merge marker, would be
+            # wrong. A bare configuration has no term to confuse it with, and adf04 writes its
+            # orbitals in upper case ('3S2 3P6 3D5 4P1'), so there the letter is unambiguous.
+            orbitalchar = orbitalstr[pos] if hasterm else orbitalstr[pos].lower()
+            if orbitalchar not in lchars_lower:
                 pos += 1
                 continue
-            l = lchars_lower.index(orbitalstr[pos])
+            l = lchars_lower.index(orbitalchar)
             pos += 1
             nstart = pos
             while pos < len(orbitalstr) and orbitalstr[pos].isdigit():
@@ -175,17 +203,17 @@ def _iter_occupied_orbitals(instr, warn: bool) -> Iterator[tuple[int, int, bool]
             print(f"WARNING: could not read an orbital from '{orbitalstr}' in '{instr}', skipping it for the parity")
 
 
-def has_merged_orbital(instr) -> bool:
+def has_merged_orbital(instr, hasterm: bool = True) -> bool:
     """Whether the configuration contains a merge marker, i.e. an orbital with l >= n.
 
     CMFGEN writes its merged high-l levels this way ('2s2_13w_2W', '10z_2Z'): the letter stands
     for several l of both parities at once, so the level has no parity rather than an unreadable
     one, and no suffix on the name can supply it.
     """
-    return any(merged for _l, _nelec, merged in _iter_occupied_orbitals(instr, warn=False))
+    return any(merged for _l, _nelec, merged in _iter_occupied_orbitals(instr, warn=False, hasterm=hasterm))
 
 
-def get_config_parity(instr, warn: bool = False) -> int | None:
+def get_config_parity(instr, warn: bool = False, hasterm: bool = True) -> int | None:
     """Parity of a configuration (0 even, 1 odd), or None when it does not determine one.
 
     None means no orbital in the name had a readable l to sum, as for CMFGEN's merged n-levels
@@ -199,7 +227,7 @@ def get_config_parity(instr, warn: bool = False) -> int | None:
     """
     lsum = 0
     readable = False
-    for l, nelec, merged in _iter_occupied_orbitals(instr, warn=warn):
+    for l, nelec, merged in _iter_occupied_orbitals(instr, warn=warn, hasterm=hasterm):
         if not merged:
             lsum += l * nelec
             readable = True

--- a/artisatomic/levelnames.py
+++ b/artisatomic/levelnames.py
@@ -1,6 +1,6 @@
 """Parse level names: split a configuration into orbitals and a term, and derive the parity."""
 
-import typing as t
+from collections.abc import Iterator
 
 alphabets = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ "
 reversedalphabets = "zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA "
@@ -127,7 +127,7 @@ def interpret_configuration(instr_orig: str, warn: bool = True) -> tuple[list[st
     return electron_config, term_twosplusone, term_l, term_parity, indexinsymmetry
 
 
-def _iter_occupied_orbitals(instr, warn: bool) -> t.Iterator[tuple[int, int, bool]]:
+def _iter_occupied_orbitals(instr, warn: bool) -> Iterator[tuple[int, int, bool]]:
     """Walk the occupied orbitals of a configuration, yielding (l, number of electrons, merged).
 
     Parent terms in parentheses are not occupied orbitals and are skipped. An orbital must

--- a/artisatomic/levelnames.py
+++ b/artisatomic/levelnames.py
@@ -217,10 +217,11 @@ def get_config_parity(instr, warn: bool = False, hasterm: bool = True) -> int | 
     """Parity of a configuration (0 even, 1 odd), or None when it does not determine one.
 
     None means no orbital in the name had a readable l to sum, as for CMFGEN's merged n-levels
-    '1___' and '13___' (g = 2n^2, every l of that n) and He I's merged '8SNG' and '8TRP'. That is
-    different from the 0 those would otherwise get from an empty sum. Merge markers are left out
-    of the sum as in get_parity_from_config(), so check has_merged_orbital() as well when a level
-    with no definite parity has to be recognised.
+    '1___' and '13___' (g = 2n^2, every l of that n) and He I's merged '8SNG' and '8TRP'. An empty
+    sum is 0, which is a real parity and the wrong answer for those, so this reports None instead
+    and leaves the caller to decide. Merge markers are left out of the sum rather than making the
+    whole result None, so check has_merged_orbital() as well to recognise a level that has no
+    definite parity at all.
 
     Unreadable names are the expected case for the callers that need the None, so this is quiet
     by default; pass warn=True to get the per-orbital diagnostics.
@@ -233,13 +234,3 @@ def get_config_parity(instr, warn: bool = False, hasterm: bool = True) -> int | 
             readable = True
 
     return lsum % 2 if readable else None
-
-
-def get_parity_from_config(instr) -> int:
-    """Parity of a level from its configuration: the sum of l over the occupied orbitals, mod 2.
-
-    Returns 0 for even and 1 for odd. Merge markers have no definite l, so they are left out of
-    the sum rather than making the whole result unknown. Prefer get_config_parity() where a level
-    with no definite parity has to be told apart from an even one.
-    """
-    return sum(l * nelec for l, nelec, merged in _iter_occupied_orbitals(instr, warn=True) if not merged) % 2

--- a/artisatomic/levelnames.py
+++ b/artisatomic/levelnames.py
@@ -7,13 +7,17 @@ reversedalphabets = "zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA "
 lchars = "SPDFGHIKLMNOPQRSTUVWXYZ"
 
 
-def interpret_configuration(instr_orig: str) -> tuple[list[str], int, int, int, int]:
+def interpret_configuration(instr_orig: str, warn: bool = True) -> tuple[list[str], int, int, int, int]:
     """Split a level name into its orbitals and term.
 
     Returns (orbitals, 2S+1, L, parity, index in symmetry), where orbitals is the configuration
     split into occupied orbitals and parent terms (kept in parentheses), and the index in
     symmetry comes from the seniority letter if the name has one. Term components that cannot be
     read come back as -1.
+
+    warn=False silences the malformed-name message for callers that expect names this cannot
+    split. CMFGEN's merged levels ('1___', '8SNG') are such names by design, and there are
+    enough of them to bury a real warning.
     """
     max_n = 20  # maximum possible principle quantum number n
     instr = instr_orig
@@ -25,7 +29,8 @@ def interpret_configuration(instr_orig: str) -> tuple[list[str], int, int, int, 
         term_parity = [0, 1][(instr[-1] == "o")]
         if all(char not in lchars for char in instr):
             # This will be an incorrectly formatted QUB file with no term
-            print("Warning: Check QUB file formatting")
+            if warn:
+                print("Warning: Check QUB file formatting")
         else:
             # Preserve previous behaviour
             instr = instr[:-1]
@@ -45,7 +50,8 @@ def interpret_configuration(instr_orig: str) -> tuple[list[str], int, int, int, 
             )
         instr = instr[:-1]
         if all(char not in lchars for char in instr):
-            print("Warning: Check QUB file formatting")
+            if warn:
+                print("Warning: Check QUB file formatting")
             break
 
     if instr and str.isdigit(instr[-1]):
@@ -135,7 +141,7 @@ def _iter_occupied_orbitals(instr, warn: bool) -> t.Iterator[tuple[int, int, boo
     follow it as its occupation and 1 where it has none.
     """
     lchars_lower = lchars.lower()
-    for orbitalstr in interpret_configuration(instr)[0]:
+    for orbitalstr in interpret_configuration(instr, warn=warn)[0]:
         if orbitalstr.startswith("("):
             continue  # a parent term such as '(5D)', not an occupied orbital
 
@@ -158,7 +164,10 @@ def _iter_occupied_orbitals(instr, warn: bool) -> t.Iterator[tuple[int, int, boo
                 pos += 1
             nelec = int(orbitalstr[nstart:pos]) if pos > nstart else 1
             foundorbital = True
-            yield l, nelec, l >= principalquantumnumber
+            # l >= n identifies a merge marker, but only where the token actually carried an n.
+            # Tokens such as the 'sp' of '3d8(2H)sp_2Go' have none, and calling those merged
+            # would discard the parity their name states outright.
+            yield l, nelec, nend > 0 and l >= principalquantumnumber
 
         if not foundorbital and warn:
             # don't fail silently: a skipped orbital means the parity (and hence the forbidden
@@ -176,7 +185,7 @@ def has_merged_orbital(instr) -> bool:
     return any(merged for _l, _nelec, merged in _iter_occupied_orbitals(instr, warn=False))
 
 
-def get_config_parity(instr) -> int | None:
+def get_config_parity(instr, warn: bool = False) -> int | None:
     """Parity of a configuration (0 even, 1 odd), or None when it does not determine one.
 
     None means no orbital in the name had a readable l to sum, as for CMFGEN's merged n-levels
@@ -184,10 +193,13 @@ def get_config_parity(instr) -> int | None:
     different from the 0 those would otherwise get from an empty sum. Merge markers are left out
     of the sum as in get_parity_from_config(), so check has_merged_orbital() as well when a level
     with no definite parity has to be recognised.
+
+    Unreadable names are the expected case for the callers that need the None, so this is quiet
+    by default; pass warn=True to get the per-orbital diagnostics.
     """
     lsum = 0
     readable = False
-    for l, nelec, merged in _iter_occupied_orbitals(instr, warn=True):
+    for l, nelec, merged in _iter_occupied_orbitals(instr, warn=warn):
         if not merged:
             lsum += l * nelec
             readable = True

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -30,12 +30,17 @@ def clear_files(args: argparse.Namespace) -> None:
 
 
 # A transition this strong is an electric dipole line, whatever the level names say. Below these
-# values, one that breaks the delta J rule is simply a forbidden line that the source listed with
-# its own small strength, which agrees with the label instead of contradicting it.
+# values, one that breaks the delta J rule is taken to be a forbidden line that the source listed
+# with its own small strength, which agrees with the label instead of contradicting it.
 #
-# The two need their own values because they are not the same quantity. f has no units and an E1
-# line carries 1e-3 to 1, so 1e-4 separates them. A is a rate in s-1 that spans many decades: a
-# forbidden line reaches ~1e2 (QUB's Co III peaks at 14), while an E1 line is 1e6 or more.
+# The two need their own values because they are not the same quantity. f has no units; A is a
+# rate in s-1 that spans many decades. Neither cut is a law of physics: a weak E1 line can sit
+# well below either (an intercombination line, or one between high levels), and a strong M1 or E2
+# line in a highly charged ion can sit above the A cut. They are where the two populations part in
+# this corpus -- forbidden lines end near f ~ 1e-6 and A ~ 1e2 (QUB's Co III peaks at 14 s-1),
+# and the lines that contradict their own J labels start at f = 7.8e-4 (F III's smallest), only
+# eight times above the cut. A mislabelled line weaker than that falls on the wrong side, and
+# that is the accepted cost.
 min_f_asserts_e1 = 1e-4
 min_a_asserts_e1 = 1e5
 

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -36,8 +36,21 @@ def clear_files(args: argparse.Namespace) -> None:
 # The two need their own values because they are not the same quantity. f has no units and an E1
 # line carries 1e-3 to 1, so 1e-4 separates them. A is a rate in s-1 that spans many decades: a
 # forbidden line reaches ~1e2 (QUB's Co III peaks at 14), while an E1 line is 1e6 or more.
-min_f_for_deltaj_contradiction = 1e-4
-min_a_for_deltaj_contradiction = 1e5
+min_f_asserts_e1 = 1e-4
+min_a_asserts_e1 = 1e5
+
+
+def strength_asserts_e1(dftransitions_ion: pl.DataFrame) -> pl.Expr:
+    """Whether the source's own numbers claim the transition is an electric dipole line.
+
+    f where the reader gives one, else the Einstein A. Both need a size, not merely a value: a
+    forbidden line has an A, and a reader that tabulates f gives one to its forbidden lines too,
+    so "greater than zero" says nothing about which kind of transition this is.
+    """
+    if "f" in dftransitions_ion.columns:
+        return pl.col("f").fill_null(0.0).abs() > min_f_asserts_e1
+
+    return pl.col("A").fill_null(0.0).abs() > min_a_asserts_e1
 
 
 def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion: pl.DataFrame) -> pl.DataFrame:
@@ -56,13 +69,13 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
     that does not carry the quantum number it needs. A data set that gives no J thus keeps the
     behaviour it had before this code read J at all.
 
-    The delta J rule applies only to a transition that came with no oscillator strength. Where
-    the source gives one, the source says the transition is E1, and that statement wins: some
-    files disagree with their own J labels. CMFGEN's provisional F III set splits a term by a
-    nominal 0.8 cm-1 and then shares the term's f over all the J pairs, so it lists delta J = 2
-    lines with f as large as 0.116. To call such a line forbidden would give a strong line the
-    forbidden collision approximation, which is worse than the label it corrects. Those
-    contradictions are counted and logged by write_output_files() instead.
+    The delta J rule yields to a transition the source made strong enough to be E1, as
+    strength_asserts_e1() judges it. Some files disagree with their own J labels: CMFGEN's
+    provisional F III set splits a term by a nominal 0.8 cm-1 and then shares the term's f over
+    all the J pairs, so it lists delta J = 2 lines with f as large as 0.116, and O II reaches
+    0.695. To call such a line forbidden would give a strong line the forbidden collision
+    approximation, which is worse than the label it corrects. write_output_files() logs those
+    instead. A weak line is not evidence of anything, so the J labels decide it.
 
     A null parity means the level has no definite parity, either because it merges sub-levels of
     both parities (CMFGEN's '1___' and '2s2_13w_2W') or because the reader could not read one
@@ -94,14 +107,7 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
         hasj = "j" in dfenergylevels_ion.columns
         knownj = pl.col("j").cast(pl.Float64, strict=False) if hasj else pl.lit(None, dtype=pl.Float64)
 
-        # An oscillator strength is the source's statement that the transition is E1. Any f at
-        # all counts as one, because a reader that supplies f computed it for this transition.
-        # A alone does not: every radiative transition has an Einstein A, a forbidden M1 or E2
-        # line included, so only a rate too large for those is evidence of an E1 line.
-        if "f" in dftransitions_ion.columns:
-            hasoscillatorstrength = pl.col("f").fill_null(0.0).abs() > 0.0
-        else:
-            hasoscillatorstrength = pl.col("A").fill_null(0.0).abs() > min_a_for_deltaj_contradiction
+        assertse1 = strength_asserts_e1(dftransitions_ion)
 
         dftransitions_ion = (
             dftransitions_ion.join(
@@ -133,7 +139,7 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
             # level with no J would undo what the two parities had already settled.
             .with_columns(
                 forbidden=(pl.col("lower_parity") == pl.col("upper_parity")).fill_null(False)
-                | (pl.col("breaksdeltaj") & ~hasoscillatorstrength)
+                | (pl.col("breaksdeltaj") & ~assertse1)
             )
             .drop("lower_j", "upper_j")
         )
@@ -156,10 +162,9 @@ def log_deltaj_contradictions(flog, dftransitions_ion: pl.DataFrame, ionstr: str
 
     hasf = "f" in dftransitions_ion.columns
     strengthcol = "f" if hasf else "A"
-    minstrength = min_f_for_deltaj_contradiction if hasf else min_a_for_deltaj_contradiction
-    contradictions = dftransitions_ion.filter(
-        pl.col("breaksdeltaj") & (pl.col(strengthcol).fill_null(0.0).abs() > minstrength)
-    )
+    minstrength = min_f_asserts_e1 if hasf else min_a_asserts_e1
+    # the same test the rule used, so this reports exactly the transitions it let through
+    contradictions = dftransitions_ion.filter(pl.col("breaksdeltaj") & strength_asserts_e1(dftransitions_ion))
     if contradictions.is_empty():
         return
 

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -29,6 +29,17 @@ def clear_files(args: argparse.Namespace) -> None:
         fphixs.write(f"{args.phixsnuincrement:14.7e}\n")
 
 
+# A transition this strong is an electric dipole line, whatever the level names say. Below these
+# values, one that breaks the delta J rule is simply a forbidden line that the source listed with
+# its own small strength, which agrees with the label instead of contradicting it.
+#
+# The two need their own values because they are not the same quantity. f has no units and an E1
+# line carries 1e-3 to 1, so 1e-4 separates them. A is a rate in s-1 that spans many decades: a
+# forbidden line reaches ~1e2 (QUB's Co III peaks at 14), while an E1 line is 1e6 or more.
+min_f_for_deltaj_contradiction = 1e-4
+min_a_for_deltaj_contradiction = 1e5
+
+
 def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion: pl.DataFrame) -> pl.DataFrame:
     """Fill in whichever of lowerlevel, upperlevel and forbidden a reader did not supply.
 
@@ -83,10 +94,14 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
         hasj = "j" in dfenergylevels_ion.columns
         knownj = pl.col("j").cast(pl.Float64, strict=False) if hasj else pl.lit(None, dtype=pl.Float64)
 
-        # f where the reader supplies one, else A, which is proportional to it. A transition with
-        # neither is one of the upsilon-only pairs, which no source called an E1 line.
-        strengthcol = "f" if "f" in dftransitions_ion.columns else "A"
-        hasoscillatorstrength = pl.col(strengthcol).fill_null(0.0).abs() > 0.0
+        # An oscillator strength is the source's statement that the transition is E1. Any f at
+        # all counts as one, because a reader that supplies f computed it for this transition.
+        # A alone does not: every radiative transition has an Einstein A, a forbidden M1 or E2
+        # line included, so only a rate too large for those is evidence of an E1 line.
+        if "f" in dftransitions_ion.columns:
+            hasoscillatorstrength = pl.col("f").fill_null(0.0).abs() > 0.0
+        else:
+            hasoscillatorstrength = pl.col("A").fill_null(0.0).abs() > min_a_for_deltaj_contradiction
 
         dftransitions_ion = (
             dftransitions_ion.join(
@@ -123,17 +138,6 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
             .drop("lower_j", "upper_j")
         )
     return dftransitions_ion
-
-
-# A transition this strong is an electric dipole line, whatever the level names say. Below these
-# values, one that breaks the delta J rule is simply a forbidden line that the source listed with
-# its own small strength, which agrees with the label instead of contradicting it.
-#
-# The two need their own values because they are not the same quantity. f has no units and an E1
-# line carries 1e-3 to 1, so 1e-4 separates them. A is a rate in s-1 that spans many decades: a
-# forbidden line reaches ~1e2 (QUB's Co III peaks at 14), while an E1 line is 1e6 or more.
-min_f_for_deltaj_contradiction = 1e-4
-min_a_for_deltaj_contradiction = 1e5
 
 
 def log_deltaj_contradictions(flog, dftransitions_ion: pl.DataFrame, ionstr: str) -> None:

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -39,7 +39,9 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
     A negative parity means the level has no definite parity, either because it merges sub-levels
     of both parities (CMFGEN's '1___' and '2s2_13w_2W') or because the reader could not read one
     from the level name. Those never count as a match: equal parity is only evidence of
-    forbiddenness when the parities are real.
+    forbiddenness when the parities are real. Anything a reader could not give a whole number
+    for -- a null, a NaN, a string pandas inferred from a blank column -- means the same thing,
+    so the column is normalised to Int64 first and unreadable values join the negatives.
     """
     if dftransitions_ion.is_empty():
         return dftransitions_ion
@@ -57,17 +59,17 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
         )
 
     if "forbidden" not in dftransitions_ion.columns:
+        # -1 for anything that is not a whole number: a NaN would otherwise compare equal to
+        # itself and pass the >= 0 test, and a null would make forbidden itself null, which
+        # write_transition_data's "{forbidden:d}" cannot format.
+        knownparity = pl.col("parity").cast(pl.Int64, strict=False).fill_null(-1)
         dftransitions_ion = (
             dftransitions_ion.join(
-                dfenergylevels_ion.select(
-                    pl.col("levelid").alias("lowerlevel"), pl.col("parity").alias("lower_parity")
-                ),
+                dfenergylevels_ion.select(pl.col("levelid").alias("lowerlevel"), knownparity.alias("lower_parity")),
                 on="lowerlevel",
             )
             .join(
-                dfenergylevels_ion.select(
-                    pl.col("levelid").alias("upperlevel"), pl.col("parity").alias("upper_parity")
-                ),
+                dfenergylevels_ion.select(pl.col("levelid").alias("upperlevel"), knownparity.alias("upper_parity")),
                 on="upperlevel",
             )
             .with_columns(forbidden=(pl.col("lower_parity") == pl.col("upper_parity")) & (pl.col("lower_parity") >= 0))

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -36,12 +36,13 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
     on here; readers that already supply ids keep them. A transition is forbidden when both of
     its levels have a known parity and it is the same one.
 
-    A negative parity means the level has no definite parity, either because it merges sub-levels
-    of both parities (CMFGEN's '1___' and '2s2_13w_2W') or because the reader could not read one
-    from the level name. Those never count as a match: equal parity is only evidence of
-    forbiddenness when the parities are real. Anything a reader could not give a whole number
-    for -- a null, a NaN, a string pandas inferred from a blank column -- means the same thing,
-    so the column is normalised to Int64 first and unreadable values join the negatives.
+    A null parity means the level has no definite parity, either because it merges sub-levels of
+    both parities (CMFGEN's '1___' and '2s2_13w_2W') or because the reader could not read one
+    from the level name. Null is the whole of that convention: polars resolves null == anything
+    to null rather than to true, so an absent parity cannot match another absent one, and no
+    sentinel number is needed for readers to spell it. Anything else a reader could not give a
+    whole number for -- a NaN, a string pandas inferred from a blank column -- casts to null and
+    is treated the same way.
     """
     if dftransitions_ion.is_empty():
         return dftransitions_ion
@@ -59,10 +60,9 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
         )
 
     if "forbidden" not in dftransitions_ion.columns:
-        # -1 for anything that is not a whole number: a NaN would otherwise compare equal to
-        # itself and pass the >= 0 test, and a null would make forbidden itself null, which
-        # write_transition_data's "{forbidden:d}" cannot format.
-        knownparity = pl.col("parity").cast(pl.Int64, strict=False).fill_null(-1)
+        # null for anything that is not a whole number, so a NaN cannot compare equal to itself
+        # and a string column cannot raise against the integer parities it is compared with
+        knownparity = pl.col("parity").cast(pl.Int64, strict=False)
         dftransitions_ion = (
             dftransitions_ion.join(
                 dfenergylevels_ion.select(pl.col("levelid").alias("lowerlevel"), knownparity.alias("lower_parity")),
@@ -72,7 +72,9 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
                 dfenergylevels_ion.select(pl.col("levelid").alias("upperlevel"), knownparity.alias("upper_parity")),
                 on="upperlevel",
             )
-            .with_columns(forbidden=(pl.col("lower_parity") == pl.col("upper_parity")) & (pl.col("lower_parity") >= 0))
+            # an unknown parity leaves the comparison null, which is neither forbidden nor
+            # something write_transition_data's "{forbidden:d}" could format
+            .with_columns(forbidden=(pl.col("lower_parity") == pl.col("upper_parity")).fill_null(False))
         )
     return dftransitions_ion
 

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -33,8 +33,13 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
     """Fill in whichever of lowerlevel, upperlevel and forbidden a reader did not supply.
 
     Readers that key their transitions by level name (namefrom/nameto) get the level ids joined
-    on here; readers that already supply ids keep them. A transition is forbidden when its two
-    levels have the same parity.
+    on here; readers that already supply ids keep them. A transition is forbidden when both of
+    its levels have a known parity and it is the same one.
+
+    A negative parity means the level has no definite parity, either because it merges sub-levels
+    of both parities (CMFGEN's '1___' and '2s2_13w_2W') or because the reader could not read one
+    from the level name. Those never count as a match: equal parity is only evidence of
+    forbiddenness when the parities are real.
     """
     if dftransitions_ion.is_empty():
         return dftransitions_ion
@@ -65,7 +70,7 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
                 ),
                 on="upperlevel",
             )
-            .with_columns(forbidden=pl.col("lower_parity") == pl.col("upper_parity"))
+            .with_columns(forbidden=(pl.col("lower_parity") == pl.col("upper_parity")) & (pl.col("lower_parity") >= 0))
         )
     return dftransitions_ion
 

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -33,16 +33,33 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
     """Fill in whichever of lowerlevel, upperlevel and forbidden a reader did not supply.
 
     Readers that key their transitions by level name (namefrom/nameto) get the level ids joined
-    on here; readers that already supply ids keep them. A transition is forbidden when both of
-    its levels have a known parity and it is the same one.
+    on here; readers that already supply ids keep them.
+
+    Forbidden here means "not an electric dipole transition", and two of the E1 selection rules
+    are checked, each on whichever levels carry what it needs:
+
+    - Laporte: E1 changes the parity, so two levels of the same parity cannot be E1.
+    - Delta J: E1 has |J_upper - J_lower| <= 1, and J = 0 -> J = 0 is forbidden outright.
+
+    Either rule is sufficient on its own, so the two are OR-ed. Neither rule can fire on a level
+    that does not carry the quantum number it needs. A data set that gives no J thus keeps the
+    behaviour it had before this code read J at all.
+
+    The delta J rule applies only to a transition that came with no oscillator strength. Where
+    the source gives one, the source says the transition is E1, and that statement wins: some
+    files disagree with their own J labels. CMFGEN's provisional F III set splits a term by a
+    nominal 0.8 cm-1 and then shares the term's f over all the J pairs, so it lists delta J = 2
+    lines with f as large as 0.116. To call such a line forbidden would give a strong line the
+    forbidden collision approximation, which is worse than the label it corrects. Those
+    contradictions are counted and logged by write_output_files() instead.
 
     A null parity means the level has no definite parity, either because it merges sub-levels of
     both parities (CMFGEN's '1___' and '2s2_13w_2W') or because the reader could not read one
     from the level name. Null is the whole of that convention: polars resolves null == anything
     to null rather than to true, so an absent parity cannot match another absent one, and no
-    sentinel number is needed for readers to spell it. Anything else a reader could not give a
-    whole number for -- a NaN, a string pandas inferred from a blank column -- casts to null and
-    is treated the same way.
+    sentinel number is needed for readers to spell it. A null J means the same, and both are
+    resolved the same way: anything a reader could not give a number for -- a NaN, a string
+    pandas inferred from a blank column -- casts to null and disables only its own rule.
     """
     if dftransitions_ion.is_empty():
         return dftransitions_ion
@@ -60,23 +77,96 @@ def add_level_ids_forbidden(dfenergylevels_ion: pl.DataFrame, dftransitions_ion:
         )
 
     if "forbidden" not in dftransitions_ion.columns:
-        # null for anything that is not a whole number, so a NaN cannot compare equal to itself
-        # and a string column cannot raise against the integer parities it is compared with
+        # null for anything that is not a number, so a NaN cannot compare equal to itself and a
+        # string column cannot raise against the numbers it is compared with
         knownparity = pl.col("parity").cast(pl.Int64, strict=False)
+        hasj = "j" in dfenergylevels_ion.columns
+        knownj = pl.col("j").cast(pl.Float64, strict=False) if hasj else pl.lit(None, dtype=pl.Float64)
+
+        # f where the reader supplies one, else A, which is proportional to it. A transition with
+        # neither is one of the upsilon-only pairs, which no source called an E1 line.
+        strengthcol = "f" if "f" in dftransitions_ion.columns else "A"
+        hasoscillatorstrength = pl.col(strengthcol).fill_null(0.0).abs() > 0.0
+
         dftransitions_ion = (
             dftransitions_ion.join(
-                dfenergylevels_ion.select(pl.col("levelid").alias("lowerlevel"), knownparity.alias("lower_parity")),
+                dfenergylevels_ion.select(
+                    pl.col("levelid").alias("lowerlevel"),
+                    knownparity.alias("lower_parity"),
+                    knownj.alias("lower_j"),
+                ),
                 on="lowerlevel",
             )
             .join(
-                dfenergylevels_ion.select(pl.col("levelid").alias("upperlevel"), knownparity.alias("upper_parity")),
+                dfenergylevels_ion.select(
+                    pl.col("levelid").alias("upperlevel"),
+                    knownparity.alias("upper_parity"),
+                    knownj.alias("upper_j"),
+                ),
                 on="upperlevel",
             )
-            # an unknown parity leaves the comparison null, which is neither forbidden nor
-            # something write_transition_data's "{forbidden:d}" could format
-            .with_columns(forbidden=(pl.col("lower_parity") == pl.col("upper_parity")).fill_null(False))
+            # The delta J rule is kept as its own column, because write_output_files() reports
+            # the transitions that break it while the source still gives them an f.
+            .with_columns(
+                breaksdeltaj=(
+                    ((pl.col("lower_j") - pl.col("upper_j")).abs() > 1)
+                    | ((pl.col("lower_j") == 0) & (pl.col("upper_j") == 0))
+                ).fill_null(False)
+            )
+            # Each rule gets fill_null(False) on its own, before the or. A null would otherwise
+            # spread and make forbidden itself null, which "{forbidden:d}" cannot format, and a
+            # level with no J would undo what the two parities had already settled.
+            .with_columns(
+                forbidden=(pl.col("lower_parity") == pl.col("upper_parity")).fill_null(False)
+                | (pl.col("breaksdeltaj") & ~hasoscillatorstrength)
+            )
+            .drop("lower_j", "upper_j")
         )
     return dftransitions_ion
+
+
+# A transition this strong is an electric dipole line, whatever the level names say. Below these
+# values, one that breaks the delta J rule is simply a forbidden line that the source listed with
+# its own small strength, which agrees with the label instead of contradicting it.
+#
+# The two need their own values because they are not the same quantity. f has no units and an E1
+# line carries 1e-3 to 1, so 1e-4 separates them. A is a rate in s-1 that spans many decades: a
+# forbidden line reaches ~1e2 (QUB's Co III peaks at 14), while an E1 line is 1e6 or more.
+min_f_for_deltaj_contradiction = 1e-4
+min_a_for_deltaj_contradiction = 1e5
+
+
+def log_deltaj_contradictions(flog, dftransitions_ion: pl.DataFrame, ionstr: str) -> None:
+    """Report the transitions whose J labels and oscillator strength contradict each other.
+
+    A transition with |delta J| > 1, or with J = 0 at both ends, is not an electric dipole
+    transition. A large oscillator strength says that it is. add_level_ids_forbidden() lets the
+    oscillator strength win, so the transition stays permitted, and this reports how often a data
+    set needed that.
+
+    CMFGEN's provisional F III set is the known example: it splits a term by a nominal 0.8 cm-1
+    and shares the term's f over all the J pairs, so a delta J = 2 line can carry f = 0.116.
+    """
+    if "breaksdeltaj" not in dftransitions_ion.columns:
+        return
+
+    hasf = "f" in dftransitions_ion.columns
+    strengthcol = "f" if hasf else "A"
+    minstrength = min_f_for_deltaj_contradiction if hasf else min_a_for_deltaj_contradiction
+    contradictions = dftransitions_ion.filter(
+        pl.col("breaksdeltaj") & (pl.col(strengthcol).fill_null(0.0).abs() > minstrength)
+    )
+    if contradictions.is_empty():
+        return
+
+    largest = contradictions[strengthcol].abs().max()
+    log_and_print(
+        flog,
+        f"WARNING: {contradictions.height:d} transitions of {ionstr} break the delta J rule but"
+        f" carry {strengthcol} > {minstrength:g} (largest {largest:.3g}). The level names and the"
+        f" {strengthcol} values of this data set disagree. The {strengthcol} values are used, so"
+        f" these stay permitted.",
+    )
 
 
 def write_output_files(atomic_number: int, iondatalist: list[IonData], args: argparse.Namespace) -> None:
@@ -105,6 +195,7 @@ def write_output_files(atomic_number: int, iondatalist: list[IonData], args: arg
                 unused_upsilon_transitions = set()
             else:
                 dftransitions_ion = add_level_ids_forbidden(dfenergylevels_ion, dftransitions_ion)
+                log_deltaj_contradictions(flog, dftransitions_ion, ionstr)
                 unused_upsilon_transitions = set(upsilondict.keys()).difference(
                     dftransitions_ion[["lowerlevel", "upperlevel"]].iter_rows(named=False)
                 )

--- a/artisatomic/readboyledata.py
+++ b/artisatomic/readboyledata.py
@@ -35,7 +35,7 @@ class EnergyLevelRow(t.NamedTuple):
     g: float
     metastable: float
     energyabovegsinpercm: float
-    parity: int
+    parity: int | None  # None where the data set gives no parity
     levelname: str
 
 
@@ -103,12 +103,12 @@ def read_levels_data(atomic_number, ion_stage):
                 g=g,
                 metastable=metastable,
                 energyabovegsinpercm=energyabovegsinpercm,
-                # A DISTINCT parity per level. This data set supplies none, and
-                # add_level_ids_forbidden() marks a transition forbidden when its two levels share
-                # one, so a fixed 0 made every transition of the ion forbidden (coll_str -2) when
-                # helium has plenty of permitted ones. readlisbondata and readkuruczdata use the
-                # negated level id for the same reason.
-                parity=-int(level_number),
+                # No parity: this data set supplies none, and add_level_ids_forbidden() marks a
+                # transition forbidden when its two levels share one, so a fixed 0 made every
+                # transition of the ion forbidden (coll_str -2) when helium has plenty of
+                # permitted ones. A null parity never matches another, here as in the other
+                # readers whose data set has no parities.
+                parity=None,
                 # int() as read_lines_data() does, so the two agree on the name whatever dtype the
                 # file stores the level number in
                 levelname=f"level{int(level_number):05d}",

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -35,7 +35,7 @@ class HillierEnergyLevel(t.NamedTuple):
     energyabovegsinpercm: float
     lambdaangstrom: float
     hillierlevelid: int
-    parity: int
+    parity: int | None  # None where the level has no definite parity, e.g. a merged '1___'
 
 
 class HillierTransition(t.NamedTuple):
@@ -51,7 +51,8 @@ class HillierTransition(t.NamedTuple):
     hilliertransitionid: int
 
 
-_pl_dtype_of = {str: pl.String, float: pl.Float64, int: pl.Int64}
+# every polars column is nullable, so an optional field needs no separate dtype
+_pl_dtype_of = {str: pl.String, float: pl.Float64, int: pl.Int64, int | None: pl.Int64}
 
 # derived from the NamedTuples so the row classes stay the single source of the frame layouts
 hillier_level_schema = pl.Schema(
@@ -466,10 +467,9 @@ def read_levels_and_transitions(
 
                 if ismerged:
                     # No definite parity: a merged level, which is normal CMFGEN, or a name we
-                    # could not read. Give each one its own value so that no two of them can
-                    # compare equal and be called forbidden, whatever the consumer does with the
-                    # parity column. add_level_ids_forbidden() also rejects negatives outright.
-                    parity = -1 - len(levelrows)
+                    # could not read. Null rather than a number, so that add_level_ids_forbidden()
+                    # cannot match it against another level's absent parity.
+                    parity = None
                     levels_without_parity.append(levelname)
 
                 levelrows.append(

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -317,15 +317,22 @@ def get_level_parity(config: str) -> int:
     return -1 if configparity is None else configparity
 
 
-def get_level_j(levelname: str) -> float | None:
+def get_level_j(levelname: str, g: float | None = None) -> float | None:
     """J of a Hillier level name, or None where the name does not state one.
 
     CMFGEN writes J in brackets at the end of a J-resolved level's name, as a whole number or a
     half-integer fraction: '3d6_a5De[4]', '3d5(4D)4po[9/2]'. A term-resolved level has no
     bracket, and its g counts every J of the term, so nothing can be recovered from that either.
 
-    JJ-coupling names carry theirs in braces ('2s2_2p(2P<1/2>)4f_2{5/2}e') where the brackets
-    would otherwise hold the level index, so those are read too.
+    The last bracketed or braced group is the one read. In pair coupling the brace holds K and
+    the bracket J ('2p5(2P*<1/2>)3d_2{3/2}o[1]'); a name with a brace and nothing after it gives
+    J there ('2s2_2p(2P<1/2>)4f_2{5/2}e'). Both come out right that way, checked against g for
+    every such level in the corpus.
+
+    Not every trailing bracket is a J. Si X and S X number their levels in brackets instead
+    ('2p3p3Pe[3]' with g = 5, and a 3P term has no J = 3), and a few single levels elsewhere do
+    the same. Pass the level's g and the value is returned only where g == 2J + 1, which is
+    what J means; anything else is some other bracketed number and gives None.
     """
     match = re.search(r"[\[{](\d+)(?:/(\d+))?[\]}]\w*$", levelname)
     if match is None:
@@ -333,10 +340,16 @@ def get_level_j(levelname: str) -> float | None:
 
     numerator, denominator = match.group(1), match.group(2)
     if denominator is None:
-        return float(numerator)
+        j = float(numerator)
+    elif denominator == "2":
+        j = float(numerator) / 2.0
+    else:
+        return None  # only halves are physical, so this is some other bracketed quantity
 
-    # only halves are physical, so anything else is some other bracketed quantity
-    return float(numerator) / float(denominator) if denominator == "2" else None
+    if g is not None and abs(g - (2 * j + 1)) > 1e-6:
+        return None  # the bracket held something other than J
+
+    return j
 
 
 def get_term_as_tuple(config: str) -> tuple[int, int, int]:
@@ -517,7 +530,7 @@ def read_levels_and_transitions(
                         lambdaangstrom=lambdaangstrom,
                         hillierlevelid=hillierlevelid,
                         parity=parity,
-                        j=get_level_j(levelname),
+                        j=get_level_j(levelname, g=float(row[colindex["g"]])),
                     )
                 )
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -276,24 +276,51 @@ def hillier_ion_folder(atomic_number, ion_stage):
     )
 
 
+def get_level_parity(config: str) -> int:
+    """Parity of a Hillier level name: 0 even, 1 odd, -1 no definite parity.
+
+    The trailing 'e'/'o' of the name is the parity wherever there is one, which is almost always:
+    it agrees with every level name in the CMFGEN set whose term is otherwise readable, and it is
+    the only thing that gets the intermediate-coupling names right ('3d5(4D)4po[3]', where the
+    term letter belongs to the parent term '(4D)' rather than to the level).
+
+    Names with no suffix fall back to summing l over the occupied orbitals. That leaves the
+    levels that merge sub-levels of both parities and so have no parity to read: CMFGEN's merged
+    high-l levels ('2s2_13w_2W'), its merged n-levels ('1___', '13___', g = 2n^2) and He I's
+    merged singlets and triplets ('8SNG', '8TRP'). Those are -1, which
+    add_level_ids_forbidden() never counts as a parity match.
+    """
+    config = config.split("[", maxsplit=1)[0]
+    if not config:
+        return -1
+
+    # first, because a merged level spans both parities whatever the rest of the name says
+    if artisatomic.has_merged_orbital(config):
+        return -1
+
+    if config[-1] == "e":
+        return 0
+    if config[-1] == "o":
+        return 1
+
+    configparity = artisatomic.get_config_parity(config)
+    return -1 if configparity is None else configparity
+
+
 def get_term_as_tuple(config: str) -> tuple[int, int, int]:
     """Read the LS term of a Hillier level name as (2S+1, L, parity), parity 0 even and 1 odd.
 
     Returns -1 for any component that cannot be read, which readers log rather than treat as an
-    error. Parity comes from the name's 'e'/'o' suffix where it has one; otherwise it is summed
-    over the occupied orbitals, which is what handles CMFGEN's merged high-l levels.
+    error. The parity is worked out separately by get_level_parity(), so it can still come back
+    when the term itself is unreadable.
     """
+    parity = get_level_parity(config)
     config = config.split("[", maxsplit=1)[0]
 
     if "{" in config and "}" in config:  # JJ coupling, no L and S
-        if config[-1] == "e":
-            return (-1, -1, 0)
-
-        if config[-1] == "o":
-            return (-1, -1, 1)
-
-        print(f"WARNING: Can't read parity from JJ coupling state '{config}'")
-        return (-1, -1, -1)
+        if parity < 0:
+            print(f"WARNING: Can't read parity from JJ coupling state '{config}'")
+        return (-1, -1, parity)
 
     lposition = -1
     l = -1
@@ -303,36 +330,15 @@ def get_term_as_tuple(config: str) -> tuple[int, int, int]:
             l = lchars.index(char)
             break
     if lposition < 0:
-        if config[-1] == "e":
-            return (-1, -1, 0)
-        if config[-1] == "o":
-            return (-1, -1, 1)
-        return (-1, -1, -1)
-    # a malformed name can fail at the int() or at either index, and any of those just means
-    # the term is unreadable
-    try:  # ruff: ignore[too-many-statements-in-try-clause]
+        return (-1, -1, parity)
+
+    # a malformed name can fail at the int() or at the index, and either just means the term is
+    # unreadable, which says nothing about the parity
+    try:
         twosplusone = int(config[lposition - 1])  # could this be two digits long?
-        if lposition + 1 > len(config) - 1:
-            # No 'e'/'o' suffix to give the parity. CMFGEN writes its merged high-l levels this
-            # way, repeating the orbital letter as the term symbol (2s2_13w_2W, 2s2_2p3(4So)5z_5Z),
-            # so sum l over the occupied orbitals instead of assuming an even term.
-            parity = artisatomic.get_parity_from_config(config)
-        elif config[lposition + 1] == "o":
-            parity = 1
-        elif config[lposition + 1] == "e":
-            parity = 0
-        elif config[lposition + 2] == "o":
-            parity = 1
-        elif config[lposition + 2] == "e":
-            parity = 0
-        else:
-            twosplusone = -1
-            l = -1
-            parity = -1
     except (IndexError, ValueError):
-        twosplusone = -1
-        l = -1
-        parity = -1
+        return (-1, -1, parity)
+
     return (twosplusone, l, parity)
 
 
@@ -378,6 +384,7 @@ def read_levels_and_transitions(
     artisatomic.log_and_print(flog, f"Reading {artisatomic.path_for_log(filename)}")
 
     levelrows: list[HillierEnergyLevel] = []
+    levels_without_parity: list[str] = []
     transitionrows: list[HillierTransition] = []
 
     prev_line = ""
@@ -448,6 +455,14 @@ def read_levels_and_transitions(
                 lambdaangstrom = float(row[colindex["lambdaangstrom"]].replace("D", "E"))
                 (twosplusone, _l, parity) = get_term_as_tuple(levelname)
 
+                if parity < 0:
+                    # No definite parity: a merged level, which is normal CMFGEN, or a name we
+                    # could not read. Give each one its own value so that no two of them can
+                    # compare equal and be called forbidden, whatever the consumer does with the
+                    # parity column. add_level_ids_forbidden() also rejects negatives outright.
+                    parity = -1 - len(levelrows)
+                    levels_without_parity.append(levelname)
+
                 levelrows.append(
                     HillierEnergyLevel(
                         levelname=levelname,
@@ -459,8 +474,9 @@ def read_levels_and_transitions(
                     )
                 )
 
-                # -1 indicates that the term could not be interpreted
-                if twosplusone == -1 and atomic_number > 1 and parity == -1:
+                # -1 indicates that the term could not be interpreted. Levels with no parity are
+                # summarised once below instead, so that a merged ion does not log every level.
+                if twosplusone == -1 and atomic_number > 1 and parity >= 0:
                     artisatomic.log_and_print(flog, f"Can't find LS term in Hillier level name '{levelname}'")
 
                 # if this is the ground state
@@ -478,6 +494,15 @@ def read_levels_and_transitions(
                 break
 
         artisatomic.log_and_print(flog, f"Read {len(levelrows):d} levels")
+        if levels_without_parity:
+            # Normal for ions with merged levels, so this is a count and a sample rather than a
+            # warning per level: H I and He II are merged all the way down.
+            artisatomic.log_and_print(
+                flog,
+                f"{len(levels_without_parity):d} of {len(levelrows):d} levels have no definite parity"
+                f" (transitions between them are treated as permitted), e.g."
+                f" {', '.join(levels_without_parity[:5])}",
+            )
         if len(levelrows) != expected_energy_levels:
             msg = f"{filename} declares {expected_energy_levels} levels but {len(levelrows)} were read"
             raise ValueError(msg)

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -329,14 +329,21 @@ def get_term_as_tuple(config: str) -> tuple[int, int, int]:
             lposition = charpos
             l = lchars.index(char)
             break
-    if lposition < 0:
+    # lposition == 0 leaves no room for the multiplicity, and config[-1] would quietly wrap round
+    # to the end of the name and read some other character as it
+    if lposition < 1:
         return (-1, -1, parity)
 
-    # a malformed name can fail at the int() or at the index, and either just means the term is
-    # unreadable, which says nothing about the parity
+    # The only L character can belong to a parenthesised parent term rather than to the level, as
+    # in '3d5(4D)4po[3]', where reporting the '(4D)' would describe the parent and not this level.
+    # An unclosed '(' before it is what tells them apart.
+    if config.rfind("(", 0, lposition) > config.rfind(")", 0, lposition):
+        return (-1, -1, parity)
+
+    # a malformed name just means the term is unreadable, which says nothing about the parity
     try:
         twosplusone = int(config[lposition - 1])  # could this be two digits long?
-    except (IndexError, ValueError):
+    except ValueError:
         return (-1, -1, parity)
 
     return (twosplusone, l, parity)
@@ -454,8 +461,10 @@ def read_levels_and_transitions(
                 energyabovegsinpercm = float(row[colindex["energyabovegsinpercm"]].replace("D", "E"))
                 lambdaangstrom = float(row[colindex["lambdaangstrom"]].replace("D", "E"))
                 (twosplusone, _l, parity) = get_term_as_tuple(levelname)
+                ismerged = parity < 0
+                isjjcoupled = "{" in levelname and "}" in levelname
 
-                if parity < 0:
+                if ismerged:
                     # No definite parity: a merged level, which is normal CMFGEN, or a name we
                     # could not read. Give each one its own value so that no two of them can
                     # compare equal and be called forbidden, whatever the consumer does with the
@@ -474,9 +483,10 @@ def read_levels_and_transitions(
                     )
                 )
 
-                # -1 indicates that the term could not be interpreted. Levels with no parity are
-                # summarised once below instead, so that a merged ion does not log every level.
-                if twosplusone == -1 and atomic_number > 1 and parity >= 0:
+                # -1 indicates that the term could not be interpreted. JJ-coupled names have no
+                # LS term by construction and merged levels are summarised once below, so neither
+                # is worth a line here; what is left is a name we expected to read and could not.
+                if twosplusone == -1 and atomic_number > 1 and not isjjcoupled and not ismerged:
                     artisatomic.log_and_print(flog, f"Can't find LS term in Hillier level name '{levelname}'")
 
                 # if this is the ground state
@@ -500,7 +510,7 @@ def read_levels_and_transitions(
             artisatomic.log_and_print(
                 flog,
                 f"{len(levels_without_parity):d} of {len(levelrows):d} levels have no definite parity"
-                f" (transitions between them are treated as permitted), e.g."
+                f" (every transition touching one is treated as permitted), e.g."
                 f" {', '.join(levels_without_parity[:5])}",
             )
         if len(levelrows) != expected_energy_levels:

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1,6 +1,7 @@
 """Read levels, transitions, collision strengths and cross sections from Hillier's CMFGEN data."""
 
 import os
+import re
 import sys
 import typing as t
 from collections import defaultdict
@@ -26,7 +27,8 @@ hillier_rowformat_noheader = "levelname g energyabovegsinpercm freqtentothe15hz 
 
 
 # The files disagree on which columns they carry, so only these are kept and every ion gets the
-# same frame. parity is not in the file: it is read from the level name and decides forbidden-ness.
+# same frame. Neither parity nor J is in the file: both are read from the level name, and both
+# decide forbidden-ness.
 class HillierEnergyLevel(t.NamedTuple):
     """One energy level read from a CMFGEN oscillator file."""
 
@@ -36,6 +38,7 @@ class HillierEnergyLevel(t.NamedTuple):
     lambdaangstrom: float
     hillierlevelid: int
     parity: int | None  # None where the level has no definite parity, e.g. a merged '1___'
+    j: float | None  # None where the name carries no J, as a term-resolved level does not
 
 
 class HillierTransition(t.NamedTuple):
@@ -52,7 +55,13 @@ class HillierTransition(t.NamedTuple):
 
 
 # every polars column is nullable, so an optional field needs no separate dtype
-_pl_dtype_of = {str: pl.String, float: pl.Float64, int: pl.Int64, int | None: pl.Int64}
+_pl_dtype_of = {
+    str: pl.String,
+    float: pl.Float64,
+    int: pl.Int64,
+    int | None: pl.Int64,
+    float | None: pl.Float64,
+}
 
 # derived from the NamedTuples so the row classes stay the single source of the frame layouts
 hillier_level_schema = pl.Schema(
@@ -62,8 +71,8 @@ hillier_transition_schema = pl.Schema(
     {name: _pl_dtype_of[fieldtype] for name, fieldtype in HillierTransition.__annotations__.items()}
 )
 
-# every schema column except parity is read straight out of the level table
-hillier_required_filecolumns = tuple(colname for colname in hillier_level_schema if colname != "parity")
+# every schema column except the two read from the level name comes straight out of the table
+hillier_required_filecolumns = tuple(colname for colname in hillier_level_schema if colname not in {"parity", "j"})
 
 
 # keys are (atomic number, ion stage)
@@ -308,6 +317,28 @@ def get_level_parity(config: str) -> int:
     return -1 if configparity is None else configparity
 
 
+def get_level_j(levelname: str) -> float | None:
+    """J of a Hillier level name, or None where the name does not state one.
+
+    CMFGEN writes J in brackets at the end of a J-resolved level's name, as a whole number or a
+    half-integer fraction: '3d6_a5De[4]', '3d5(4D)4po[9/2]'. A term-resolved level has no
+    bracket, and its g counts every J of the term, so nothing can be recovered from that either.
+
+    JJ-coupling names carry theirs in braces ('2s2_2p(2P<1/2>)4f_2{5/2}e') where the brackets
+    would otherwise hold the level index, so those are read too.
+    """
+    match = re.search(r"[\[{](\d+)(?:/(\d+))?[\]}]\w*$", levelname)
+    if match is None:
+        return None
+
+    numerator, denominator = match.group(1), match.group(2)
+    if denominator is None:
+        return float(numerator)
+
+    # only halves are physical, so anything else is some other bracketed quantity
+    return float(numerator) / float(denominator) if denominator == "2" else None
+
+
 def get_term_as_tuple(config: str) -> tuple[int, int, int]:
     """Read the LS term of a Hillier level name as (2S+1, L, parity), parity 0 even and 1 odd.
 
@@ -373,7 +404,13 @@ def read_levels_and_transitions(
             pl.DataFrame(
                 [
                     HillierEnergyLevel(
-                        levelname="I", g=10.0, energyabovegsinpercm=0.0, lambdaangstrom=0.0, hillierlevelid=1, parity=0
+                        levelname="I",
+                        g=10.0,
+                        energyabovegsinpercm=0.0,
+                        lambdaangstrom=0.0,
+                        hillierlevelid=1,
+                        parity=0,
+                        j=None,  # a bare nucleus, with no transitions for a J to bear on
                     )
                 ],
                 schema=hillier_level_schema,
@@ -480,6 +517,7 @@ def read_levels_and_transitions(
                         lambdaangstrom=lambdaangstrom,
                         hillierlevelid=hillierlevelid,
                         parity=parity,
+                        j=get_level_j(levelname),
                     )
                 )
 

--- a/artisatomic/readkuruczdata.py
+++ b/artisatomic/readkuruczdata.py
@@ -220,7 +220,9 @@ def read_levels_and_transitions(
         .collect()
     )
     dflevels = artisatomic.leveltuples_to_pldataframe(dflevels).with_columns(
-        parity=-pl.col("levelid")  # give a unique parity so that all transitions are permitted
+        # this data set supplies no parities, and a null one never matches another, so
+        # add_level_ids_forbidden() leaves every transition permitted
+        parity=pl.lit(None, dtype=pl.Int64)
     )
     artisatomic.log_and_print(flog, f"Read {len(dflevels):d} levels")
 

--- a/artisatomic/readlisbondata.py
+++ b/artisatomic/readlisbondata.py
@@ -104,8 +104,8 @@ def read_levels_data(dflevels):
     index label. So the map is keyed by that position, which reset_index() below makes explicit
     rather than relying on the levels CSV happening to be numbered from zero.
 
-    Every level is given a distinct parity so that add_level_ids_forbidden() marks none of the
-    transitions forbidden: this data set does not supply parities.
+    Every level's parity is null so that add_level_ids_forbidden() marks none of the transitions
+    forbidden: this data set does not supply parities, and a null one never matches another.
     """
     # sort first, so that the ids handed out below are the ones the levels keep. The index is
     # reset to the row position beforehand, so sorting leaves each level carrying its file position
@@ -114,7 +114,7 @@ def read_levels_data(dflevels):
     energy_levels = [
         EnergyLevelTuple(
             levelname=get_levelname(row),
-            parity=-levelid,  # give a unique parity so that all transitions are permitted
+            parity=None,  # no parity in this data set, so all transitions stay permitted
             g=2 * row.j + 1,
             energyabovegsinpercm=float(row.energy),
         )
@@ -157,7 +157,7 @@ class EnergyLevelTuple(t.NamedTuple):
     levelname: str
     energyabovegsinpercm: float
     g: float
-    parity: int
+    parity: int | None  # None where the data set gives no parity
 
 
 class TransitionTuple(t.NamedTuple):

--- a/artisatomic/readlisbondata.py
+++ b/artisatomic/readlisbondata.py
@@ -104,8 +104,9 @@ def read_levels_data(dflevels):
     index label. So the map is keyed by that position, which reset_index() below makes explicit
     rather than relying on the levels CSV happening to be numbered from zero.
 
-    Every level's parity is null so that add_level_ids_forbidden() marks none of the transitions
-    forbidden: this data set does not supply parities, and a null one never matches another.
+    This data set supplies no parities, so every level's parity is null and the Laporte rule
+    never fires. It does supply J, which its level names are keyed on, so the delta J rule is
+    what decides forbidden-ness here.
     """
     # sort first, so that the ids handed out below are the ones the levels keep. The index is
     # reset to the row position beforehand, so sorting leaves each level carrying its file position
@@ -114,7 +115,8 @@ def read_levels_data(dflevels):
     energy_levels = [
         EnergyLevelTuple(
             levelname=get_levelname(row),
-            parity=None,  # no parity in this data set, so all transitions stay permitted
+            parity=None,  # no parity in this data set, so the Laporte rule cannot fire
+            j=float(row.j),
             g=2 * row.j + 1,
             energyabovegsinpercm=float(row.energy),
         )
@@ -158,6 +160,7 @@ class EnergyLevelTuple(t.NamedTuple):
     energyabovegsinpercm: float
     g: float
     parity: int | None  # None where the data set gives no parity
+    j: float  # the level's J, which its name is keyed on and its g derived from
 
 
 class TransitionTuple(t.NamedTuple):

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -49,7 +49,7 @@ class QUBEnergyLevel(t.NamedTuple):
     j: float
     energyabovegsinpercm: float
     g: float
-    parity: int
+    parity: int | None  # None where the configuration determines no parity
 
 
 qubpath = (Path(__file__).parent.resolve() / ".." / "atomic-data-qub").resolve()
@@ -126,18 +126,18 @@ def read_adf04(
                     0.0,
                     0,
                 )
-            # Deliberately the best-effort sum rather than get_config_parity(): an adf04
-            # configuration is often bare ('5s2') or uppercase ('3S2 3P6 3D5 4P1'), and
-            # interpret_configuration() reads neither as orbitals, so get_config_parity() would
-            # call the parity unknown for entire files. This keeps the long-standing behaviour --
-            # an empty sum, hence 0 -- which is right only where the true parity is even; fixing
-            # that needs the configuration parser to handle these forms, not a different caller.
-            parity = artisatomic.get_parity_from_config(config)
+            # hasterm=False: an adf04 name is all configuration, because the file keeps 2S+1 and
+            # L in their own columns (read just above). Stripping a term off the end would lose
+            # the last orbital of '3S2 3P6 3D5 4P1', and would read the bare '5s2' as a term
+            # rather than an orbital, which is how every level of some files came out even.
+            parity = artisatomic.get_config_parity(config, hasterm=False)
 
             levelname = energylevel.levelname + "_{:d}{:}{:}[{:d}/2]_id={:}".format(
                 energylevel.twosplusone,
                 lchars[energylevel.l],
-                ["e", "o"][parity],
+                # the name keeps the old even/odd letter where the parity is unknown, so that
+                # adata.txt does not depend on a distinction the parity column now makes
+                ["e", "o"][parity if parity is not None else 0],
                 int(2 * energylevel.j),
                 energylevel.qub_id,
             )

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -49,7 +49,7 @@ class QUBEnergyLevel(t.NamedTuple):
     j: float
     energyabovegsinpercm: float
     g: float
-    parity: int | None  # None where the configuration determines no parity
+    parity: int
 
 
 qubpath = (Path(__file__).parent.resolve() / ".." / "atomic-data-qub").resolve()
@@ -126,15 +126,18 @@ def read_adf04(
                     0.0,
                     0,
                 )
-            # None where the configuration determines no parity. The level name keeps the old
-            # best-effort even/odd letter in that case, so that names (and the adata.txt they are
-            # written to) do not depend on this, but the parity column says what is actually known
-            parity = artisatomic.get_config_parity(config)
+            # Deliberately the best-effort sum rather than get_config_parity(): an adf04
+            # configuration is often bare ('5s2') or uppercase ('3S2 3P6 3D5 4P1'), and
+            # interpret_configuration() reads neither as orbitals, so get_config_parity() would
+            # call the parity unknown for entire files. This keeps the long-standing behaviour --
+            # an empty sum, hence 0 -- which is right only where the true parity is even; fixing
+            # that needs the configuration parser to handle these forms, not a different caller.
+            parity = artisatomic.get_parity_from_config(config)
 
             levelname = energylevel.levelname + "_{:d}{:}{:}[{:d}/2]_id={:}".format(
                 energylevel.twosplusone,
                 lchars[energylevel.l],
-                ["e", "o"][parity if parity is not None else 0],
+                ["e", "o"][parity],
                 int(2 * energylevel.j),
                 energylevel.qub_id,
             )

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -37,7 +37,6 @@ class QUBTransitionRow(t.NamedTuple):
     nameto: str
     namefrom: str
     lambdaangstrom: float
-    coll_str: float
 
 
 class QUBEnergyLevel(t.NamedTuple):
@@ -50,15 +49,10 @@ class QUBEnergyLevel(t.NamedTuple):
     j: float
     energyabovegsinpercm: float
     g: float
-    parity: int
+    parity: int | None  # None where the configuration determines no parity
 
 
 qubpath = (Path(__file__).parent.resolve() / ".." / "atomic-data-qub").resolve()
-
-
-def check_forbidden(levela: QUBEnergyLevel, levelb: QUBEnergyLevel) -> bool:
-    """Whether a transition between two levels is forbidden, i.e. they have the same parity."""
-    return levela.parity == levelb.parity
 
 
 def extend_ion_list(ion_handlers):
@@ -132,12 +126,15 @@ def read_adf04(
                     0.0,
                     0,
                 )
-            parity = artisatomic.get_parity_from_config(config)
+            # None where the configuration determines no parity. The level name keeps the old
+            # best-effort even/odd letter in that case, so that names (and the adata.txt they are
+            # written to) do not depend on this, but the parity column says what is actually known
+            parity = artisatomic.get_config_parity(config)
 
             levelname = energylevel.levelname + "_{:d}{:}{:}[{:d}/2]_id={:}".format(
                 energylevel.twosplusone,
                 lchars[energylevel.l],
-                ["e", "o"][parity],
+                ["e", "o"][parity if parity is not None else 0],
                 int(2 * energylevel.j),
                 energylevel.qub_id,
             )
@@ -276,18 +273,10 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
                     level_lower = qub_energylevels[id_lower]
                     levelname_upper = level_upper.levelname
                     levelname_lower = level_lower.levelname
-                    # WARNING replace with correct selection rules!
-                    forbidden = level_upper.parity == level_lower.parity
                     transition_count_of_level_name[levelname_upper] += 1
                     transition_count_of_level_name[levelname_lower] += 1
                     delta_percm = level_upper.energyabovegsinpercm - level_lower.energyabovegsinpercm
                     lamdaangstrom = 1.0e8 / delta_percm if delta_percm != 0.0 else -1.0
-                    if (id_lower, id_upper) in upsilondict:
-                        coll_str = upsilondict[id_lower, id_upper]
-                    elif forbidden:
-                        coll_str = -2.0
-                    else:
-                        coll_str = -1.0
                     transition = QUBTransitionRow(
                         lowerlevel=id_lower,
                         upperlevel=id_upper,
@@ -295,7 +284,6 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
                         nameto=levelname_upper,
                         namefrom=levelname_lower,
                         lambdaangstrom=lamdaangstrom,
-                        coll_str=coll_str,
                     )
                     qub_transitions.append(transition)
 
@@ -368,17 +356,10 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
                     level_lower = qub_energylevels[id_lower]
                     levelname_upper = level_upper.levelname
                     levelname_lower = level_lower.levelname
-                    forbidden = check_forbidden(level_upper, level_lower)
                     transition_count_of_level_name[levelname_upper] += 1
                     transition_count_of_level_name[levelname_lower] += 1
                     delta_percm = level_upper.energyabovegsinpercm - level_lower.energyabovegsinpercm
                     lamdaangstrom = 1.0e8 / delta_percm if delta_percm != 0.0 else -1.0
-                    if (id_lower, id_upper) in upsilondict:
-                        coll_str = upsilondict[id_lower, id_upper]
-                    elif forbidden:
-                        coll_str = -2.0
-                    else:
-                        coll_str = -1.0
                     transition = QUBTransitionRow(
                         lowerlevel=id_lower,
                         upperlevel=id_upper,
@@ -386,7 +367,6 @@ def read_qub_levels_and_transitions(atomic_number, ion_stage, flog):
                         nameto=levelname_upper,
                         namefrom=levelname_lower,
                         lambdaangstrom=lamdaangstrom,
-                        coll_str=coll_str,
                     )
                     qub_transitions.append(transition)
 

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -739,6 +739,122 @@ def test_add_level_ids_forbidden_parity():
     assert forbidden == [False, False, False, False, True]
 
 
+def test_get_level_j():
+    """J is read from the brackets a J-resolved CMFGEN level name ends with."""
+    get_level_j = readhillierdata.get_level_j
+
+    assert get_level_j("3d6_a5De[4]") == 4.0
+    assert get_level_j("3d5(4D)4po[9/2]") == 4.5
+    assert get_level_j("3d4(3P2)4po[1/2]") == 0.5
+
+    # JJ coupling states the J in braces, the brackets being taken by the level index
+    assert get_level_j("2s2_2p(2P<1/2>)4f_2{5/2}e") == 2.5
+
+    # A term-resolved level has no J of its own -- its g counts every J of the term -- and nor
+    # does a merged level. Neither may be given one.
+    for noj in ("1___", "8SNG", "10z_2Zo", "2s2_2p3(4So)5z_5Z", "3d6(5D)4s_6De"):
+        assert get_level_j(noj) is None
+
+
+def test_add_level_ids_forbidden_delta_j():
+    """E1 needs |dJ| <= 1 and forbids J=0 -> J=0, on a transition that carries no f."""
+    # opposite parities throughout, so the Laporte rule can never fire and only dJ decides
+    dflevels = pl.DataFrame(
+        {
+            "levelid": [0, 1, 2, 3, 4],
+            "parity": [0, 1, 0, 1, 0],
+            "j": [1.0, 2.0, 3.0, 0.0, 0.0],
+        },
+        schema={"levelid": pl.Int64, "parity": pl.Int64, "j": pl.Float64},
+    )
+    # A = 0 marks the upsilon-only pairs, which no source called an electric dipole line
+    dftransitions = pl.DataFrame(
+        {
+            "lowerlevel": [0, 0, 4, 0],
+            "upperlevel": [1, 2, 3, 3],
+            "A": [0.0, 0.0, 0.0, 0.0],
+        }
+    )
+    result = add_level_ids_forbidden(dflevels, dftransitions)
+    # the joins do not keep the row order, so read the answers back by transition
+    forbidden = {(lo, up): f for lo, up, f in result[["lowerlevel", "upperlevel", "forbidden"]].iter_rows()}
+
+    assert forbidden[0, 1] is False  # J 1 -> 2, dJ = 1
+    assert forbidden[0, 2] is True  # J 1 -> 3, dJ = 2
+    assert forbidden[4, 3] is True  # J 0 -> 0, forbidden even though dJ = 0
+    assert forbidden[0, 3] is False  # J 1 -> 0, dJ = 1
+
+
+def test_add_level_ids_forbidden_delta_j_yields_to_an_oscillator_strength():
+    """A source that gives the transition an f says it is E1, and that beats the J labels.
+
+    Some data sets disagree with themselves. CMFGEN's provisional F III set splits a term by a
+    nominal 0.8 cm-1 and then shares the term's f over all the J pairs, so it lists dJ = 2 lines
+    with f as large as 0.116. To call those forbidden would give a strong line the forbidden
+    collision approximation.
+    """
+    dflevels = pl.DataFrame(
+        {"levelid": [0, 1], "parity": [1, 0], "j": [0.5, 2.5]},
+        schema={"levelid": pl.Int64, "parity": pl.Int64, "j": pl.Float64},
+    )
+    dftransitions = pl.DataFrame({"lowerlevel": [0], "upperlevel": [1], "A": [3.4e9], "f": [0.116]})
+
+    result = add_level_ids_forbidden(dflevels, dftransitions)
+
+    # dJ = 2, so the rule is broken and reported, but the f keeps the transition permitted
+    assert result["breaksdeltaj"].to_list() == [True]
+    assert result["forbidden"].to_list() == [False]
+
+    # with no f and no A, the same pair is forbidden
+    nof = dftransitions.with_columns(A=0.0).drop("f")
+    assert add_level_ids_forbidden(dflevels, nof)["forbidden"].to_list() == [True]
+
+
+def test_log_deltaj_contradictions_judges_f_and_a_separately():
+    """Only a transition strong enough to be E1 contradicts its own J labels.
+
+    f has no units and an E1 line carries 1e-3 to 1. A is a rate in s-1 over many decades, where
+    a forbidden line still reaches ~1e2, so the same cut would report every forbidden line a
+    reader supplies A for as a contradiction.
+    """
+    from artisatomic.output import log_deltaj_contradictions
+
+    def warnings_for(dftransitions: pl.DataFrame) -> str:
+        flog = io.StringIO()
+        log_deltaj_contradictions(flog, dftransitions, "Test II")
+        return flog.getvalue()
+
+    breaksrule = {"lowerlevel": [0], "upperlevel": [1], "breaksdeltaj": [True]}
+
+    # f: a strong line contradicts the labels, a forbidden line's own small f does not
+    assert "WARNING" in warnings_for(pl.DataFrame({**breaksrule, "A": [3.4e9], "f": [0.116]}))
+    assert not warnings_for(pl.DataFrame({**breaksrule, "A": [1.0e-2], "f": [1.9e-9]}))
+
+    # A, where a forbidden line reaches 14 s-1 in QUB's Co III and must stay quiet
+    assert "WARNING" in warnings_for(pl.DataFrame({**breaksrule, "A": [1.9e8]}))
+    assert not warnings_for(pl.DataFrame({**breaksrule, "A": [14.0]}))
+
+    # a transition that keeps the rule is never reported, however strong it is
+    assert not warnings_for(pl.DataFrame({**breaksrule, "breaksdeltaj": [False], "A": [1.9e8]}))
+
+
+def test_add_level_ids_forbidden_delta_j_needs_both_levels():
+    """A level with no J turns off the dJ rule for its transitions. It does not undo the parities."""
+    dflevels = pl.DataFrame(
+        {"levelid": [0, 1, 2], "parity": [0, 1, 1], "j": [1.0, None, 5.0]},
+        schema={"levelid": pl.Int64, "parity": pl.Int64, "j": pl.Float64},
+    )
+    dftransitions = pl.DataFrame({"lowerlevel": [0, 1], "upperlevel": [1, 2], "A": [0.0, 0.0]})
+
+    # the first pair has no J to compare and two different parities, so nothing can call it
+    # forbidden. The second pair shares a parity, which the missing J must not undo.
+    assert add_level_ids_forbidden(dflevels, dftransitions)["forbidden"].to_list() == [False, True]
+
+    # a frame with no j column at all behaves as it did before this code read J
+    nojcol = dflevels.drop("j")
+    assert add_level_ids_forbidden(nojcol, dftransitions)["forbidden"].to_list() == [False, True]
+
+
 def test_add_level_ids_forbidden_treats_negative_parity_as_a_real_one():
     """Absence is null and only null, so a negative number is an ordinary parity that can match.
 

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -676,36 +676,47 @@ def test_read_coldata_term_to_j_redistribution():
 
 
 def test_add_level_ids_forbidden_parity():
-    """Equal parity means forbidden, but only where both parities are real."""
+    """Equal parity means forbidden, but a null parity is absent and matches nothing, itself included."""
     dflevels = pl.DataFrame(
         {
-            "levelid": [0, 1, 2, 3],
-            "parity": [0, 1, -1, -2],  # two real parities, then two levels with no definite parity
-        }
+            "levelid": [0, 1, 2, 3, 4],
+            "parity": [0, 1, None, None, 0],  # two real parities, two absent ones, then a repeat of 0
+        },
+        schema={"levelid": pl.Int64, "parity": pl.Int64},
     )
     dftransitions = pl.DataFrame(
         {
-            "lowerlevel": [0, 0, 0, 2],
-            "upperlevel": [1, 2, 3, 3],
-            "A": [1.0, 1.0, 1.0, 1.0],
+            "lowerlevel": [0, 0, 0, 2, 0],
+            "upperlevel": [1, 2, 3, 3, 4],
+            "A": [1.0, 1.0, 1.0, 1.0, 1.0],
         }
     )
     forbidden = add_level_ids_forbidden(dflevels, dftransitions)["forbidden"].to_list()
 
-    # even -> odd is permitted, and a real parity never matches an absent one
-    assert forbidden == [False, False, False, False]
+    # even -> odd permitted; a real parity never matches an absent one; two absent ones do not
+    # match each other either, which is the whole reason absence is spelled null; two real
+    # even ones do match
+    assert forbidden == [False, False, False, False, True]
 
-    # ...while two levels that really do share a parity are forbidden
-    dfsameparity = pl.DataFrame({"levelid": [0, 1], "parity": [1, 1]})
-    dftrans = pl.DataFrame({"lowerlevel": [0], "upperlevel": [1], "A": [1.0]})
-    assert add_level_ids_forbidden(dfsameparity, dftrans)["forbidden"].to_list() == [True]
+
+def test_add_level_ids_forbidden_treats_negative_parity_as_a_real_one():
+    """Absence is null and only null, so a negative number is an ordinary parity that can match.
+
+    Three readers used to spell "no parity" as the negated level id, which made level 0 come out
+    as a real even parity while every other level was unmatchable. Nothing may depend on negative
+    numbers meaning absent any more, so two levels sharing one are forbidden like any other pair.
+    """
+    dflevels = pl.DataFrame({"levelid": [0, 1], "parity": [-7, -7]}, schema={"levelid": pl.Int64, "parity": pl.Int64})
+    dftransitions = pl.DataFrame({"lowerlevel": [0], "upperlevel": [1], "A": [1.0]})
+
+    assert add_level_ids_forbidden(dflevels, dftransitions)["forbidden"].to_list() == [True]
 
 
 @pytest.mark.parametrize(
     ("parity", "dtype"),
     [
-        ([None, None], pl.Int64),  # forbidden would be null, which "{forbidden:d}" cannot format
-        ([float("nan"), float("nan")], pl.Float64),  # NaN == NaN and NaN >= 0 are both true
+        ([None, None], pl.Int64),  # the canonical spelling of an absent parity
+        ([float("nan"), float("nan")], pl.Float64),  # NaN compares equal to itself, so it must cast away
         (["1", "1"], pl.String),  # pandas infers text from a blank column, e.g. FAC's P
     ],
 )
@@ -731,8 +742,7 @@ def test_readhillierdata_hydrogen_lyman_alpha_is_permitted():
     _, dflevels, dftransitions, _ = readhillierdata.read_levels_and_transitions(1, 1, io.StringIO())
 
     # no level has a parity that could match another's
-    assert (dflevels["parity"] < 0).all()
-    assert dflevels["parity"].n_unique() == dflevels.height
+    assert dflevels["parity"].is_null().all()
 
     dflevels = dflevels.with_row_index("levelid").with_columns(pl.col("levelid").cast(pl.Int64))
     dftransitions = add_level_ids_forbidden(dflevels, dftransitions)
@@ -744,13 +754,13 @@ def test_readhillierdata_hydrogen_lyman_alpha_is_permitted():
     assert not lymanalpha["forbidden"].item()
 
 
-def test_readboyledata_levels_get_distinct_parities(monkeypatch):
+def test_readboyledata_levels_have_no_parity(monkeypatch):
     """The AOIFE data set supplies no parities, so no transition may come out forbidden.
 
     add_level_ids_forbidden() marks a transition forbidden when its two levels share a parity, so
     giving every level the same parity made every transition of the ion forbidden — and helium has
-    plenty of permitted ones. readlisbondata and readkuruczdata use the negated level id for
-    exactly this reason.
+    plenty of permitted ones. A null parity cannot match another, which is how readlisbondata and
+    readkuruczdata say the same thing.
 
     The aoife.hdf5 in the repository is a placeholder (the real file is gitignored, fetched per
     its README), so this builds the three tables the reader wants in memory.
@@ -796,8 +806,8 @@ def test_readboyledata_levels_get_distinct_parities(monkeypatch):
     # the other ion's level is filtered out
     assert len(energy_levels) == 3
 
-    # every level gets its own parity, so no pair of them can compare equal
-    assert len({level.parity for level in energy_levels}) == len(energy_levels)
+    # no level has a parity, so no pair of them can compare equal
+    assert all(level.parity is None for level in energy_levels)
 
     dflevels = leveltuples_to_pldataframe(
         pl.DataFrame(
@@ -846,8 +856,8 @@ def test_readlisbondata_maps_file_indices_to_energy_sorted_ids():
     # levels come back in ascending energy, so the file's order is exactly reversed
     assert [level.energyabovegsinpercm for level in energy_levels] == [0.0, 1000.0, 5000.0]
     assert levelid_of_fileindex == {2: 0, 1: 1, 0: 2}
-    # the unique parity sentinel keeps all transitions permitted
-    assert len({level.parity for level in energy_levels}) == len(energy_levels)
+    # a null parity never matches another, so all transitions stay permitted
+    assert all(level.parity is None for level in energy_levels)
 
     # one line from the file's level 2 (the ground state) to its level 0 (the top level)
     dflines = pd.DataFrame(

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -745,8 +745,16 @@ def test_get_level_j():
     assert get_level_j("3d5(4D)4po[9/2]") == 4.5
     assert get_level_j("3d4(3P2)4po[1/2]") == 0.5
 
-    # JJ coupling states the J in braces, the brackets being taken by the level index
+    # a name with a brace and nothing after it gives J there; in pair coupling the brace holds
+    # K and the trailing bracket is J. The last group is the one read, and both come out right.
     assert get_level_j("2s2_2p(2P<1/2>)4f_2{5/2}e") == 2.5
+    assert get_level_j("2p5(2P*<1/2>)3d_2{3/2}o[1]") == 1.0
+
+    # Not every trailing bracket is a J: Si X and S X number their levels there instead. g tells
+    # them apart, because J is only J where g == 2J + 1. A 3P term has no J = 3.
+    assert get_level_j("2p3p3Pe[3]", g=5.0) is None
+    assert get_level_j("2s2_2p3_4So[2]", g=4.0) is None
+    assert get_level_j("3d6_a5De[4]", g=9.0) == 4.0
 
     # A term-resolved level has no J of its own -- its g counts every J of the term -- and nor
     # does a merged level. Neither may be given one.
@@ -1018,8 +1026,10 @@ def test_readlisbondata_maps_file_indices_to_energy_sorted_ids():
     # levels come back in ascending energy, so the file's order is exactly reversed
     assert [level.energyabovegsinpercm for level in energy_levels] == [0.0, 1000.0, 5000.0]
     assert levelid_of_fileindex == {2: 0, 1: 1, 0: 2}
-    # a null parity never matches another, so all transitions stay permitted
+    # a null parity never matches another, so the Laporte rule cannot fire...
     assert all(level.parity is None for level in energy_levels)
+    # ...and J is what the delta J rule has to go on, so it must reach the level tuple
+    assert [level.j for level in energy_levels] == [0.0, 1.0, 2.0]
 
     # one line from the file's level 2 (the ground state) to its level 0 (the top level)
     dflines = pd.DataFrame(

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -123,17 +123,6 @@ def test_get_parity_from_config():
     assert get_parity_from_config("3d64s2") == 0  # 2 * 6 = 12
     assert get_parity_from_config("5s2.5p5") == 1  # 0 * 2 + 1 * 5 = 5
 
-    # A configuration with no term is not split into orbitals at all, so the sum is empty and the
-    # answer is 0 whatever the orbitals would have said. That is right for '3d7' (2 * 7 = 14) only
-    # by coincidence, and wrong for '5p3' (1 * 3 = 3, odd). readqubdata relies on this, so it is
-    # pinned rather than left to be discovered; get_config_parity() reports the same names as
-    # unknown, which is what a caller that must not guess should use.
-    assert interpret_configuration("3d7")[0] == []
-    assert get_parity_from_config("3d7") == 0
-    assert get_parity_from_config("5p3") == 0  # the true parity is odd
-    assert get_config_parity("3d7") is None
-    assert get_config_parity("5p3") is None
-
     # parent terms in parentheses are not occupied orbitals and must be skipped, not parsed
     assert get_parity_from_config("3s23p63d7(4F)") == 0  # 0*2 + 1*6 + 2*7 = 20
     assert get_parity_from_config("3d6(5D)4s_6De") == 0  # 2 * 6 = 12
@@ -147,6 +136,46 @@ def test_get_parity_from_config():
     # the real orbitals decide the parity.
     assert get_parity_from_config("2s2_2p3(4So)5z_5Z") == 1  # 2s2 + 2p3 = 3, the 5z contributes none
     assert get_parity_from_config("2s2_13w_2W") == 0  # 2s2 = 0, the 13w contributes none
+
+    # Read as name-with-a-term, a bare configuration is mistaken for a term and no orbitals come
+    # back at all, so the sum is empty and the answer is 0 whatever the orbitals said: right for
+    # '3d7' (2 * 7 = 14) only by coincidence, and wrong for '5p3' (1 * 3 = 3, odd). Callers with
+    # a bare configuration pass hasterm=False, below.
+    assert interpret_configuration("3d7")[0] == []
+    assert get_parity_from_config("3d7") == 0
+    assert get_parity_from_config("5p3") == 0  # the true parity is odd
+    assert get_config_parity("3d7") is None
+
+
+def test_parity_of_a_bare_configuration():
+    """A name with no term is all configuration, and adf04 writes its orbitals in upper case."""
+    from artisatomic import get_config_parity
+
+    # the whole string is orbitals, so nothing is lost off the end and odd really reads as odd
+    assert get_config_parity("3d7", hasterm=False) == 0  # 2 * 7 = 14
+    assert get_config_parity("5s2", hasterm=False) == 0  # 0 * 2
+    assert get_config_parity("5p3", hasterm=False) == 1  # 1 * 3
+    assert get_config_parity("2p", hasterm=False) == 1  # a lone orbital with no occupation
+
+    # ADAS adf04 configurations: upper case, space separated, with the level's own index in
+    # brackets at the end. Stripping a term took the last orbital with it, so '4P1' was lost and
+    # every level of FeIII.adf04 came out even; 3s2 3p6 3d5 4p1 is 0 + 6 + 10 + 1 = 17, odd.
+    assert get_config_parity("3S2 3P6 3D5 4P1   (1)", hasterm=False) == 1
+    assert get_config_parity("3S2 3P6 3D6   (5)", hasterm=False) == 0  # 0 + 6 + 12 = 18
+    assert interpret_configuration("3S2 3P6 3D5 4P1   (1)", hasterm=False)[0] == [
+        "3S2",
+        "3P6",
+        "3D5",
+        "4P1",
+        "(1)",
+    ]
+
+    # ...but upper case is only an orbital where there is no term to confuse it with. With a term
+    # the case still matters: '8SNG' is He I's merged singlets, not an 8s orbital, and the parent
+    # term left over from '3d4(3H)s44p_x3Io' is not a merge marker.
+    assert get_config_parity("8SNG") is None
+    assert readhillierdata.get_level_parity("8SNG") < 0
+    assert readhillierdata.get_level_parity("3d4(3H)s44p_x3Io[6]") == 1
 
 
 def test_interpret_configuration():

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -106,45 +106,43 @@ def test_has_merged_orbital():
 
 def test_get_parity_from_multi_orbital_token():
     """A digit-letter-letter run is one token holding two orbitals that share a principal number."""
-    from artisatomic import get_parity_from_config
+    from artisatomic import get_config_parity
 
     # '4sp(3P)_7Po' splits to the token '4sp', i.e. 4s and 4p: l = 0 + 1 is odd, matching the 'o'.
     # Reading only the first letter and calling the rest an occupation raises on int('p').
-    assert get_parity_from_config("4sp(3P)_7Po") == 1
+    assert get_config_parity("4sp(3P)_7Po") == 1
     assert readhillierdata.get_level_parity("4sp(3P)_7Po[2]") == 1
 
 
-def test_get_parity_from_config():
+def test_get_config_parity():
     """Parity is the sum of l over the occupied orbitals, skipping parent terms and merge markers."""
     from artisatomic import get_config_parity
-    from artisatomic import get_parity_from_config
 
     # sum of l over the occupied orbitals, mod 2
-    assert get_parity_from_config("3d64s2") == 0  # 2 * 6 = 12
-    assert get_parity_from_config("5s2.5p5") == 1  # 0 * 2 + 1 * 5 = 5
+    assert get_config_parity("3d64s2") == 0  # 2 * 6 = 12
+    assert get_config_parity("5s2.5p5") == 1  # 0 * 2 + 1 * 5 = 5
 
     # parent terms in parentheses are not occupied orbitals and must be skipped, not parsed
-    assert get_parity_from_config("3s23p63d7(4F)") == 0  # 0*2 + 1*6 + 2*7 = 20
-    assert get_parity_from_config("3d6(5D)4s_6De") == 0  # 2 * 6 = 12
+    assert get_config_parity("3s23p63d7(4F)") == 0  # 0*2 + 1*6 + 2*7 = 20
+    assert get_config_parity("3d6(5D)4s_6De") == 0  # 2 * 6 = 12
 
     # closed shells with two-digit occupations: a truncated '4f1' reading would give the
     # wrong (odd) parity here, since 3*14 is even but 3*1 is odd
-    assert get_parity_from_config("4f145d96s2") == 0  # 3*14 + 2*9 + 0 = 60
+    assert get_config_parity("4f145d96s2") == 0  # 3*14 + 2*9 + 0 = 60
 
     # CMFGEN packs a shell's high-l levels into one level whose orbital letter is a merge marker,
     # not a real l ('5z' would be l=22, '13w' l=19). It spans several l of both parities, so only
     # the real orbitals decide the parity.
-    assert get_parity_from_config("2s2_2p3(4So)5z_5Z") == 1  # 2s2 + 2p3 = 3, the 5z contributes none
-    assert get_parity_from_config("2s2_13w_2W") == 0  # 2s2 = 0, the 13w contributes none
+    assert get_config_parity("2s2_2p3(4So)5z_5Z") == 1  # 2s2 + 2p3 = 3, the 5z contributes none
+    assert get_config_parity("2s2_13w_2W") == 0  # 2s2 = 0, the 13w contributes none
 
-    # Read as name-with-a-term, a bare configuration is mistaken for a term and no orbitals come
-    # back at all, so the sum is empty and the answer is 0 whatever the orbitals said: right for
-    # '3d7' (2 * 7 = 14) only by coincidence, and wrong for '5p3' (1 * 3 = 3, odd). Callers with
-    # a bare configuration pass hasterm=False, below.
+    # A bare configuration read as a name-with-a-term is mistaken for a term, so no orbitals come
+    # back. The sum is then empty, and 0 is a real parity that would be the wrong answer: right
+    # for '3d7' (2 * 7 = 14) only by coincidence, and wrong for '5p3' (1 * 3 = 3, odd). None says
+    # so instead. Callers holding a bare configuration pass hasterm=False, below.
     assert interpret_configuration("3d7")[0] == []
-    assert get_parity_from_config("3d7") == 0
-    assert get_parity_from_config("5p3") == 0  # the true parity is odd
     assert get_config_parity("3d7") is None
+    assert get_config_parity("5p3") is None
 
 
 def test_parity_of_a_bare_configuration():

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -38,6 +38,59 @@ def test_interpret_term():
         assert readhillierdata.get_term_as_tuple(unreadable) == (-1, -1, -1)
 
 
+def test_get_level_parity():
+    """A CMFGEN level's parity comes from its 'e'/'o' suffix, and merged levels have none at all."""
+    get_level_parity = readhillierdata.get_level_parity
+
+    # the 'e'/'o' suffix, which is what nearly every name carries
+    assert get_level_parity("1s2_1Se") == 0
+    assert get_level_parity("2p_2Po") == 1
+    assert get_level_parity("3d5(6S)4s(7S)4d6De") == 0
+
+    # intermediate-coupling names, where the only term letter belongs to the parent term in
+    # parentheses. Reading the term instead of the suffix leaves these with no parity at all,
+    # and then any two of them wrongly compare equal.
+    assert get_level_parity("3d5(4D)4po[3]") == 1
+    assert get_level_parity("3d4(3P2)4po[1/2]") == 1
+    assert get_level_parity("3d6(3P2)4pbo[5/2]") == 1
+
+    # no suffix: sum l over the orbitals instead
+    assert get_level_parity("5s2.5p5") == 1  # 0*2 + 1*5
+    assert get_level_parity("3s23p63d7(4F)") == 0  # 0*2 + 1*6 + 2*7, the parent term skipped
+
+    # ...and where there is no suffix and no readable orbital either, there is no parity
+    assert get_level_parity("Eqv st (0S ) 0s  a4P") < 0
+
+    # Levels that merge sub-levels of both parities have no parity to read, and must not be given
+    # one: '1___' and '13___' hold every l of that n (g = 2n^2), '8SNG'/'8TRP' are He I's merged
+    # singlets and triplets, and 'w'/'z' are merge markers for the high-l orbitals of a shell.
+    for merged in ("1___", "2___", "13___", "8SNG", "8TRP", "2s2_29w_2W", "10z_2Z", "2s2_2p3(4So)5z_5Z"):
+        assert get_level_parity(merged) < 0
+
+
+def test_has_merged_orbital():
+    """Merge markers are orbital letters standing for several l at once, so l >= n gives them away."""
+    from artisatomic import has_merged_orbital
+
+    assert has_merged_orbital("2s2_13w_2W")  # 'w' would be l=19, but n=13
+    assert has_merged_orbital("10z_2Z")  # 'z' would be l=22, but n=10
+    assert has_merged_orbital("2s2_2p3(4So)5z_5Z")
+
+    assert not has_merged_orbital("3d6(5D)10d_5Pe")  # 10d is a real orbital, l=2 < n=10
+    assert not has_merged_orbital("2p_2Po")
+    assert not has_merged_orbital("3d7(4F)6d_5Pbe")
+
+
+def test_get_parity_from_multi_orbital_token():
+    """A digit-letter-letter run is one token holding two orbitals that share a principal number."""
+    from artisatomic import get_parity_from_config
+
+    # '4sp(3P)_7Po' splits to the token '4sp', i.e. 4s and 4p: l = 0 + 1 is odd, matching the 'o'.
+    # Reading only the first letter and calling the rest an occupation raises on int('p').
+    assert get_parity_from_config("4sp(3P)_7Po") == 1
+    assert readhillierdata.get_level_parity("4sp(3P)_7Po[2]") == 1
+
+
 def test_get_parity_from_config():
     """Parity is the sum of l over the occupied orbitals, skipping parent terms and merge markers."""
     from artisatomic import get_parity_from_config
@@ -597,6 +650,55 @@ def test_read_coldata_term_to_j_redistribution():
     # Fe II collision data is already J-resolved, so every value passes through unscaled
     _, upsilondict_fe2, _ = read_ion(26, 2)
     assert sum(1 for v in upsilondict_fe2.values() if v > 0.0) == 10601
+
+
+def test_add_level_ids_forbidden_parity():
+    """Equal parity means forbidden, but only where both parities are real."""
+    dflevels = pl.DataFrame(
+        {
+            "levelid": [0, 1, 2, 3],
+            "parity": [0, 1, -1, -2],  # two real parities, then two levels with no definite parity
+        }
+    )
+    dftransitions = pl.DataFrame(
+        {
+            "lowerlevel": [0, 0, 0, 2],
+            "upperlevel": [1, 2, 3, 3],
+            "A": [1.0, 1.0, 1.0, 1.0],
+        }
+    )
+    forbidden = add_level_ids_forbidden(dflevels, dftransitions)["forbidden"].to_list()
+
+    # even -> odd is permitted, and a real parity never matches an absent one
+    assert forbidden == [False, False, False, False]
+
+    # ...while two levels that really do share a parity are forbidden
+    dfsameparity = pl.DataFrame({"levelid": [0, 1], "parity": [1, 1]})
+    dftrans = pl.DataFrame({"lowerlevel": [0], "upperlevel": [1], "A": [1.0]})
+    assert add_level_ids_forbidden(dfsameparity, dftrans)["forbidden"].to_list() == [True]
+
+
+def test_readhillierdata_hydrogen_lyman_alpha_is_permitted():
+    """H I is merged n-levels throughout, so nothing in it may come out forbidden.
+
+    Every H I level is named '<n>___' and holds every l of that n, giving it no definite parity.
+    Treating those as a matching parity made all 435 H I transitions forbidden, Lyman alpha
+    included -- the strongest permitted line there is, listed in hi_osc.dat with f = 0.4162.
+    """
+    _, dflevels, dftransitions, _ = readhillierdata.read_levels_and_transitions(1, 1, io.StringIO())
+
+    # no level has a parity that could match another's
+    assert (dflevels["parity"] < 0).all()
+    assert dflevels["parity"].n_unique() == dflevels.height
+
+    dflevels = dflevels.with_row_index("levelid").with_columns(pl.col("levelid").cast(pl.Int64))
+    dftransitions = add_level_ids_forbidden(dflevels, dftransitions)
+    assert not any(dftransitions["forbidden"].to_list())
+
+    lymanalpha = dftransitions.filter((pl.col("lowerlevel") == 0) & (pl.col("upperlevel") == 1))
+    assert lymanalpha.height == 1
+    assert lymanalpha["A"].item() == pytest.approx(4.696e8)
+    assert not lymanalpha["forbidden"].item()
 
 
 def test_readboyledata_levels_get_distinct_parities(monkeypatch):

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -807,6 +807,12 @@ def test_add_level_ids_forbidden_delta_j_yields_to_an_oscillator_strength():
     nof = dftransitions.with_columns(A=0.0).drop("f")
     assert add_level_ids_forbidden(dflevels, nof)["forbidden"].to_list() == [True]
 
+    # A weak f is not evidence of an E1 line, so the J labels decide it. C IV lists
+    # 2p_2Po[1/2] -> 3d_2De[5/2] at f = 2.7e-10, and its 108 cm-1 fine structure means its J
+    # labels are sound, so that line really is forbidden.
+    weakf = dftransitions.with_columns(A=4.1, f=2.7e-10)
+    assert add_level_ids_forbidden(dflevels, weakf)["forbidden"].to_list() == [True]
+
 
 def test_log_deltaj_contradictions_judges_f_and_a_separately():
     """Only a transition strong enough to be E1 contradicts its own J labels.
@@ -827,6 +833,8 @@ def test_log_deltaj_contradictions_judges_f_and_a_separately():
     # f: a strong line contradicts the labels, a forbidden line's own small f does not
     assert "WARNING" in warnings_for(pl.DataFrame({**breaksrule, "A": [3.4e9], "f": [0.116]}))
     assert not warnings_for(pl.DataFrame({**breaksrule, "A": [1.0e-2], "f": [1.9e-9]}))
+    # ...and the quiet case is the one the rule now marks forbidden, so the two agree
+    assert not warnings_for(pl.DataFrame({**breaksrule, "A": [4.1], "f": [2.7e-10]}))
 
     # A, where a forbidden line reaches 14 s-1 in QUB's Co III and must stay quiet
     assert "WARNING" in warnings_for(pl.DataFrame({**breaksrule, "A": [1.9e8]}))

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -116,12 +116,23 @@ def test_get_parity_from_multi_orbital_token():
 
 def test_get_parity_from_config():
     """Parity is the sum of l over the occupied orbitals, skipping parent terms and merge markers."""
+    from artisatomic import get_config_parity
     from artisatomic import get_parity_from_config
 
     # sum of l over the occupied orbitals, mod 2
-    assert get_parity_from_config("3d7") == 0  # 2 * 7 = 14
     assert get_parity_from_config("3d64s2") == 0  # 2 * 6 = 12
     assert get_parity_from_config("5s2.5p5") == 1  # 0 * 2 + 1 * 5 = 5
+
+    # A configuration with no term is not split into orbitals at all, so the sum is empty and the
+    # answer is 0 whatever the orbitals would have said. That is right for '3d7' (2 * 7 = 14) only
+    # by coincidence, and wrong for '5p3' (1 * 3 = 3, odd). readqubdata relies on this, so it is
+    # pinned rather than left to be discovered; get_config_parity() reports the same names as
+    # unknown, which is what a caller that must not guess should use.
+    assert interpret_configuration("3d7")[0] == []
+    assert get_parity_from_config("3d7") == 0
+    assert get_parity_from_config("5p3") == 0  # the true parity is odd
+    assert get_config_parity("3d7") is None
+    assert get_config_parity("5p3") is None
 
     # parent terms in parentheses are not occupied orbitals and must be skipped, not parsed
     assert get_parity_from_config("3s23p63d7(4F)") == 0  # 0*2 + 1*6 + 2*7 = 20

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -37,6 +37,17 @@ def test_interpret_term():
     for unreadable in ("e2x", "o12", "3d5", "12"):
         assert readhillierdata.get_term_as_tuple(unreadable) == (-1, -1, -1)
 
+    # The only L character can belong to a parenthesised parent term. Reporting '(4D)' would
+    # describe the parent rather than this level, so the term is unreadable -- but the trailing
+    # 'o' still gives the parity.
+    assert readhillierdata.get_term_as_tuple("3d5(4D)4po[3]") == (-1, -1, 1)
+    assert readhillierdata.get_term_as_tuple("3d4(3P2)4po[1/2]") == (-1, -1, 1)
+
+    # an L character at index 0 leaves no room for the multiplicity, and config[-1] would wrap
+    # round to the end of the name and read some unrelated character as it
+    assert readhillierdata.get_term_as_tuple("S2") == (-1, -1, -1)
+    assert readhillierdata.get_term_as_tuple("P2") == (-1, -1, -1)
+
 
 def test_get_level_parity():
     """A CMFGEN level's parity comes from its 'e'/'o' suffix, and merged levels have none at all."""
@@ -79,6 +90,18 @@ def test_has_merged_orbital():
     assert not has_merged_orbital("3d6(5D)10d_5Pe")  # 10d is a real orbital, l=2 < n=10
     assert not has_merged_orbital("2p_2Po")
     assert not has_merged_orbital("3d7(4F)6d_5Pbe")
+
+    # A token with no principal quantum number cannot be judged: n would default to 0 and then
+    # l >= n holds for every orbital letter, which would call the whole configuration merged and
+    # throw away the parity these names state outright with their 'o'.
+    for hasnon in ("3d8(2H)sp_2Go", "3d2(2D)sp_4Fo", "3d7(a2D)4sep_4Fo", "SEJ_s6p_7Fo", "3s2_3p_nd_a3Po"):
+        assert not has_merged_orbital(hasnon)
+        assert readhillierdata.get_level_parity(hasnon) == 1
+
+    # ...while a real merge marker still wins over an 'e'/'o' suffix, because the level really
+    # does span both parities. Al XI names one: '10z_2Zo', g=168.
+    assert has_merged_orbital("10z_2Zo")
+    assert readhillierdata.get_level_parity("10z_2Zo") < 0
 
 
 def test_get_parity_from_multi_orbital_token():
@@ -676,6 +699,26 @@ def test_add_level_ids_forbidden_parity():
     dfsameparity = pl.DataFrame({"levelid": [0, 1], "parity": [1, 1]})
     dftrans = pl.DataFrame({"lowerlevel": [0], "upperlevel": [1], "A": [1.0]})
     assert add_level_ids_forbidden(dfsameparity, dftrans)["forbidden"].to_list() == [True]
+
+
+@pytest.mark.parametrize(
+    ("parity", "dtype"),
+    [
+        ([None, None], pl.Int64),  # forbidden would be null, which "{forbidden:d}" cannot format
+        ([float("nan"), float("nan")], pl.Float64),  # NaN == NaN and NaN >= 0 are both true
+        (["1", "1"], pl.String),  # pandas infers text from a blank column, e.g. FAC's P
+    ],
+)
+def test_add_level_ids_forbidden_unreadable_parity(parity, dtype):
+    """A parity that is not a whole number means the level has none, not that it matches itself."""
+    dflevels = pl.DataFrame({"levelid": [0, 1], "parity": parity}, schema={"levelid": pl.Int64, "parity": dtype})
+    dftransitions = pl.DataFrame({"lowerlevel": [0], "upperlevel": [1], "A": [1.0]})
+
+    forbidden = add_level_ids_forbidden(dflevels, dftransitions)["forbidden"].to_list()
+
+    # a readable string parity is a real parity and still counts; the rest are unknown
+    assert forbidden == [dtype == pl.String]
+    assert forbidden[0] is not None  # would raise in write_transition_data
 
 
 def test_readhillierdata_hydrogen_lyman_alpha_is_permitted():

--- a/tests/cmfgen/checksums.txt
+++ b/tests/cmfgen/checksums.txt
@@ -1,4 +1,4 @@
 958694aa1d0863498688a7689860448a  adata.txt
 3317c6dfe823400481ca656b42fe4210  compositiondata.txt
 4df3705c87b71bd8c9ef9f97ef59ab2a  phixsdata_v2.txt
-0fbf3b90085a7cc0dc84c155e3a30e53  transitiondata.txt
+c00ae794ace5e982f92c567f8fd31ff3  transitiondata.txt

--- a/tests/cmfgen/checksums.txt
+++ b/tests/cmfgen/checksums.txt
@@ -1,4 +1,4 @@
 958694aa1d0863498688a7689860448a  adata.txt
 3317c6dfe823400481ca656b42fe4210  compositiondata.txt
 4df3705c87b71bd8c9ef9f97ef59ab2a  phixsdata_v2.txt
-c00ae794ace5e982f92c567f8fd31ff3  transitiondata.txt
+d7b2f66ce1d13612e52a32c5862f6962  transitiondata.txt

--- a/tests/cmfgen/checksums.txt
+++ b/tests/cmfgen/checksums.txt
@@ -1,4 +1,4 @@
 958694aa1d0863498688a7689860448a  adata.txt
 3317c6dfe823400481ca656b42fe4210  compositiondata.txt
 4df3705c87b71bd8c9ef9f97ef59ab2a  phixsdata_v2.txt
-d7b2f66ce1d13612e52a32c5862f6962  transitiondata.txt
+dc7a7a7e9e34e832035e61d1eb753a50  transitiondata.txt

--- a/tests/cmfgen_lowz/checksums.txt
+++ b/tests/cmfgen_lowz/checksums.txt
@@ -1,4 +1,4 @@
 5bdaae5fd1bb506f33e960dffe4988fc  adata.txt
 5fbbc0dc9cf13e66a15caf576650a408  compositiondata.txt
 02d9297f06baae1cba7646ed9327cc45  phixsdata_v2.txt
-e94cc91d08dd3ac30ff1e3f25cf9ee97  transitiondata.txt
+f8ce77b8e44ee1aebab082381dd2497a  transitiondata.txt

--- a/tests/cmfgen_lowz/checksums.txt
+++ b/tests/cmfgen_lowz/checksums.txt
@@ -1,4 +1,4 @@
 5bdaae5fd1bb506f33e960dffe4988fc  adata.txt
 5fbbc0dc9cf13e66a15caf576650a408  compositiondata.txt
 02d9297f06baae1cba7646ed9327cc45  phixsdata_v2.txt
-80266dd6696e2e96177955a912ba827a  transitiondata.txt
+31c2e9270d5f3971e7a79961ac8b87ac  transitiondata.txt

--- a/tests/cmfgen_lowz/checksums.txt
+++ b/tests/cmfgen_lowz/checksums.txt
@@ -1,4 +1,4 @@
 5bdaae5fd1bb506f33e960dffe4988fc  adata.txt
 5fbbc0dc9cf13e66a15caf576650a408  compositiondata.txt
 02d9297f06baae1cba7646ed9327cc45  phixsdata_v2.txt
-f8ce77b8e44ee1aebab082381dd2497a  transitiondata.txt
+f9e888b911476f2499876a6c6007b7c4  transitiondata.txt

--- a/tests/cmfgen_lowz/checksums.txt
+++ b/tests/cmfgen_lowz/checksums.txt
@@ -1,4 +1,4 @@
 5bdaae5fd1bb506f33e960dffe4988fc  adata.txt
 5fbbc0dc9cf13e66a15caf576650a408  compositiondata.txt
 02d9297f06baae1cba7646ed9327cc45  phixsdata_v2.txt
-31c2e9270d5f3971e7a79961ac8b87ac  transitiondata.txt
+e94cc91d08dd3ac30ff1e3f25cf9ee97  transitiondata.txt

--- a/tests/qub/checksums.txt
+++ b/tests/qub/checksums.txt
@@ -1,4 +1,4 @@
 a0047d3873d5de6d194e75bb540ea41d  adata.txt
 a20943827eba942629179bed717ac222  compositiondata.txt
 017f2ec7d18ad2c5956c94fd83601914  phixsdata_v2.txt
-c10e310384b34f7909c3f5ea9a25dbe4  transitiondata.txt
+4bd5327c5b7dea7b4668fd5fd12f6d9c  transitiondata.txt


### PR DESCRIPTION
## The bug

`add_level_ids_forbidden()` marks a transition forbidden when its two levels share a parity. CMFGEN levels that **merge** sub-levels of both parities have no parity to share. The code compared them anyway.

The result: **every H I and He II transition was written `forbidden=1`**. Lyman alpha is one of them. `hi_osc.dat` lists it as

```
1___ -2___      4.162E-01   4.696E+08     1215.67      1-  2      1
```

and `transitiondata.txt` gave it as `1    2 4.69600e+08  6.62e-01 1`.

Three kinds of merged level, all mishandled:

| level type | example | g | what happened |
|---|---|---|---|
| merged n-level | `1___`, `13___` | 2n² | parsed to `-1`; two `-1`s compare **equal** → forbidden |
| merged singlet/triplet | `8SNG`, `8TRP` | n², 3n² | the same `-1` collision |
| merged high-l marker | `2s2_29w_2W`, `10z_2Z` | 182–338 | worse — took the **core's** parity, so pairs compared equal |

The third kind does the most damage. C II's `2s2_29w_2W → 2s2_30w_2W` has **f = 5.8**, among the strongest lines in the ion, and it was confidently marked forbidden.

The flag matters twice over. `write_transition_data()` writes it into `transitiondata.txt`, and it also picks `coll_str`: −2 for forbidden, −1 for unknown. A wrong flag therefore also gives a strong line the forbidden collision approximation.

## Is parity even the right test?

Yes, and I checked it against the data rather than assume it. A parity change is a rigorous E1 requirement, so an equal parity really does mean "not E1". Across Fe II, Fe III, Co III, Ni III and O II, **zero of 1103** same-parity transitions have `f > 1e-6`. Their median f is ~1e-10 and their median A is ~1e-2 s⁻¹, against a permitted population 6 to 7 orders higher. Where the parity is known, it never contradicts the oscillator strengths.

The defect was never the criterion. It was the use of that criterion on levels that have no parity.

## Result

Measured on the written `transitiondata.txt`, `main` (now the 19apr23 CMFGEN compilation, #74) against this branch, row by row. Every ion of both CMFGEN reference sets is listed below; the light ions and the iron group tell different stories.

**Wrong flags fixed: 7,406** — 5,461 in `cmfgen_lowz`, 1,945 in `cmfgen`. Nothing flips the other way for that reason.
**Flags added by the ΔJ rule: 13,001**, of which ARTIS would notice **18**. That last number is explained under *What ARTIS reads*.

## What the branch does

**1. Read the parity from the level name correctly.** The parity comes from the trailing `e`/`o` where the name has one. That rule also recovers 65 Fe/Co/Ni levels such as `3d5(4D)4po[3]`, whose only term letter belongs to the parent term `(4D)`. It agrees with the old parser on **all 22,944** levels that parser already resolved, so it changes no flag that was right.

**2. A level with no parity says so.** "No definite parity" is now a null, in one place. Four readers each had their own spelling, and three negated the level id, which makes **level 0 come out as parity 0** — a real even parity, the opposite of what they meant. Polars resolves `null == anything` to null, so an absent parity cannot match another absent one and no sentinel is needed.

**3. Parse a configuration that carries no term.** `interpret_configuration()` assumed every name ends in a term and stripped one off. That destroys a name that is only configuration: `5s2` and `3d7` came back with no orbitals, and `3S2 3P6 3D5 4P1` lost the `4P1`. Every level of `FeIII.adf04` was then even, and every transition between them forbidden. The true split is 214 odd and 108 even. An adf04 file keeps 2S+1 and L in their own columns, so `hasterm=False` reads the whole string as configuration.

**4. Apply the ΔJ selection rule.** E1 also needs `|ΔJ| ≤ 1` and forbids J=0 → J=0. CMFGEN writes J in the last bracketed group of a J-resolved level name; Kurucz, QUB and Lisbon already had a J column. 99.4% of CMFGEN transitions carry J at both ends. Not every bracket is a J — Si X and S X number their levels there — so J is taken only where `g == 2J+1`. That check found one N I level whose name and g disagree, and corrected a flag.

## The ΔJ rule yields to a strong line

Some files disagree with their own J labels. CMFGEN's provisional F III set splits a term by a nominal 0.8 cm⁻¹, then shares the term's f over **all** the J pairs. It therefore lists ΔJ = 2 lines with f up to 0.116, and O II reaches 0.695. Compare a set whose labels are sound:

| | fine-structure split | f of the ΔJ=2 pair |
|---|---|---|
| C IV `2p_2Po` | 108 cm⁻¹, real | 2.7×10⁻¹⁰ — a true forbidden line |
| F III `2s2_2p3_2Po` | **0.8 cm⁻¹**, nominal | 1.16×10⁻¹ — a strong E1 line |

So one helper, `strength_asserts_e1()`, asks whether the source's own numbers claim an E1 line: `f > 1e-4`, or `A > 1e5 s⁻¹` where the reader gives no f. Both need a size, not merely a value, because a forbidden line has an A and a reader that tabulates f gives one to its forbidden lines too. The ΔJ rule yields to that test, and each ion logs what it let through:

> WARNING: 6 transitions of F III break the delta J rule but carry f > 0.0001 (largest 0.116). The level names and the f values of this data set disagree. The f values are used, so these stay permitted.

Four ions warn: F III (6), O II (31), Y I (1), Y II (1).

**The margin is thin, and the cuts are corpus-tuned.** Neither threshold is a law of physics: a weak E1 line (an intercombination line, or one between high levels) can sit below either cut, and a strong M1/E2 line in a highly charged ion can sit above the A cut. They are where the two populations part in *this* corpus. On the forbidden side that gap is wide — genuine forbidden lines end near f ~ 1e-6. On the contradiction side it is not: F III's smallest self-contradicting line is f = 7.8e-4, only **8× above** the 1e-4 cut. A mislabelled line weaker than that will be marked forbidden and given the forbidden collision approximation. That is the accepted cost, and it is stated in the code next to the constants. The alternative is to drop the yield-to-strength mechanism and accept 37 strong lines flagged forbidden in F III and O II.

## What changes, ion by ion

"…ARTIS felt" counts the rows where `coll_str < 0`, because — see below — ARTIS reads the flag only there.

### `cmfgen_lowz` — the light ions

| ion | rows | forbidden `main` | forbidden here | fixed (1→0) | …ARTIS felt | added (0→1) | …ARTIS felt |
|---|---|---|---|---|---|---|---|
| H I | 435 | 435 | 0 | **435** | 0 | 0 | 0 |
| H II | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| He I | 1,039 | 251 | 95 | **156** | **156** | 0 | 0 |
| He II | 435 | 435 | 0 | **435** | 0 | 0 | 0 |
| C I | 10,207 | 10 | 11 | 0 | 0 | **1** | 0 |
| C II | 8,482 | 1,376 | 391 | **1,050** | **1,050** | **65** | 0 |
| C III | 5,553 | 2,063 | 63 | **2,008** | **2,008** | **8** | 0 |
| C IV | 1,539 | 377 | 83 | **300** | **286** | **6** | 0 |
| N I | 1,258 | 295 | 334 | 0 | 0 | **39** | 0 |
| N II | 9,247 | 813 | 1,067 | 0 | 0 | **254** | 0 |
| N III | 6,839 | 1,168 | 104 | **1,077** | **1,077** | **13** | 0 |
| F II | 2,354 | 6 | 6 | 0 | 0 | 0 | 0 |
| F III | 9,725 | 8 | 13 | 0 | 0 | **5** | **5** |
| P IV | 2,537 | 0 | 0 | 0 | 0 | 0 | 0 |
| P V | 561 | 0 | 0 | 0 | 0 | 0 | 0 |
| **total** | 60,211 | 7,237 | 2,167 | **5,461** | **4,577** | **391** | **5** |

### `cmfgen` — O and the iron group

| ion | rows | forbidden `main` | forbidden here | fixed (1→0) | …ARTIS felt | added (0→1) | …ARTIS felt |
|---|---|---|---|---|---|---|---|
| O I | 4,383 | 1,165 | 178 | **1,023** | **1,023** | **36** | 0 |
| O II | 9,173 | 169 | 218 | 0 | 0 | **49** | **13** |
| O III | 11,536 | 2,948 | 3,891 | **22** | **22** | **965** | 0 |
| O IV | 7,671 | 949 | 56 | **900** | **900** | **7** | 0 |
| Fe I | 141,961 | 140 | 140 | 0 | 0 | 0 | 0 |
| Fe II | 539,277 | 6,885 | 9,008 | 0 | 0 | **2,123** | 0 |
| Fe III | 153,151 | 10,941 | 17,282 | 0 | 0 | **6,341** | 0 |
| Fe IV | 79,485 | 5,256 | 7,164 | 0 | 0 | **1,908** | 0 |
| Fe V | 72,213 | 230 | 230 | 0 | 0 | 0 | 0 |
| Co II | 593,629 | 489 | 489 | 0 | 0 | 0 | 0 |
| Co III | 679,443 | 163 | 163 | 0 | 0 | 0 | 0 |
| Co IV | 73,882 | 4,457 | 4,457 | 0 | 0 | 0 | 0 |
| Ni II | 53,814 | 1,399 | 2,007 | 0 | 0 | **608** | 0 |
| Ni III | 68,569 | 1,335 | 1,908 | 0 | 0 | **573** | 0 |
| Ni IV | 74,026 | 1,128 | 1,128 | 0 | 0 | 0 | 0 |
| Ni V | 76,049 | 508 | 508 | 0 | 0 | 0 | 0 |
| **total** | 2,638,262 | 38,162 | 48,827 | **1,945** | **1,945** | **12,610** | **13** |

Three things follow.

**The original bug was a light-ion bug.** Every fixed flag sits in H, He, C, N or O. The iron group has no merged levels, so no Fe, Co or Ni line was ever wrongly forbidden — the 1→0 column is zero for all twelve iron-group ions. For a nebular Type Ia, the fix changes nothing about [Fe II], [Fe III], [Co III] or [Ni II].

**ARTIS felt 88% of the fix.** 6,522 of the 7,406 wrong flags sat on rows with no tabulated Ω, and each moves from Axelrod's collision approximation to van Regemorter with its real f, and from no non-thermal excitation to the Mewe/van Regemorter cross-section. The 884 it did not feel are every H I and He II line — Lyman α among them — plus 14 in C IV: those had a real Ω, so ARTIS never read their flag and the fix there is to the file only.

**The ΔJ rule is almost entirely bookkeeping to ARTIS.** Of its 13,001 new flags, 12,983 sit on rows that carry a real Ω — the collision-only pairs of Fe II (2,123), Fe III (6,341), Fe IV, Ni II, Ni III, O III and N II, which exist because the collision file links levels the oscillator file does not, across opposite parities with |ΔJ| > 1. ARTIS takes the `coll_str` branch on all of them and the flag is dead. The **18** it does feel are 5 lines of F III and 13 of O II: lines with f < 1e-4 and no collision data, on precisely the two ions whose J labels this PR shows disagree with their own f. Those 18 rows are the thin margin above, made concrete, and they are the whole ARTIS-visible effect of the ΔJ rule on these two sets.

## What ARTIS reads

Checked against the ARTIS source (`d6363aa2`): `forbidden` is consulted in three places. `spectrum_lightcurve.cc:153` prints it in a diagnostic. The two that matter both gate on `coll_str` first:

- `macroatom.cc:714, 760` — `col_deexcitation_ratecoeff()` / `col_excitation_ratecoeff()`: `if (coll_strength < 0)`, then `forbidden` picks van Regemorter with the line's f (permitted) or Axelrod's Ω = 0.01 g_l g_u (forbidden). A positive `coll_str` returns the tabulated Ω before the flag is touched.
- `nonthermal.cc:927, 1436` — `xs_excitation()` and `has_xs_excitation()`: `if (coll_str >= 0)` uses Ω; otherwise `forbidden` decides between van Regemorter with f and **no non-thermal excitation at all**.

That same reading says where the flag *does* bite, and so what the original bug cost. On a row with no tabulated Ω, `forbidden = 1` sets the thermal collision rate to Axelrod's approximation and the non-thermal excitation cross-section to **zero**. A permitted line wrongly flagged forbidden and lacking collision data therefore got no non-thermal excitation whatsoever.

ARTIS itself uses the same convention: `input.cc:535` synthesises `forbidden = true, coll_str = −2` for any missing pair among the first N levels of an ion.

## Verification

- 44 tests pass. There was previously **no** test that asserted a transition comes out `forbidden=True`, and none of `write_transition_data()`'s forbidden column. There now are, including an H I end-to-end assertion that would have caught the original bug.
- All five reference sets regenerated per `tests/README.md`. Only `transitiondata.txt` moves, and only for `cmfgen`, `cmfgen_lowz` and `qub`. `kurucz` and `floers25` are byte-identical.
- Every parity change was measured against a baseline of all **23,545** CMFGEN level names before it was made.

## Known limits

- **The J labels of a term-resolved level cannot be recovered.** Its g counts every J of the term, so no J is read and the ΔJ rule stays off for it.
- **A weak E1 line below f = 1e-4 is treated as forbidden** if its J labels break the rule. The threshold separates the two populations in this data by four orders of magnitude, but it is a threshold.
- **`interpret_configuration()` matches orbital letters case-sensitively** when the name has a term. This is load-bearing: a case-insensitive match would read He I's `8SNG` as an 8s orbital, give it a parity, and wrongly forbid its merged singlet-triplet transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


