### PR TITLE
Refactor Hillier defaults and photo file rules

### DIFF
--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -81,11 +81,20 @@ class IonFiles(t.NamedTuple):
 
     folder: str
     levelstransitionsfilename: str
-    photfilenames: list[str]
+    photfilenames: tuple[str, ...] | None
     coldatafilename: str
+    photfilecount: int = 1
 
 
-default_ion_files = IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data")
+def get_photfilenames(ionfiles: IonFiles) -> list[str]:
+    """Get one ion's photoionization file names."""
+    if ionfiles.photfilenames is not None:
+        return list(ionfiles.photfilenames)
+
+    return [f"phot_data_{chr(ord('A') + file_index)}" for file_index in range(ionfiles.photfilecount)]
+
+
+default_ion_files = IonFiles("19apr23", "osc_data", None, "col_data")
 
 default_ion_stages: dict[int, t.Iterable[int]] = {
     6: range(1, 7),  # C
@@ -119,27 +128,27 @@ ions_data = {
 
 ions_data |= {
     # H
-    (1, 1): IonFiles("5dec96", "hi_osc.dat", ["hiphot.dat"], "hicol.dat"),
-    (1, 2): IonFiles("", "", [""], ""),
+    (1, 1): IonFiles("5dec96", "hi_osc.dat", ("hiphot.dat",), "hicol.dat"),
+    (1, 2): IonFiles("", "", None, "", photfilecount=0),
     # He
-    (2, 1): IonFiles("11may07", "heioscdat_a7.dat_old", ["heiphot_a7.dat"], "heicol.dat"),
-    (2, 2): IonFiles("5dec96", "he2_osc.dat", ["he2phot.dat"], "he2col.dat"),
+    (2, 1): IonFiles("11may07", "heioscdat_a7.dat_old", ("heiphot_a7.dat",), "heicol.dat"),
+    (2, 2): IonFiles("5dec96", "he2_osc.dat", ("he2phot.dat",), "he2col.dat"),
     # N
-    (7, 1): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B", "phot_data_C", "phot_data_D"], "col_data"),
-    (7, 2): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
-    (7, 3): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
-    (7, 4): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
+    (7, 1): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=4),
+    (7, 2): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
+    (7, 3): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
+    (7, 4): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
     # O
-    (8, 1): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
-    (8, 4): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
+    (8, 1): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
+    (8, 4): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
     # F
-    (9, 2): IonFiles("tst", "fin_osc", ["phot_data_a", "phot_data_b", "phot_data_c"], ""),
-    (9, 3): IonFiles("tst", "fin_osc", ["phot_data_a", "phot_data_b", "phot_data_c", "phot_data_d"], ""),
+    (9, 2): IonFiles("tst", "fin_osc", ("phot_data_a", "phot_data_b", "phot_data_c"), ""),
+    (9, 3): IonFiles("tst", "fin_osc", ("phot_data_a", "phot_data_b", "phot_data_c", "phot_data_d"), ""),
     # Si
-    (14, 2): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
+    (14, 2): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
     # Fe
-    (26, 1): IonFiles("19apr23", "osc_data", ["REV_PHOT_DATA"], "col_data"),
-    (26, 4): IonFiles("19apr23", "feiv_osc_rev2", ["phot_data_A"], "col_data"),
+    (26, 1): IonFiles("19apr23", "osc_data", ("REV_PHOT_DATA",), "col_data"),
+    (26, 4): IonFiles("19apr23", "feiv_osc_rev2", None, "col_data"),
     # Ti IV has dummy files with a single level.
     # (22, 4): IonFiles("18oct00", "tkiv_osc.dat", ["phot_data.dat"], "col_guess.dat"),
     # V I is in CMFGEN and it has a single level.
@@ -638,7 +647,7 @@ def read_phixs_tables(
     # charge of the ion left behind, i.e. CMFGEN's ZION (= ZXzV from the oscillator file, which
     # equals the ionisation stage for every ion here)
     zion = ion_stage
-    photfilenames = ions_data[atomic_number, ion_stage].photfilenames
+    photfilenames = get_photfilenames(ions_data[atomic_number, ion_stage])
     phixstables = [{} for _ in photfilenames]
     phixstargets = ["" for _ in photfilenames]
     reduced_phixs_dict = {}

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -5,6 +5,7 @@ import re
 import sys
 import typing as t
 from collections import defaultdict
+from collections.abc import Iterable
 from functools import cache
 from pathlib import Path
 
@@ -96,7 +97,7 @@ def get_photfilenames(ionfiles: IonFiles) -> list[str]:
 
 default_ion_files = IonFiles("19apr23", "osc_data", None, "col_data")
 
-default_ion_stages: dict[int, t.Iterable[int]] = {
+default_ion_stages: dict[int, Iterable[int]] = {
     6: range(1, 7),  # C
     7: range(5, 8),  # N
     8: (2, 3, 5, 6, 7, 8),  # O

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from functools import cache
 from pathlib import Path
+from string import ascii_uppercase
 
 import numpy as np
 import numpy.typing as npt
@@ -81,20 +82,16 @@ class IonFiles(t.NamedTuple):
 
     folder: str
     levelstransitionsfilename: str
-    photfilenames: tuple[str, ...] | None
+    photfilenames: tuple[str, ...]
     coldatafilename: str
-    photfilecount: int = 1
 
 
-def get_photfilenames(ionfiles: IonFiles) -> list[str]:
-    """Get one ion's photoionization file names."""
-    if ionfiles.photfilenames is not None:
-        return list(ionfiles.photfilenames)
-
-    return [f"phot_data_{chr(ord('A') + file_index)}" for file_index in range(ionfiles.photfilecount)]
+def phot_data_names(count: int) -> tuple[str, ...]:
+    """Get the standard CMFGEN photoionisation file names for one ion."""
+    return tuple(f"phot_data_{ascii_uppercase[index]}" for index in range(count))
 
 
-default_ion_files = IonFiles("19apr23", "osc_data", None, "col_data")
+default_ion_files = IonFiles("19apr23", "osc_data", phot_data_names(1), "col_data")
 
 default_ion_stages: dict[int, Iterable[int]] = {
     6: range(1, 7),  # C
@@ -130,37 +127,38 @@ ions_data = {
 ions_data |= {
     # H
     (1, 1): IonFiles("5dec96", "hi_osc.dat", ("hiphot.dat",), "hicol.dat"),
-    (1, 2): IonFiles("", "", None, "", photfilecount=0),
+    (1, 2): IonFiles("", "", (), ""),
     # He
     (2, 1): IonFiles("11may07", "heioscdat_a7.dat_old", ("heiphot_a7.dat",), "heicol.dat"),
     (2, 2): IonFiles("5dec96", "he2_osc.dat", ("he2phot.dat",), "he2col.dat"),
     # C
-    (6, 2): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
-    (6, 3): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
+    (6, 2): IonFiles("19apr23", "osc_data", phot_data_names(2), "col_data"),
+    (6, 3): IonFiles("19apr23", "osc_data", phot_data_names(2), "col_data"),
     # N
-    (7, 1): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=4),
-    (7, 2): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
-    (7, 3): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
-    (7, 4): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
+    (7, 1): IonFiles("19apr23", "osc_data", phot_data_names(4), "col_data"),
+    (7, 2): IonFiles("19apr23", "osc_data", phot_data_names(2), "col_data"),
+    (7, 3): IonFiles("19apr23", "osc_data", phot_data_names(2), "col_data"),
+    (7, 4): IonFiles("19apr23", "osc_data", phot_data_names(2), "col_data"),
     # O
-    (8, 1): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
-    (8, 4): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
+    (8, 1): IonFiles("19apr23", "osc_data", phot_data_names(2), "col_data"),
+    (8, 4): IonFiles("19apr23", "osc_data", phot_data_names(2), "col_data"),
     # F
     (9, 2): IonFiles("tst", "fin_osc", ("phot_data_a", "phot_data_b", "phot_data_c"), ""),
     (9, 3): IonFiles("tst", "fin_osc", ("phot_data_a", "phot_data_b", "phot_data_c", "phot_data_d"), ""),
     # Si
-    (14, 2): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
+    (14, 2): IonFiles("19apr23", "osc_data", phot_data_names(2), "col_data"),
     # P
-    (15, 4): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
+    (15, 4): IonFiles("19apr23", "osc_data", phot_data_names(2), "col_data"),
+    # Ti IV has dummy files with a single level.
+    # (22, 4): IonFiles("18oct00", "tkiv_osc.dat", ("phot_data.dat",), "col_guess.dat"),
+    # V (only V I is in CMFGEN and it has a single level)
+    # (23, 1): IonFiles("27may10", "vi_osc", ("vi_phot.dat",), "col_guess.dat"),
     # Fe
     (26, 1): IonFiles("19apr23", "osc_data", ("REV_PHOT_DATA",), "col_data"),
-    (26, 4): IonFiles("19apr23", "feiv_osc_rev2", None, "col_data"),
-    # Ti IV has dummy files with a single level.
-    # (22, 4): IonFiles("18oct00", "tkiv_osc.dat", ["phot_data.dat"], "col_guess.dat"),
-    # V (only V I is in CMFGEN and it has a single level)
-    # (23, 1): IonFiles("27may10", "vi_osc", ["vi_phot.dat"], "col_guess.dat"),
+    (26, 4): IonFiles("19apr23", "feiv_osc_rev2", phot_data_names(1), "col_data"),
     # Cu, Zn and above are not in CMGFEN?
-    # (56, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
+    # Ba
+    # (56, 2): IonFiles("19apr23", "osc_data", phot_data_names(1), "col_data"),
 }
 
 elsymboltohilliercode = {
@@ -653,7 +651,7 @@ def read_phixs_tables(
     # charge of the ion left behind, i.e. CMFGEN's ZION (= ZXzV from the oscillator file, which
     # equals the ionisation stage for every ion here)
     zion = ion_stage
-    photfilenames = get_photfilenames(ions_data[atomic_number, ion_stage])
+    photfilenames = ions_data[atomic_number, ion_stage].photfilenames
     phixstables = [{} for _ in photfilenames]
     phixstargets = ["" for _ in photfilenames]
     reduced_phixs_dict = {}
@@ -672,8 +670,6 @@ def read_phixs_tables(
     phixs_type_levels: defaultdict[int, set[str]] = defaultdict(set)
     unknown_phixs_types = []
     for filenum, photfilename in enumerate(photfilenames):
-        if not photfilename:
-            continue
         filename = Path(
             hillier_ion_folder(atomic_number, ion_stage), ions_data[atomic_number, ion_stage].folder, photfilename
         )

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -76,7 +76,6 @@ hillier_transition_schema = pl.Schema(
 hillier_required_filecolumns = tuple(colname for colname in hillier_level_schema if colname not in {"parity", "j"})
 
 
-# keys are (atomic number, ion stage)
 class IonFiles(t.NamedTuple):
     """The CMFGEN files holding one ion's levels, cross sections and collision data."""
 
@@ -127,6 +126,7 @@ ions_data = {
     for ion_stage in ion_stages
 }
 
+# keys are (atomic number, ion stage)
 ions_data |= {
     # H
     (1, 1): IonFiles("5dec96", "hi_osc.dat", ("hiphot.dat",), "hicol.dat"),
@@ -157,7 +157,7 @@ ions_data |= {
     (26, 4): IonFiles("19apr23", "feiv_osc_rev2", None, "col_data"),
     # Ti IV has dummy files with a single level.
     # (22, 4): IonFiles("18oct00", "tkiv_osc.dat", ["phot_data.dat"], "col_guess.dat"),
-    # V I is in CMFGEN and it has a single level.
+    # V (only V I is in CMFGEN and it has a single level)
     # (23, 1): IonFiles("27may10", "vi_osc", ["vi_phot.dat"], "col_guess.dat"),
     # Cu, Zn and above are not in CMGFEN?
     # (56, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -134,6 +134,9 @@ ions_data |= {
     # He
     (2, 1): IonFiles("11may07", "heioscdat_a7.dat_old", ("heiphot_a7.dat",), "heicol.dat"),
     (2, 2): IonFiles("5dec96", "he2_osc.dat", ("he2phot.dat",), "he2col.dat"),
+    # C
+    (6, 2): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
+    (6, 3): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
     # N
     (7, 1): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=4),
     (7, 2): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
@@ -147,6 +150,8 @@ ions_data |= {
     (9, 3): IonFiles("tst", "fin_osc", ("phot_data_a", "phot_data_b", "phot_data_c", "phot_data_d"), ""),
     # Si
     (14, 2): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
+    # P
+    (15, 4): IonFiles("19apr23", "osc_data", None, "col_data", photfilecount=2),
     # Fe
     (26, 1): IonFiles("19apr23", "osc_data", ("REV_PHOT_DATA",), "col_data"),
     (26, 4): IonFiles("19apr23", "feiv_osc_rev2", None, "col_data"),

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -85,240 +85,68 @@ class IonFiles(t.NamedTuple):
     coldatafilename: str
 
 
+default_ion_files = IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data")
+
+default_ion_stages: dict[int, t.Iterable[int]] = {
+    6: range(1, 7),  # C
+    7: range(5, 8),  # N
+    8: (2, 3, 5, 6, 7, 8),  # O
+    10: range(1, 9),  # Ne
+    11: range(1, 10),  # Na
+    12: range(1, 11),  # Mg
+    13: range(1, 12),  # Al
+    14: (1, *range(3, 13)),  # Si
+    15: range(2, 12),  # P (I not in CMFGEN)
+    16: range(1, 11),  # S
+    17: range(4, 8),  # Cl (only ions IV to VII)
+    18: range(1, 11),  # Ar
+    19: range(1, 12),  # K
+    20: range(1, 12),  # Ca
+    21: range(1, 4),  # Sc (only I-III are in CMFGEN)
+    22: range(2, 4),  # Ti (only II and III are in CMFGEN)
+    24: range(1, 15),  # Cr
+    25: range(2, 8),  # Mn (Mn I is not in CMFGEN)
+    26: (2, 3, *range(5, 17)),  # Fe
+    27: range(1, 10),  # Co
+    28: range(1, 17),  # Ni
+}
+
 ions_data = {
+    (atomic_number, ion_stage): default_ion_files
+    for atomic_number, ion_stages in default_ion_stages.items()
+    for ion_stage in ion_stages
+}
+
+ions_data |= {
     # H
     (1, 1): IonFiles("5dec96", "hi_osc.dat", ["hiphot.dat"], "hicol.dat"),
     (1, 2): IonFiles("", "", [""], ""),
     # He
     (2, 1): IonFiles("11may07", "heioscdat_a7.dat_old", ["heiphot_a7.dat"], "heicol.dat"),
     (2, 2): IonFiles("5dec96", "he2_osc.dat", ["he2phot.dat"], "he2col.dat"),
-    # C
-    (6, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (6, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (6, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (6, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (6, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (6, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
     # N
     (7, 1): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B", "phot_data_C", "phot_data_D"], "col_data"),
     (7, 2): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
     (7, 3): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
     (7, 4): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
-    (7, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (7, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (7, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
     # O
     (8, 1): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
-    (8, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (8, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
     (8, 4): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
-    (8, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (8, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (8, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (8, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
     # F
     (9, 2): IonFiles("tst", "fin_osc", ["phot_data_a", "phot_data_b", "phot_data_c"], ""),
     (9, 3): IonFiles("tst", "fin_osc", ["phot_data_a", "phot_data_b", "phot_data_c", "phot_data_d"], ""),
-    # Ne
-    (10, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (10, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (10, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (10, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (10, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (10, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (10, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (10, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Na
-    (11, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (11, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (11, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (11, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (11, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (11, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (11, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (11, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (11, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Mg
-    (12, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (12, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (12, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (12, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (12, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (12, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (12, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (12, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (12, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (12, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Al
-    (13, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (13, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (13, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (13, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (13, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (13, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (13, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (13, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (13, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (13, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (13, 11): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
     # Si
-    (14, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
     (14, 2): IonFiles("19apr23", "osc_data", ["phot_data_A", "phot_data_B"], "col_data"),
-    (14, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (14, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (14, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (14, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (14, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (14, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (14, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (14, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (14, 11): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (14, 12): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # P (I not in CMFGEN)  # ruff: ignore[commented-out-code]
-    (15, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (15, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (15, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (15, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (15, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (15, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (15, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (15, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (15, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (15, 11): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # S
-    (16, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (16, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (16, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (16, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (16, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (16, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (16, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (16, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (16, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (16, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Cl (only ions IV to VII)
-    (17, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (17, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (17, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (17, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Ar
-    (18, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (18, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (18, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (18, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (18, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (18, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (18, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (18, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (18, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (18, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # K
-    (19, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (19, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (19, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (19, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (19, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (19, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (19, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (19, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (19, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (19, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (19, 11): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Ca
-    (20, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (20, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (20, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (20, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (20, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (20, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (20, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (20, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (20, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (20, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (20, 11): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Sc (only I-III are in CMFGEN)
-    (21, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (21, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (21, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Ti (only II and III are in CMFGEN, IV has dummy files with a single level)
-    (22, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (22, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # (22, 4): IonFiles("18oct00", "tkiv_osc.dat", ["phot_data.dat"], "col_guess.dat"),
-    # V (only V I is in CMFGEN and it has a single level)
-    # (23, 1): IonFiles("27may10", "vi_osc", ["vi_phot.dat"], "col_guess.dat"),
-    # Cr
-    (24, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 11): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 12): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 13): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (24, 14): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Mn (Mn I is not in CMFGEN)
-    (25, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (25, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (25, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (25, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (25, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (25, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
     # Fe
     (26, 1): IonFiles("19apr23", "osc_data", ["REV_PHOT_DATA"], "col_data"),
-    (26, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
     (26, 4): IonFiles("19apr23", "feiv_osc_rev2", ["phot_data_A"], "col_data"),
-    (26, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 11): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 12): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 13): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 14): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 15): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (26, 16): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Co
-    (27, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (27, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (27, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (27, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (27, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (27, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (27, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (27, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (27, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    # Ni
-    (28, 1): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 3): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 4): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 5): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 6): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 7): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 8): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 9): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 10): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 11): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 12): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 13): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 14): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 15): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
-    (28, 16): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
+    # Ti IV has dummy files with a single level.
+    # (22, 4): IonFiles("18oct00", "tkiv_osc.dat", ["phot_data.dat"], "col_guess.dat"),
+    # V I is in CMFGEN and it has a single level.
+    # (23, 1): IonFiles("27may10", "vi_osc", ["vi_phot.dat"], "col_guess.dat"),
     # Cu, Zn and above are not in CMGFEN?
-    # Ba
     # (56, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
 }
-
-default_ion_files = IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data")
-ions_data = defaultdict(lambda: default_ion_files, ions_data)
 
 elsymboltohilliercode = {
     "H": "HYD",

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -317,6 +317,9 @@ ions_data = {
     # (56, 2): IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data"),
 }
 
+default_ion_files = IonFiles("19apr23", "osc_data", ["phot_data_A"], "col_data")
+ions_data = defaultdict(lambda: default_ion_files, ions_data)
+
 elsymboltohilliercode = {
     "H": "HYD",
     "He": "HE",

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -615,9 +615,11 @@ def test_read_phixs_tables_multiple_photoionisation_files(monkeypatch):
     rhd.read_hyd_phixsdata()
     args = argparse.Namespace(nphixspoints=100, phixsnuincrement=0.03, optimaltemperature=6000)
 
-    def read_phixs(photfilenames):
+    def read_phixs(named_photfilenames):
         """Read O I's cross sections using only the named phot files."""
-        monkeypatch.setitem(readhillierdata.ions_data, (8, 1), ionfiles._replace(photfilenames=tuple(photfilenames)))
+        monkeypatch.setitem(
+            readhillierdata.ions_data, (8, 1), ionfiles._replace(photfilenames=tuple(named_photfilenames))
+        )
         flog = io.StringIO()
         with contextlib.redirect_stdout(io.StringIO()):
             _, dflevels, _, _ = rhd.read_levels_and_transitions(8, 1, flog)

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -592,11 +592,11 @@ def test_write_output_files_rejects_unresolved_targetfractions(tmp_path):
 def test_read_phixs_tables_multiple_photoionisation_files(monkeypatch):
     """A level with a cross-section table in more than one phot file keeps the largest, rescaled.
 
-    Every CMFGEN ion with several phot files has one file per final state of the upper ion. A
-    level is normally present in all of them: O I's phot_nosm_A and phot_nosm_B share all 107
-    of their configuration names. Treating the second table as an error made those ions (C I,
-    C III, N I, N III, O I, O IV, F II, F III, P IV) unreadable, and none of them was in the
-    tests/ matrix, which was Fe/Co/Ni only.
+    Every CMFGEN ion with several entries in ions_data[...].photfilenames has one file per final
+    state of the upper ion, and a level is normally present in all of them: O I's phot_nosm_A and
+    phot_nosm_B share all 107 of their configuration names. Treating the second table as an error
+    made those ions (C I, C III, N I, N III, O I, O IV, F II, F III, P IV) unreadable, and none of
+    them was in the tests/ matrix, which was Fe/Co/Ni only.
 
     Only one table can be written per level, so the one with the largest threshold cross section
     wins. write_phixs_data() writes it as the level's TOTAL and splits it over the targets, so it
@@ -608,28 +608,25 @@ def test_read_phixs_tables_multiple_photoionisation_files(monkeypatch):
     import contextlib
 
     ionfiles = readhillierdata.ions_data[8, 1]
-    photfilenames = readhillierdata.get_photfilenames(ionfiles)
     # checked before the expensive reads below, so a change here fails as itself
-    assert len(photfilenames) == 2, f"O I is expected to have two phot files, got {photfilenames}"
+    assert len(ionfiles.photfilenames) == 2, f"O I is expected to have two phot files, got {ionfiles.photfilenames}"
 
     rhd.read_hyd_phixsdata()
     args = argparse.Namespace(nphixspoints=100, phixsnuincrement=0.03, optimaltemperature=6000)
 
-    def read_phixs(named_photfilenames):
+    def read_phixs(photfilenames):
         """Read O I's cross sections using only the named phot files."""
-        monkeypatch.setitem(
-            readhillierdata.ions_data, (8, 1), ionfiles._replace(photfilenames=tuple(named_photfilenames))
-        )
+        monkeypatch.setitem(readhillierdata.ions_data, (8, 1), ionfiles._replace(photfilenames=photfilenames))
         flog = io.StringIO()
         with contextlib.redirect_stdout(io.StringIO()):
             _, dflevels, _, _ = rhd.read_levels_and_transitions(8, 1, flog)
             crosssections, targetconfigs, _thresholds = rhd.read_phixs_tables(8, 1, dflevels, args, flog)
         return crosssections, targetconfigs, flog.getvalue()
 
-    file_a, file_b = photfilenames
-    crosssections_a, targets_a, _ = read_phixs([file_a])
-    crosssections_b, targets_b, _ = read_phixs([file_b])
-    crosssections, targetconfigs, log = read_phixs([file_a, file_b])
+    file_a, file_b = ionfiles.photfilenames
+    crosssections_a, targets_a, _ = read_phixs((file_a,))
+    crosssections_b, targets_b, _ = read_phixs((file_b,))
+    crosssections, targetconfigs, log = read_phixs((file_a, file_b))
 
     # the duplicates are reported rather than raised
     assert "has a cross section table in more than one photoionisation file" in log
@@ -1166,6 +1163,75 @@ def test_split_element_ionstage_str():
 
     with pytest.raises(ValueError, match="Could not split"):
         split_element_ionstage_str("NotAnIon")
+
+
+def test_hillier_ions_data_matches_the_cmfgen_corpus():
+    """ions_data holds one entry for every CMFGEN ion, with the phot file names of that ion.
+
+    The ion stages come from ranges, so a wrong bound drops an ion without a syntax error.
+    extend_ion_list() then never offers that ion, and the checksum tests do not find the
+    mistake: the two CMFGEN sets read 31 of the 199 ions. This test pins the full list.
+    """
+    expected_ion_stages = {
+        1: [1, 2],  # H
+        2: [1, 2],  # He
+        6: [1, 2, 3, 4, 5, 6],  # C
+        7: [1, 2, 3, 4, 5, 6, 7],  # N
+        8: [1, 2, 3, 4, 5, 6, 7, 8],  # O
+        9: [2, 3],  # F
+        10: [1, 2, 3, 4, 5, 6, 7, 8],  # Ne
+        11: [1, 2, 3, 4, 5, 6, 7, 8, 9],  # Na
+        12: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],  # Mg
+        13: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],  # Al
+        14: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],  # Si
+        15: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11],  # P
+        16: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],  # S
+        17: [4, 5, 6, 7],  # Cl
+        18: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],  # Ar
+        19: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],  # K
+        20: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],  # Ca
+        21: [1, 2, 3],  # Sc
+        22: [2, 3],  # Ti
+        24: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],  # Cr
+        25: [2, 3, 4, 5, 6, 7],  # Mn
+        26: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],  # Fe
+        27: [1, 2, 3, 4, 5, 6, 7, 8, 9],  # Co
+        28: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],  # Ni
+    }
+    ion_stages = {
+        atomic_number: sorted(
+            stage for (found_atomic_number, stage) in readhillierdata.ions_data if found_atomic_number == atomic_number
+        )
+        for atomic_number in sorted({atomic_number for atomic_number, _ in readhillierdata.ions_data})
+    }
+    assert ion_stages == expected_ion_stages
+
+    # every ion whose phot files are not the single default file. H II is the bare top ion, so
+    # it has no files at all.
+    expected_photfilenames = {
+        (1, 1): ("hiphot.dat",),
+        (1, 2): (),
+        (2, 1): ("heiphot_a7.dat",),
+        (2, 2): ("he2phot.dat",),
+        (6, 2): ("phot_data_A", "phot_data_B"),
+        (6, 3): ("phot_data_A", "phot_data_B"),
+        (7, 1): ("phot_data_A", "phot_data_B", "phot_data_C", "phot_data_D"),
+        (7, 2): ("phot_data_A", "phot_data_B"),
+        (7, 3): ("phot_data_A", "phot_data_B"),
+        (7, 4): ("phot_data_A", "phot_data_B"),
+        (8, 1): ("phot_data_A", "phot_data_B"),
+        (8, 4): ("phot_data_A", "phot_data_B"),
+        (9, 2): ("phot_data_a", "phot_data_b", "phot_data_c"),
+        (9, 3): ("phot_data_a", "phot_data_b", "phot_data_c", "phot_data_d"),
+        (14, 2): ("phot_data_A", "phot_data_B"),
+        (15, 4): ("phot_data_A", "phot_data_B"),
+        (26, 1): ("REV_PHOT_DATA",),
+    }
+    assert {
+        ion: ionfiles.photfilenames
+        for ion, ionfiles in readhillierdata.ions_data.items()
+        if ionfiles.photfilenames != ("phot_data_A",)
+    } == expected_photfilenames
 
 
 def test_hillier_extend_ion_list():

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -592,11 +592,11 @@ def test_write_output_files_rejects_unresolved_targetfractions(tmp_path):
 def test_read_phixs_tables_multiple_photoionisation_files(monkeypatch):
     """A level with a cross-section table in more than one phot file keeps the largest, rescaled.
 
-    Every CMFGEN ion with several entries in ions_data[...].photfilenames has one file per final
-    state of the upper ion, and a level is normally present in all of them: O I's phot_nosm_A and
-    phot_nosm_B share all 107 of their configuration names. Treating the second table as an error
-    made those ions (C I, C III, N I, N III, O I, O IV, F II, F III, P IV) unreadable, and none of
-    them was in the tests/ matrix, which was Fe/Co/Ni only.
+    Every CMFGEN ion with several phot files has one file per final state of the upper ion. A
+    level is normally present in all of them: O I's phot_nosm_A and phot_nosm_B share all 107
+    of their configuration names. Treating the second table as an error made those ions (C I,
+    C III, N I, N III, O I, O IV, F II, F III, P IV) unreadable, and none of them was in the
+    tests/ matrix, which was Fe/Co/Ni only.
 
     Only one table can be written per level, so the one with the largest threshold cross section
     wins. write_phixs_data() writes it as the level's TOTAL and splits it over the targets, so it
@@ -608,22 +608,23 @@ def test_read_phixs_tables_multiple_photoionisation_files(monkeypatch):
     import contextlib
 
     ionfiles = readhillierdata.ions_data[8, 1]
+    photfilenames = readhillierdata.get_photfilenames(ionfiles)
     # checked before the expensive reads below, so a change here fails as itself
-    assert len(ionfiles.photfilenames) == 2, f"O I is expected to have two phot files, got {ionfiles.photfilenames}"
+    assert len(photfilenames) == 2, f"O I is expected to have two phot files, got {photfilenames}"
 
     rhd.read_hyd_phixsdata()
     args = argparse.Namespace(nphixspoints=100, phixsnuincrement=0.03, optimaltemperature=6000)
 
     def read_phixs(photfilenames):
         """Read O I's cross sections using only the named phot files."""
-        monkeypatch.setitem(readhillierdata.ions_data, (8, 1), ionfiles._replace(photfilenames=photfilenames))
+        monkeypatch.setitem(readhillierdata.ions_data, (8, 1), ionfiles._replace(photfilenames=tuple(photfilenames)))
         flog = io.StringIO()
         with contextlib.redirect_stdout(io.StringIO()):
             _, dflevels, _, _ = rhd.read_levels_and_transitions(8, 1, flog)
             crosssections, targetconfigs, _thresholds = rhd.read_phixs_tables(8, 1, dflevels, args, flog)
         return crosssections, targetconfigs, flog.getvalue()
 
-    file_a, file_b = ionfiles.photfilenames
+    file_a, file_b = photfilenames
     crosssections_a, targets_a, _ = read_phixs([file_a])
     crosssections_b, targets_b, _ = read_phixs([file_b])
     crosssections, targetconfigs, log = read_phixs([file_a, file_b])

--- a/tests/cmfgen_lowz/checksums.txt
+++ b/tests/cmfgen_lowz/checksums.txt
@@ -1,4 +1,4 @@
 0d5755fa720eadc8cb1ce98ece0a596c  adata.txt
 5fbbc0dc9cf13e66a15caf576650a408  compositiondata.txt
-6bb2f4acaa78a93224dd38662e7940b2  phixsdata_v2.txt
+7f19ef7c99bed70bc94a04e0b739ab30  phixsdata_v2.txt
 a4c07e3ded1f523e6f9b2e079a09340c  transitiondata.txt


### PR DESCRIPTION
## Summary
- replace repeated Hillier ion file entries with default-stage expansion and explicit exceptions only
- add generated standard photoionization filenames (phot_data_A, phot_data_B, ...) from a per-ion count
- keep explicit photo filename overrides only for real exceptions (for example F and Fe I)

## Testing
- uv run -m pytest artisatomic/test_artisatomic.py -k multiple_photoionisation_files
- uv run -m pytest *(fails in this environment for missing Kurucz data file gf3800)*