### PR TITLE
Make the charge transfer file smaller and drop the estimates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,15 +264,15 @@ jobs:
               run: uv sync --compile-bytecode
 
             # the source files are tracked in atomic-data-chargetransfer, so this job downloads nothing
-            - name: Generate the charge transfer file
-              run: uv run coverage run -p -m artisatomic.makechargetransferfile -outputfile tests/chargetransfer/output/chargetransfer.txt
+            - name: Generate the charge transfer files
+              run: uv run coverage run -p -m artisatomic.makechargetransferfile -output_folder tests/chargetransfer/output
 
-            - name: Checksum the output file
+            - name: Checksum the output files
               working-directory: tests/chargetransfer/output
               run: |
-                  head -70 chargetransfer.txt
+                  head -70 *.txt
                   echo
-                  md5sum chargetransfer.txt
+                  md5sum *.txt
                   md5sum -c ../checksums.txt
 
             - name: Upload coverage data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,10 +264,10 @@ jobs:
               run: uv sync --compile-bytecode
 
             # the source files are tracked in atomic-data-chargetransfer, so this job downloads nothing
-            - name: Generate the charge transfer files
+            - name: Generate the charge transfer file
               run: uv run coverage run -p -m artisatomic.makechargetransferfile -output_folder tests/chargetransfer/output
 
-            - name: Checksum the output files
+            - name: Checksum the output file
               working-directory: tests/chargetransfer/output
               run: |
                   head -70 *.txt

--- a/artisatomic/makechargetransferfile.py
+++ b/artisatomic/makechargetransferfile.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
-"""Write the charge transfer rate files for ARTIS: data/chargetransfer.txt and data/chargetransfer_estimates.txt.
+"""Write the file of charge transfer rates for ARTIS (data/chargetransfer.txt in the artis repository).
 
 The script reads the published fits and rate tables from the folder atomic-data-chargetransfer.
-It converts them into one fit form and writes one reaction for each line. The published fits go
-into chargetransfer.txt. The estimates go into chargetransfer_estimates.txt, which holds the ion
-columns only, because ARTIS applies one rate to all of them. The script
+It converts them into one fit form and writes one reaction for each line. The script
 setup_chargetransfer_data.sh in that folder downloads the tables. The sources are:
 
 - The Cloudy master data files ctrecombdata.dat and ctiondata.dat (gitlab.nublado.org). They carry
@@ -16,32 +14,23 @@ setup_chargetransfer_data.sh in that folder downloads the tables. The sources ar
 - The CDS tables of Sterling & Stancil (2011), A&A, 535, A117 (SS11). They cover the n-capture
   elements Ge, Se, Br, Kr, Rb, and Xe with hydrogen. SS11 publish tabulated k(T) values and no
   fit coefficients, so the script fits their tables over 1e3 to 4e4 K.
-- Estimates for the reactions of a heavy ion with a neutral heavy atom. The estimates also
-  cover the reactions of any element with hydrogen that the sources above omit. The kilonova
-  ejecta consist mostly of heavy elements, so these reactions matter there. No publication gives
-  these rates, so the script takes the ionization energies from the NIST table of this package.
-  It keeps the exothermic reactions with a small energy defect. Each one gets the near-resonant
-  rate of 1e-9 cm3/s (Melius 1974). The reverse reactions come from detailed balance in ARTIS.
 
 Every entry uses the KF96 fit form (their equation 7, from AR85):
   k = a * 1e-9 * t4^b * (1 + c * exp(d * t4)) * exp(-eexp/T)  [cm3/s],  t4 = T / 1e4 K.
 See the header of the output file for the column definitions. The chargetransfer.cc module of ARTIS
-reads the file and generates Landau-Zener estimates for the reactions that the file does not cover.
+reads the file and makes its own estimates for the reactions that the file does not cover.
 """
 
 import argparse
 import math
 import typing as t
 from collections import Counter
-from collections.abc import Set as AbstractSet
 from itertools import starmap
 from pathlib import Path
 
 import numpy as np
 
 from artisatomic.base import elsymbols
-from artisatomic.base import get_nist_ionization_energies_ev
-from artisatomic.base import get_nist_ionization_provenance
 from artisatomic.base import xopen_check_extension
 
 # KF96 Table 1 and the Table 2 totals, transcribed from the paper: (Z, q) -> (a, b, c, d).
@@ -198,29 +187,8 @@ SS11_USABLE_MIN = 1.2e-14  # a tabulated total above this value is a usable fit 
 SS11_MIN_POINTS = 4  # a curve with fewer usable points gets a flat value instead of a fit
 SS11_FLAT_TEMP = 20000  # the entry that supplies the flat value [K]
 
-# The near-resonant rate estimate for a reaction between two heavy species (Melius 1974).
-# The unit is 1e-9 cm3/s, which is the unit of the fit coefficient a.
-METAL_METAL_RATE = 1.0
-# An exothermic reaction with an energy defect up to this value gets the estimate. A larger
-# defect can not reach a level of the products near resonance. The reaction then stays slow,
-# and ARTIS makes its own Landau-Zener estimate.
-METAL_METAL_MAX_DEFECT_EV = 4.0
-# the acceptor charges of the estimate; higher stages are rare in the kilonova nebular phase
-METAL_METAL_ACCEPTOR_CHARGES = (1, 2, 3)
-# The elements of the estimates. The bounds are parameters of this script. The estimates with a
-# neutral heavy atom start at Sc, because the light elements have few low levels. Both kinds end
-# at Lr, the last actinide.
-METAL_METAL_ZMIN = 21
-ESTIMATE_ZMAX = 103
-# The range of use of the estimates [K]. A flat value has no temperature dependence, so the clamp
-# has no effect; the values document the nebular range only.
-METAL_METAL_TMIN = 1000
-METAL_METAL_TMAX = 40000
-
-ION_COLUMNS = "Z_acc ionstage_acc Z_don ionstage_don"
-FIT_COLUMNS = "a b c d eexp tmin tmax"
-# ARTIS holds these values for every estimate, so the estimates file does not carry them
-ESTIMATE_COEFFS = (METAL_METAL_RATE, 0.0, 0.0, 0.0, 0.0, METAL_METAL_TMIN, METAL_METAL_TMAX)
+# the columns of a reaction line, in their order
+COLUMN_NAMES = "Z_acc ionstage_acc Z_don ionstage_don a b c d eexp tmin tmax autoreverse"
 
 # the n-capture elements that SS11 cover
 SS11_ZNUM = {elsymbol: elsymbols.index(elsymbol) for elsymbol in ("Ge", "Se", "Br", "Kr", "Rb", "Xe")}
@@ -231,12 +199,12 @@ def comment_block(lines: list[str]) -> str:
     return "".join(f"# {line}".rstrip() + "\n" for line in lines)
 
 
-def format_fits_header(source_counts: Counter[str]) -> str:
-    """Build the comment block of the fits file: the format, the sources, and the parameters."""
+def format_header(source_counts: Counter[str]) -> str:
+    """Build the comment block of the output file: the format, the sources, and the parameters."""
     lines = [
         "Fits of the rate coefficients for charge transfer, for the chargetransfer.cc module of ARTIS.",
         "The artisatomic script makechargetransferfile generates this file. Do not edit it by hand.",
-        "The file chargetransfer_estimates.txt holds the near-resonant estimates for the other reactions.",
+        "ARTIS makes its own estimates for the reactions that this file does not cover.",
         "",
         "FORMAT",
         "The first non-comment line gives the number of reactions. Each reaction line holds 12 columns",
@@ -246,7 +214,7 @@ def format_fits_header(source_counts: Counter[str]) -> str:
         "t4 is T/1e4 K with T clamped into [tmin, tmax]; the factor exp(-eexp/T) uses the true T, and eexp is in K.",
         "For a flat entry (b = c = eexp = 0) the clamp has no effect.",
         "autoreverse 1 lets the code add the reverse reaction from detailed balance when the forward",
-        "reaction releases energy. It is 0 when one of the two files holds the reverse reaction.",
+        "reaction releases energy. It is 0 when this file holds a fit for the reverse reaction.",
         "A comment follows the columns. It starts with the tag of the source, then gives the values that",
         "are specific to the reaction. The four Z and ionstage columns identify the reaction, so the",
         "comment does not repeat it. SOURCES below gives the text that all lines of a source share.",
@@ -275,46 +243,7 @@ def format_fits_header(source_counts: Counter[str]) -> str:
         f"  {SS11_FLAT_TEMP} K. The comment of each line gives the largest relative error of the fit or the flat value",
         "  over the usable points. eexp of an SS11 entry is a fit coefficient and not a measured energy.",
         "  Below tmin, an entry with eexp > 0 keeps falling and an entry with eexp = 0 holds its value at tmin.",
-        "autoreverse: set from the reactions of this file and of chargetransfer_estimates.txt together.",
-    ]
-    return comment_block(lines)
-
-
-def format_estimates_header(nestimates: int) -> str:
-    """Build the comment block of the estimates file: the format, the source, and the parameters."""
-    lines = [
-        "Near-resonant estimates of the rate coefficients for charge transfer, for chargetransfer.cc of ARTIS.",
-        "The artisatomic script makechargetransferfile generates this file. Do not edit it by hand.",
-        "The file chargetransfer.txt holds the published fits.",
-        "",
-        "FORMAT",
-        "The first non-comment line gives the number of reactions. Each reaction line holds 5 columns",
-        "that one or more spaces separate. The comment line above the first reaction names the columns.",
-        "The acceptor ion (Z_acc, ionstage_acc) captures an electron from the donor ion (Z_don, ionstage_don).",
-        "This file holds no rate. ARTIS applies the same rate to every reaction of this file:",
-        f"{METAL_METAL_RATE:g}e-9 cm3/s, flat in T. See PARAMETERS.",
-        "autoreverse 1 lets the code add the reverse reaction from detailed balance when the forward",
-        "reaction releases energy. It is 0 when chargetransfer.txt holds a fit for the reverse reaction.",
-        "",
-        "SOURCES",
-        f"Estimate ({nestimates} reactions): a heavy ion with a neutral heavy atom, for the kilonova ejecta,",
-        "  which consist mostly of heavy elements, and any ion with a hydrogen atom or a proton with any neutral",
-        "  atom. No publication gives these rates. Each exothermic reaction with a small energy defect, which",
-        "  chargetransfer.txt does not cover, gets the near-resonant rate of Melius (1974), J. Phys. B, 7, 1692.",
-        "  The energy defect comes from the ground-state ionization energies of the NIST table that",
-        "  artisatomic ships (nist_ionization.txt.zst):",
-        *[f"    {line}" for line in get_nist_ionization_provenance()],
-        f"  With a neutral heavy atom, the elements are {elsymbols[METAL_METAL_ZMIN]} to {elsymbols[ESTIMATE_ZMAX]} (Z = {METAL_METAL_ZMIN} to {ESTIMATE_ZMAX}). With hydrogen,",
-        f"  the elements are He to {elsymbols[ESTIMATE_ZMAX]}.",
-        "",
-        "PARAMETERS",
-        f"Estimates: rate {METAL_METAL_RATE:g}e-9 cm3/s, flat in T, for an exothermic reaction with an energy defect",
-        f"  in (0, {METAL_METAL_MAX_DEFECT_EV:g}] eV. The acceptor charge is one of {METAL_METAL_ACCEPTOR_CHARGES}, or 1 for a proton. The",
-        "  donor is always neutral, because the Coulomb repulsion between two positive ions makes their reactions",
-        "  slow. The estimate assumes that a level of the products lies near the energy defect; it does not",
-        f"  check the level lists. The range of use is {METAL_METAL_TMIN}-{METAL_METAL_TMAX} K.",
-        "  ARTIS makes a Landau-Zener estimate for every reaction that neither file holds.",
-        "autoreverse: set from the reactions of this file and of chargetransfer.txt together.",
+        "autoreverse: set from the full list of reactions in this file, not from one source alone.",
     ]
     return comment_block(lines)
 
@@ -445,75 +374,6 @@ def get_kf96_h_entries(sourcedir: Path) -> tuple[list[CTEntry], list[str]]:
         entries.append(CTEntry(1, 2, z, q + 1, a, b, c, d, de4 * 1e4, tmin, tmax, comment))
 
     return entries, report
-
-
-def get_estimate_entries(covered: AbstractSet[tuple[int, int, int, int]] = frozenset()) -> list[CTEntry]:
-    """Build estimates for the capture of an electron from a neutral atom, with a small energy defect.
-
-    The kilonova ejecta consist mostly of heavy elements, so the reactions between heavy species
-    matter there. No publication gives the heavy-element rates. The heavy species have many low
-    levels. An exothermic reaction with an energy defect below METAL_METAL_MAX_DEFECT_EV can
-    therefore reach a level of the products near resonance. Such a reaction gets the
-    near-resonant rate of 1e-9 cm3/s (Melius 1974). The donor is always neutral, because the
-    Coulomb repulsion between two positive ions makes their reactions slow.
-
-    Three kinds of reaction get an estimate:
-
-    - a heavy ion (Sc to Lr) captures from a neutral heavy atom (Sc to Lr);
-    - an ion of any element up to Lr captures from a hydrogen atom;
-    - a proton captures from a neutral atom of any element up to Lr.
-
-    A reaction in `covered`, the keys (Z_acc, stage_acc, Z_don, stage_don) of the other sources,
-    gets no estimate. A published rate therefore replaces its estimate. The ionization energies
-    come from the NIST table that the package ships, artisatomic/nist_ionization.txt.zst.
-    """
-    energies = {(z, stage - 1): energy_ev for (z, stage), energy_ev in get_nist_ionization_energies_ev().items()}
-    ie_hydrogen_ev = energies[1, 0]
-    entries = []
-
-    def add(z_acc: int, charge_acc: int, z_don: int, deltae_ev: float) -> None:
-        """Add the capture by (z_acc, charge_acc) from the neutral atom z_don when the defect is small."""
-        if (z_acc, charge_acc + 1, z_don, 1) in covered or not 0.0 < deltae_ev <= METAL_METAL_MAX_DEFECT_EV:
-            return
-        comment = "Estimate"
-        entries.append(
-            CTEntry(
-                z_acc,
-                charge_acc + 1,
-                z_don,
-                1,
-                METAL_METAL_RATE,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                METAL_METAL_TMIN,
-                METAL_METAL_TMAX,
-                comment,
-            )
-        )
-
-    heavy = [z for (z, charge) in sorted(energies) if charge == 0 and METAL_METAL_ZMIN <= z <= ESTIMATE_ZMAX]
-    for z_acc in heavy:
-        for charge_acc in METAL_METAL_ACCEPTOR_CHARGES:
-            if (z_acc, charge_acc - 1) not in energies:
-                continue
-            # the capture releases the ionization energy of the product ion
-            energy_released_ev = energies[z_acc, charge_acc - 1]
-            for z_don in heavy:
-                if z_don == z_acc and charge_acc == 1:
-                    continue  # the products equal the reactants, so the reaction changes nothing
-                add(z_acc, charge_acc, z_don, energy_released_ev - energies[z_don, 0])
-
-    for z in sorted({z for (z, charge) in energies if 1 < z <= ESTIMATE_ZMAX}):
-        # an ion captures from a hydrogen atom
-        for charge_acc in METAL_METAL_ACCEPTOR_CHARGES:
-            if (z, charge_acc - 1) in energies:
-                add(z, charge_acc, 1, energies[z, charge_acc - 1] - ie_hydrogen_ev)
-        # a proton captures from the neutral atom
-        if (z, 0) in energies:
-            add(1, 1, z, ie_hydrogen_ev - energies[z, 0])
-    return entries
 
 
 def get_he_entries(sourcedir: Path) -> list[CTEntry]:
@@ -674,45 +534,31 @@ def set_autoreverse_flags(entries: list[CTEntry]) -> list[CTEntry]:
     ]
 
 
-def write_chargetransfer_files(entries: list[CTEntry], outdir: Path) -> None:
-    """Write the fits file and the estimates file in the format that chargetransfer.cc of ARTIS reads."""
-    fitted = [e for e in entries if not e.comment.startswith("Estimate")]
-    estimates = [e for e in entries if e.comment.startswith("Estimate")]
-    # the estimates file carries no coefficients, so its header must state the values of the entries
-    assert all((e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax) == ESTIMATE_COEFFS for e in estimates)
-
+def write_chargetransfer_file(entries: list[CTEntry], outdir: Path) -> None:
+    """Write the assembled entries in the format that chargetransfer.cc of ARTIS reads."""
     # each comment starts with the tag of its source, so the header counts come from the entries
-    source_counts = Counter(e.comment.split(";", 1)[0] for e in fitted)
-    fitspath = outdir / "chargetransfer.txt"
-    with fitspath.open("w", encoding="utf-8") as fout:
-        fout.write(format_fits_header(source_counts))
-        fout.write(f"{len(fitted)}\n")
-        fout.write(f"#{ION_COLUMNS} {FIT_COLUMNS} autoreverse\n")
-        for e in fitted:
+    source_counts = Counter(e.comment.split(";", 1)[0] for e in entries)
+    outpath = outdir / "chargetransfer.txt"
+    with outpath.open("w", encoding="utf-8") as fout:
+        fout.write(format_header(source_counts))
+        fout.write(f"{len(entries)}\n")
+        fout.write(f"#{COLUMN_NAMES}\n")
+        for e in entries:
             cols = (e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don)
             coeffs = (e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax)
             fout.write(
                 " ".join([*(str(x) for x in cols), *(fnum(x) for x in coeffs), str(e.autoreverse)])
                 + f" # {e.comment}\n"
             )
-    print(f"wrote {len(fitted)} fitted reactions to {fitspath}")
-
-    estimatespath = outdir / "chargetransfer_estimates.txt"
-    with estimatespath.open("w", encoding="utf-8") as fout:
-        fout.write(format_estimates_header(len(estimates)))
-        fout.write(f"{len(estimates)}\n")
-        fout.write(f"#{ION_COLUMNS} autoreverse\n")
-        for e in estimates:
-            fout.write(f"{e.z_acc} {e.ionstage_acc} {e.z_don} {e.ionstage_don} {e.autoreverse}\n")
-    print(f"wrote {len(estimates)} estimates to {estimatespath}")
+    print(f"wrote {len(entries)} reactions to {outpath}")
 
 
 def main() -> None:
-    """Read the sources of the charge transfer rates and write the two files for ARTIS."""
+    """Read the sources of the charge transfer rates and write chargetransfer.txt for ARTIS."""
     parser = argparse.ArgumentParser(description=__doc__)
     defaultoutdir = Path(__file__).parent.parent.absolute() / "artis_files" / "data"
     defaultsourcedir = Path(__file__).parent.parent.absolute() / "atomic-data-chargetransfer"
-    parser.add_argument("-output_folder", default=defaultoutdir, type=Path, help="folder of the output files")
+    parser.add_argument("-output_folder", default=defaultoutdir, type=Path, help="folder of the output file")
     parser.add_argument(
         "-sourcedir",
         default=defaultsourcedir,
@@ -727,11 +573,6 @@ def main() -> None:
     he_entries = get_he_entries(args.sourcedir)
     print("n-capture elements with hydrogen (SS11):")
     ss11_entries, ss11_report = get_ss11_entries(args.sourcedir)
-    print("Near-resonant estimates (heavy ion with neutral heavy atom, and any element with hydrogen):")
-    published_entries = kf96_entries + he_entries + ss11_entries
-    covered = {(e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don) for e in published_entries}
-    metal_entries = get_estimate_entries(covered)
-    print(f"  {len(metal_entries)} reactions with an energy defect in (0, {METAL_METAL_MAX_DEFECT_EV}] eV")
 
     print("\nCloudy rows that differ from the KF96 paper tables:")
     for line in kf96_report:
@@ -742,8 +583,8 @@ def main() -> None:
     print()
 
     args.output_folder.mkdir(parents=True, exist_ok=True)
-    entries = set_autoreverse_flags(published_entries + metal_entries)
-    write_chargetransfer_files(entries, args.output_folder)
+    entries = set_autoreverse_flags(kf96_entries + he_entries + ss11_entries)
+    write_chargetransfer_file(entries, args.output_folder)
 
 
 if __name__ == "__main__":

--- a/artisatomic/makechargetransferfile.py
+++ b/artisatomic/makechargetransferfile.py
@@ -215,8 +215,12 @@ ESTIMATE_ZMAX = 103
 METAL_METAL_TMIN = 1000
 METAL_METAL_TMAX = 40000
 
-# the columns of a reaction line, in their order
-COLUMN_NAMES = "Z_acc ionstage_acc Z_don ionstage_don a b c d eexp tmin tmax autoreverse"
+# The columns of the output file. The first table holds the reactions with their own fit. The
+# second table holds the estimates, which share one set of coefficients. That set appears once,
+# above the table, so each estimate line holds the ion columns and the autoreverse flag only.
+ION_COLUMNS = "Z_acc ionstage_acc Z_don ionstage_don"
+COEFF_COLUMNS = "a b c d eexp tmin tmax"
+ESTIMATE_COEFFS = (METAL_METAL_RATE, 0.0, 0.0, 0.0, 0.0, METAL_METAL_TMIN, METAL_METAL_TMAX)
 
 # the n-capture elements that SS11 cover
 SS11_ZNUM = {elsymbol: elsymbols.index(elsymbol) for elsymbol in ("Ge", "Se", "Br", "Kr", "Rb", "Xe")}
@@ -229,8 +233,15 @@ def format_header(source_counts: Counter[str]) -> str:
         "The artisatomic script makechargetransferfile generates this file. Do not edit it by hand.",
         "",
         "FORMAT",
-        "The first non-comment line gives the number of reactions. Each reaction line holds 12 columns",
-        "that one or more spaces separate. The comment line above the first reaction names the columns.",
+        "The file holds two tables. One or more spaces separate the columns of a line, and a comment line",
+        "above each table names its columns. The first table starts with the number of its reactions, and",
+        "each of its lines holds a reaction with its own fit:",
+        f"  {ION_COLUMNS} {COEFF_COLUMNS} autoreverse",
+        "The second table holds the estimates, which all share one set of coefficients. It starts with",
+        "the number of its reactions, then one line with the shared coefficients:",
+        f"  {COEFF_COLUMNS}",
+        "and then one line for each reaction:",
+        f"  {ION_COLUMNS} autoreverse",
         "The acceptor ion (Z_acc, ionstage_acc) captures an electron from the donor ion (Z_don, ionstage_don).",
         "The rate coefficient is k = a * 1e-9 * t4^b * (1 + c * exp(d * t4)) * exp(-eexp/T) [cm3/s].",
         "t4 is T/1e4 K with T clamped into [tmin, tmax]; the factor exp(-eexp/T) uses the true T, and eexp is in K.",
@@ -644,18 +655,28 @@ def write_chargetransfer_file(entries: list[CTEntry], outpath: Path) -> None:
     """Write the assembled entries in the format that chargetransfer.cc of ARTIS reads."""
     # each comment starts with the tag of its source, so the header counts come from the entries
     source_counts = Counter(e.comment.split(";", 1)[0] for e in entries)
+    fitted = [e for e in entries if not e.comment.startswith("Estimate")]
+    estimates = [e for e in entries if e.comment.startswith("Estimate")]
+    # the reader applies one set of coefficients to the whole second table
+    assert all((e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax) == ESTIMATE_COEFFS for e in estimates)
     with outpath.open("w", encoding="utf-8") as fout:
         fout.write(format_header(source_counts))
-        fout.write(f"{len(entries)}\n")
-        fout.write(f"#{COLUMN_NAMES}\n")
-        for e in entries:
+        fout.write(f"{len(fitted)}\n")
+        fout.write(f"#{ION_COLUMNS} {COEFF_COLUMNS} autoreverse\n")
+        for e in fitted:
             cols = (e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don)
             coeffs = (e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax)
             fout.write(
                 " ".join([*(str(x) for x in cols), *(fnum(x) for x in coeffs), str(e.autoreverse)])
                 + f" # {e.comment}\n"
             )
-    print(f"wrote {len(entries)} reactions to {outpath}")
+        fout.write(f"{len(estimates)}\n")
+        fout.write(f"#{COEFF_COLUMNS}\n")
+        fout.write(" ".join(fnum(x) for x in ESTIMATE_COEFFS) + "\n")
+        fout.write(f"#{ION_COLUMNS} autoreverse\n")
+        for e in estimates:
+            fout.write(f"{e.z_acc} {e.ionstage_acc} {e.z_don} {e.ionstage_don} {e.autoreverse}\n")
+    print(f"wrote {len(fitted)} fitted reactions and {len(estimates)} estimates to {outpath}")
 
 
 def main() -> None:

--- a/artisatomic/makechargetransferfile.py
+++ b/artisatomic/makechargetransferfile.py
@@ -215,9 +215,6 @@ ESTIMATE_ZMAX = 103
 METAL_METAL_TMIN = 1000
 METAL_METAL_TMAX = 40000
 
-# The columns of the output file. The first table holds the reactions with their own fit. The
-# second table holds the estimates, which share one set of coefficients. That set appears once,
-# above the table, so each estimate line holds the ion columns and the autoreverse flag only.
 ION_COLUMNS = "Z_acc ionstage_acc Z_don ionstage_don"
 COEFF_COLUMNS = "a b c d eexp tmin tmax"
 ESTIMATE_COEFFS = (METAL_METAL_RATE, 0.0, 0.0, 0.0, 0.0, METAL_METAL_TMIN, METAL_METAL_TMAX)
@@ -250,7 +247,7 @@ def format_header(source_counts: Counter[str]) -> str:
         "reaction releases energy. It is 0 when this file holds a fit for the reverse reaction.",
         "A comment follows the columns. It starts with the tag of the source, then gives the values that",
         "are specific to the reaction. The four Z and ionstage columns identify the reaction, so the",
-        "comment does not repeat it, and SOURCES below gives the text that all lines of a source share.",
+        "comment does not repeat it. SOURCES below gives the text that all lines of a source share.",
         "",
         "SOURCES",
         f"Cloudy ({source_counts['Cloudy']} reactions): reactions with hydrogen, from the Cloudy data files",

--- a/artisatomic/makechargetransferfile.py
+++ b/artisatomic/makechargetransferfile.py
@@ -215,9 +215,8 @@ ESTIMATE_ZMAX = 103
 METAL_METAL_TMIN = 1000
 METAL_METAL_TMAX = 40000
 
-ION_COLUMNS = "Z_acc ionstage_acc Z_don ionstage_don"
-COEFF_COLUMNS = "a b c d eexp tmin tmax"
-ESTIMATE_COEFFS = (METAL_METAL_RATE, 0.0, 0.0, 0.0, 0.0, METAL_METAL_TMIN, METAL_METAL_TMAX)
+# the columns of a reaction line, in their order
+COLUMN_NAMES = "Z_acc ionstage_acc Z_don ionstage_don a b c d eexp tmin tmax autoreverse"
 
 # the n-capture elements that SS11 cover
 SS11_ZNUM = {elsymbol: elsymbols.index(elsymbol) for elsymbol in ("Ge", "Se", "Br", "Kr", "Rb", "Xe")}
@@ -230,15 +229,8 @@ def format_header(source_counts: Counter[str]) -> str:
         "The artisatomic script makechargetransferfile generates this file. Do not edit it by hand.",
         "",
         "FORMAT",
-        "The file holds two tables. One or more spaces separate the columns of a line, and a comment line",
-        "above each table names its columns. The first table starts with the number of its reactions, and",
-        "each of its lines holds a reaction with its own fit:",
-        f"  {ION_COLUMNS} {COEFF_COLUMNS} autoreverse",
-        "The second table holds the estimates, which all share one set of coefficients. It starts with",
-        "the number of its reactions, then one line with the shared coefficients:",
-        f"  {COEFF_COLUMNS}",
-        "and then one line for each reaction:",
-        f"  {ION_COLUMNS} autoreverse",
+        "The first non-comment line gives the number of reactions. Each reaction line holds 12 columns",
+        "that one or more spaces separate. The comment line above the first reaction names the columns.",
         "The acceptor ion (Z_acc, ionstage_acc) captures an electron from the donor ion (Z_don, ionstage_don).",
         "The rate coefficient is k = a * 1e-9 * t4^b * (1 + c * exp(d * t4)) * exp(-eexp/T) [cm3/s].",
         "t4 is T/1e4 K with T clamped into [tmin, tmax]; the factor exp(-eexp/T) uses the true T, and eexp is in K.",
@@ -652,28 +644,18 @@ def write_chargetransfer_file(entries: list[CTEntry], outpath: Path) -> None:
     """Write the assembled entries in the format that chargetransfer.cc of ARTIS reads."""
     # each comment starts with the tag of its source, so the header counts come from the entries
     source_counts = Counter(e.comment.split(";", 1)[0] for e in entries)
-    fitted = [e for e in entries if not e.comment.startswith("Estimate")]
-    estimates = [e for e in entries if e.comment.startswith("Estimate")]
-    # the reader applies one set of coefficients to the whole second table
-    assert all((e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax) == ESTIMATE_COEFFS for e in estimates)
     with outpath.open("w", encoding="utf-8") as fout:
         fout.write(format_header(source_counts))
-        fout.write(f"{len(fitted)}\n")
-        fout.write(f"#{ION_COLUMNS} {COEFF_COLUMNS} autoreverse\n")
-        for e in fitted:
+        fout.write(f"{len(entries)}\n")
+        fout.write(f"#{COLUMN_NAMES}\n")
+        for e in entries:
             cols = (e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don)
             coeffs = (e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax)
             fout.write(
                 " ".join([*(str(x) for x in cols), *(fnum(x) for x in coeffs), str(e.autoreverse)])
                 + f" # {e.comment}\n"
             )
-        fout.write(f"{len(estimates)}\n")
-        fout.write(f"#{COEFF_COLUMNS}\n")
-        fout.write(" ".join(fnum(x) for x in ESTIMATE_COEFFS) + "\n")
-        fout.write(f"#{ION_COLUMNS} autoreverse\n")
-        for e in estimates:
-            fout.write(f"{e.z_acc} {e.ionstage_acc} {e.z_don} {e.ionstage_don} {e.autoreverse}\n")
-    print(f"wrote {len(fitted)} fitted reactions and {len(estimates)} estimates to {outpath}")
+    print(f"wrote {len(entries)} reactions to {outpath}")
 
 
 def main() -> None:

--- a/artisatomic/makechargetransferfile.py
+++ b/artisatomic/makechargetransferfile.py
@@ -226,7 +226,8 @@ def format_header(source_counts: Counter[str]) -> str:
         "The artisatomic script makechargetransferfile generates this file. Do not edit it by hand.",
         "",
         "FORMAT",
-        "The first non-comment line gives the number of reactions. Each reaction line has the columns:",
+        "The first non-comment line gives the number of reactions. Each reaction line holds 12 columns",
+        "that one or more spaces separate:",
         "  Z_acc ionstage_acc Z_don ionstage_don a b c d eexp tmin tmax autoreverse",
         "The acceptor ion (Z_acc, ionstage_acc) captures an electron from the donor ion (Z_don, ionstage_don).",
         "The rate coefficient is k = a * 1e-9 * t4^b * (1 + c * exp(d * t4)) * exp(-eexp/T) [cm3/s].",
@@ -234,7 +235,9 @@ def format_header(source_counts: Counter[str]) -> str:
         "For a flat entry (b = c = eexp = 0) the clamp has no effect.",
         "autoreverse 1 lets the code add the reverse reaction from detailed balance when the forward",
         "reaction releases energy. It is 0 when this file holds a fit for the reverse reaction.",
-        "The comment of each line starts with the tag of its source, then names the reaction.",
+        "A comment follows the columns. It starts with the tag of the source, then gives the values that",
+        "are specific to the reaction. The four Z and ionstage columns identify the reaction, so the",
+        "comment does not repeat it, and SOURCES below gives the text that all lines of a source share.",
         "",
         "SOURCES",
         f"Cloudy ({source_counts['Cloudy']} reactions): reactions with hydrogen, from the Cloudy data files",
@@ -255,8 +258,8 @@ def format_header(source_counts: Counter[str]) -> str:
         "  which consist mostly of heavy elements, and any ion with a hydrogen atom or a proton with any neutral",
         "  atom. No publication gives these rates. Each exothermic reaction with a small energy defect, which no",
         "  other source of this file covers, gets the near-resonant rate of Melius (1974), J. Phys. B, 7, 1692.",
-        "  The energy defect comes from the ground-state ionization",
-        "  energies of the NIST table that artisatomic ships (nist_ionization.txt.zst):",
+        "  The comment of a line gives the energy defect only. The defect comes from the ground-state",
+        "  ionization energies of the NIST table that artisatomic ships (nist_ionization.txt.zst):",
         *[f"    {line}" for line in get_nist_ionization_provenance()],
         f"  With a neutral heavy atom, the elements are {elsymbols[METAL_METAL_ZMIN]} to {elsymbols[ESTIMATE_ZMAX]} (Z = {METAL_METAL_ZMIN} to {ESTIMATE_ZMAX}). With hydrogen,",
         f"  the elements are He to {elsymbols[ESTIMATE_ZMAX]}.",
@@ -356,11 +359,6 @@ def read_cloudy_table(text: str, ncols: int) -> dict[tuple[int, int], list[float
     return rows
 
 
-def ionlabel(z: int, q: int) -> str:
-    """Return a label like Fe+2 or Fe0 for an element with the given charge."""
-    return f"{elsymbols[z]}{'+' + str(q) if q > 0 else '0'}"
-
-
 def get_kf96_h_entries(sourcedir: Path) -> tuple[list[CTEntry], list[str]]:
     """Build the entries for the reactions with hydrogen from the Cloudy data files.
 
@@ -380,7 +378,6 @@ def get_kf96_h_entries(sourcedir: Path) -> tuple[list[CTEntry], list[str]]:
             paper_deltae = KF96_ENDOTHERMIC.get((z, q), "unknown")
             report.append(f"rec Z={z} q={q}: endothermic, no fit (KF96 Table 4, deltaE={paper_deltae} eV); not written")
             continue
-        label = f"{ionlabel(z, q)} + H0 -> {ionlabel(z, q - 1)} + H+"
         kf = KF96_REC.get((z, q))
         if kf is None:
             note = "no KF96 entry"
@@ -391,7 +388,7 @@ def get_kf96_h_entries(sourcedir: Path) -> tuple[list[CTEntry], list[str]]:
             note = f"Cloudy update; KF96 published {kf96_published_text(kf)}"
             report.append(f"rec Z={z} q={q}: {note}")
         # the energy column of Cloudy is the defect of the dominant channel, with the sign of the file
-        comment = f"Cloudy; {label}; Cloudy deltaE={fnum(deltae_ev)} eV; {note}"
+        comment = f"Cloudy; Cloudy deltaE={fnum(deltae_ev)} eV; {note}"
         entries.append(CTEntry(z, q + 1, 1, 1, a, b, c, d, 0.0, tmin, tmax, comment))
 
     for (z, q1), vals in sorted(ion.items()):
@@ -399,7 +396,6 @@ def get_kf96_h_entries(sourcedir: Path) -> tuple[list[CTEntry], list[str]]:
         if a == 0.0:
             continue
         q = q1 - 1  # the charge before the ion loses the electron
-        label = f"{ionlabel(z, q)} + H+ -> {ionlabel(z, q + 1)} + H0"
         kf_ion = KF96_ION.get((z, q))
         if kf_ion is None:
             note = "no KF96 entry (Cloudy addition)"
@@ -409,7 +405,7 @@ def get_kf96_h_entries(sourcedir: Path) -> tuple[list[CTEntry], list[str]]:
         else:
             note = f"Cloudy update; KF96 published {kf96_published_text(kf_ion[:4])} dE/k={fnum(kf_ion[4])}(1e4 K)"
             report.append(f"ion Z={z} q={q}: {note}")
-        comment = f"Cloudy; {label}; energy deficit={fnum(deficit_ev)} eV; {note}"
+        comment = f"Cloudy; energy deficit={fnum(deficit_ev)} eV; {note}"
         entries.append(CTEntry(1, 2, z, q + 1, a, b, c, d, de4 * 1e4, tmin, tmax, comment))
 
     return entries, report
@@ -443,8 +439,7 @@ def get_estimate_entries(covered: AbstractSet[tuple[int, int, int, int]] = froze
         """Add the capture by (z_acc, charge_acc) from the neutral atom z_don when the defect is small."""
         if (z_acc, charge_acc + 1, z_don, 1) in covered or not 0.0 < deltae_ev <= METAL_METAL_MAX_DEFECT_EV:
             return
-        label = f"{ionlabel(z_acc, charge_acc)} + {ionlabel(z_don, 0)} -> {ionlabel(z_acc, charge_acc - 1)} + {ionlabel(z_don, 1)}"
-        comment = f"Estimate; {label}; deltaE={fnum(deltae_ev)} eV; near-resonant rate, NIST ASD energies"
+        comment = f"Estimate; deltaE={deltae_ev:.3g} eV"
         entries.append(
             CTEntry(
                 z_acc,
@@ -496,9 +491,8 @@ def get_he_entries(sourcedir: Path) -> list[CTEntry]:
         z, nelectrons = int(parts[0]), int(parts[1])
         a, b, c, d, tmin, tmax = (float(x) for x in parts[2:8])
         q = z - nelectrons + 1  # the file lists the electron count of the product ion
-        label = f"{ionlabel(z, q)} + He0 -> {ionlabel(z, q - 1)} + He+"
         note = CLOUDY_HE_NOTES.get((z, q), "")
-        comment = f"AR85; {label}" + (f"; {note}" if note else "")
+        comment = "AR85" + (f"; {note}" if note else "")
         entries.append(CTEntry(z, q + 1, 2, 1, a, b, c, d, 0.0, tmin, tmax, comment))
     return entries
 
@@ -603,11 +597,6 @@ def get_ss11_entries(sourcedir: Path) -> tuple[list[CTEntry], list[str]]:
                 f"{direction} {elsymbol} q={q}: a={fit.a:.3e} b={fit.b:.3f} eexp={fit.eexp:.0f}"
                 f" maxerr={fit.maxerr * 100:.0f}% npts={fit.npts}{warning}"
             )
-            label = (
-                f"{ionlabel(z, q)} + H0 -> {ionlabel(z, q - 1)} + H+"
-                if is_recombination
-                else f"{ionlabel(z, q)} + H+ -> {ionlabel(z, q + 1)} + H0"
-            )
             window = f"{fnum(SS11_FIT_TMIN)}-{fnum(SS11_FIT_TMAX)} K"
             if fit.npts >= SS11_MIN_POINTS:
                 source = (
@@ -621,7 +610,7 @@ def get_ss11_entries(sourcedir: Path) -> tuple[list[CTEntry], list[str]]:
                 )
             else:
                 source = f"flat value from their {fnum(SS11_FLAT_TEMP)} K entry (no usable fit points over {window})"
-            comment = f"SS11; {label}; {source}"
+            comment = f"SS11; {source}"
             reaction = (z, q + 1, 1, 1) if is_recombination else (1, 2, z, q + 1)
             entries.append(CTEntry(*reaction, fit.a / 1e-9, fit.b, 0.0, 0.0, fit.eexp, fit.tmin, fit.tmax, comment))
     return entries, report
@@ -657,10 +646,11 @@ def write_chargetransfer_file(entries: list[CTEntry], outpath: Path) -> None:
         fout.write(format_header(source_counts))
         fout.write(f"{len(entries)}\n")
         for e in entries:
+            cols = (e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don)
+            coeffs = (e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax)
             fout.write(
-                f"{e.z_acc:3d} {e.ionstage_acc:2d} {e.z_don:3d} {e.ionstage_don:2d} {e.a:12.6g} {e.b:10.6g}"
-                f" {e.c:10.6g} {e.d:10.6g} {e.eexp:9.6g} {e.tmin:8.6g} {e.tmax:8.6g} {e.autoreverse}"
-                f" # {e.comment}\n"
+                " ".join([*(str(x) for x in cols), *(fnum(x) for x in coeffs), str(e.autoreverse)])
+                + f" # {e.comment}\n"
             )
     print(f"wrote {len(entries)} reactions to {outpath}")
 

--- a/artisatomic/makechargetransferfile.py
+++ b/artisatomic/makechargetransferfile.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""Write the file of charge transfer rates for ARTIS (data/chargetransfer.txt in the artis repository).
+"""Write the charge transfer rate files for ARTIS: data/chargetransfer.txt and data/chargetransfer_estimates.txt.
 
 The script reads the published fits and rate tables from the folder atomic-data-chargetransfer.
-It converts them into one fit form and writes one reaction for each line. The script
+It converts them into one fit form and writes one reaction for each line. The published fits go
+into chargetransfer.txt. The estimates go into chargetransfer_estimates.txt, which holds the ion
+columns only, because ARTIS applies one rate to all of them. The script
 setup_chargetransfer_data.sh in that folder downloads the tables. The sources are:
 
 - The Cloudy master data files ctrecombdata.dat and ctiondata.dat (gitlab.nublado.org). They carry
@@ -215,18 +217,26 @@ ESTIMATE_ZMAX = 103
 METAL_METAL_TMIN = 1000
 METAL_METAL_TMAX = 40000
 
-# the columns of a reaction line, in their order
-COLUMN_NAMES = "Z_acc ionstage_acc Z_don ionstage_don a b c d eexp tmin tmax autoreverse"
+ION_COLUMNS = "Z_acc ionstage_acc Z_don ionstage_don"
+FIT_COLUMNS = "a b c d eexp tmin tmax"
+# ARTIS holds these values for every estimate, so the estimates file does not carry them
+ESTIMATE_COEFFS = (METAL_METAL_RATE, 0.0, 0.0, 0.0, 0.0, METAL_METAL_TMIN, METAL_METAL_TMAX)
 
 # the n-capture elements that SS11 cover
 SS11_ZNUM = {elsymbol: elsymbols.index(elsymbol) for elsymbol in ("Ge", "Se", "Br", "Kr", "Rb", "Xe")}
 
 
-def format_header(source_counts: Counter[str]) -> str:
-    """Build the comment block of the output file: the format, the sources, and the parameters."""
+def comment_block(lines: list[str]) -> str:
+    """Return the lines as a block of comments of the output file."""
+    return "".join(f"# {line}".rstrip() + "\n" for line in lines)
+
+
+def format_fits_header(source_counts: Counter[str]) -> str:
+    """Build the comment block of the fits file: the format, the sources, and the parameters."""
     lines = [
         "Fits of the rate coefficients for charge transfer, for the chargetransfer.cc module of ARTIS.",
         "The artisatomic script makechargetransferfile generates this file. Do not edit it by hand.",
+        "The file chargetransfer_estimates.txt holds the near-resonant estimates for the other reactions.",
         "",
         "FORMAT",
         "The first non-comment line gives the number of reactions. Each reaction line holds 12 columns",
@@ -236,7 +246,7 @@ def format_header(source_counts: Counter[str]) -> str:
         "t4 is T/1e4 K with T clamped into [tmin, tmax]; the factor exp(-eexp/T) uses the true T, and eexp is in K.",
         "For a flat entry (b = c = eexp = 0) the clamp has no effect.",
         "autoreverse 1 lets the code add the reverse reaction from detailed balance when the forward",
-        "reaction releases energy. It is 0 when this file holds a fit for the reverse reaction.",
+        "reaction releases energy. It is 0 when one of the two files holds the reverse reaction.",
         "A comment follows the columns. It starts with the tag of the source, then gives the values that",
         "are specific to the reaction. The four Z and ionstage columns identify the reaction, so the",
         "comment does not repeat it. SOURCES below gives the text that all lines of a source share.",
@@ -256,15 +266,6 @@ def format_header(source_counts: Counter[str]) -> str:
         "  https://cdsarc.cds.unistra.fr/ftp/J/A+A/535/A117/table5.dat",
         "  SS11 publish tabulated k(T) values and no fit coefficients. This script fits their tables, see",
         "  PARAMETERS. The tables resolve the final state; the fit uses the sum over the final states.",
-        f"Estimate ({source_counts['Estimate']} reactions): a heavy ion with a neutral heavy atom, for the kilonova ejecta,",
-        "  which consist mostly of heavy elements, and any ion with a hydrogen atom or a proton with any neutral",
-        "  atom. No publication gives these rates. Each exothermic reaction with a small energy defect, which no",
-        "  other source of this file covers, gets the near-resonant rate of Melius (1974), J. Phys. B, 7, 1692.",
-        "  The energy defect comes from the ground-state ionization energies of the NIST table that",
-        "  artisatomic ships (nist_ionization.txt.zst):",
-        *[f"    {line}" for line in get_nist_ionization_provenance()],
-        f"  With a neutral heavy atom, the elements are {elsymbols[METAL_METAL_ZMIN]} to {elsymbols[ESTIMATE_ZMAX]} (Z = {METAL_METAL_ZMIN} to {ESTIMATE_ZMAX}). With hydrogen,",
-        f"  the elements are He to {elsymbols[ESTIMATE_ZMAX]}.",
         "",
         "PARAMETERS",
         "SS11 fits: ln k = ln a + b ln t4 - eexp/T, so c = d = 0. A fit uses the tabulated totals between",
@@ -274,15 +275,48 @@ def format_header(source_counts: Counter[str]) -> str:
         f"  {SS11_FLAT_TEMP} K. The comment of each line gives the largest relative error of the fit or the flat value",
         "  over the usable points. eexp of an SS11 entry is a fit coefficient and not a measured energy.",
         "  Below tmin, an entry with eexp > 0 keeps falling and an entry with eexp = 0 holds its value at tmin.",
+        "autoreverse: set from the reactions of this file and of chargetransfer_estimates.txt together.",
+    ]
+    return comment_block(lines)
+
+
+def format_estimates_header(nestimates: int) -> str:
+    """Build the comment block of the estimates file: the format, the source, and the parameters."""
+    lines = [
+        "Near-resonant estimates of the rate coefficients for charge transfer, for chargetransfer.cc of ARTIS.",
+        "The artisatomic script makechargetransferfile generates this file. Do not edit it by hand.",
+        "The file chargetransfer.txt holds the published fits.",
+        "",
+        "FORMAT",
+        "The first non-comment line gives the number of reactions. Each reaction line holds 5 columns",
+        "that one or more spaces separate. The comment line above the first reaction names the columns.",
+        "The acceptor ion (Z_acc, ionstage_acc) captures an electron from the donor ion (Z_don, ionstage_don).",
+        "This file holds no rate. ARTIS applies the same rate to every reaction of this file:",
+        f"{METAL_METAL_RATE:g}e-9 cm3/s, flat in T. See PARAMETERS.",
+        "autoreverse 1 lets the code add the reverse reaction from detailed balance when the forward",
+        "reaction releases energy. It is 0 when chargetransfer.txt holds a fit for the reverse reaction.",
+        "",
+        "SOURCES",
+        f"Estimate ({nestimates} reactions): a heavy ion with a neutral heavy atom, for the kilonova ejecta,",
+        "  which consist mostly of heavy elements, and any ion with a hydrogen atom or a proton with any neutral",
+        "  atom. No publication gives these rates. Each exothermic reaction with a small energy defect, which",
+        "  chargetransfer.txt does not cover, gets the near-resonant rate of Melius (1974), J. Phys. B, 7, 1692.",
+        "  The energy defect comes from the ground-state ionization energies of the NIST table that",
+        "  artisatomic ships (nist_ionization.txt.zst):",
+        *[f"    {line}" for line in get_nist_ionization_provenance()],
+        f"  With a neutral heavy atom, the elements are {elsymbols[METAL_METAL_ZMIN]} to {elsymbols[ESTIMATE_ZMAX]} (Z = {METAL_METAL_ZMIN} to {ESTIMATE_ZMAX}). With hydrogen,",
+        f"  the elements are He to {elsymbols[ESTIMATE_ZMAX]}.",
+        "",
+        "PARAMETERS",
         f"Estimates: rate {METAL_METAL_RATE:g}e-9 cm3/s, flat in T, for an exothermic reaction with an energy defect",
         f"  in (0, {METAL_METAL_MAX_DEFECT_EV:g}] eV. The acceptor charge is one of {METAL_METAL_ACCEPTOR_CHARGES}, or 1 for a proton. The",
         "  donor is always neutral, because the Coulomb repulsion between two positive ions makes their reactions",
         "  slow. The estimate assumes that a level of the products lies near the energy defect; it does not",
-        f"  check the level lists. tmin and tmax are {METAL_METAL_TMIN}-{METAL_METAL_TMAX} K, the range of use.",
-        "  ARTIS makes a Landau-Zener estimate for every reaction that this file does not hold.",
-        "autoreverse: set from the full list of reactions in this file, not from one source alone.",
+        f"  check the level lists. The range of use is {METAL_METAL_TMIN}-{METAL_METAL_TMAX} K.",
+        "  ARTIS makes a Landau-Zener estimate for every reaction that neither file holds.",
+        "autoreverse: set from the reactions of this file and of chargetransfer.txt together.",
     ]
-    return "".join(f"# {line}".rstrip() + "\n" for line in lines)
+    return comment_block(lines)
 
 
 class CTEntry(t.NamedTuple):
@@ -640,30 +674,45 @@ def set_autoreverse_flags(entries: list[CTEntry]) -> list[CTEntry]:
     ]
 
 
-def write_chargetransfer_file(entries: list[CTEntry], outpath: Path) -> None:
-    """Write the assembled entries in the format that chargetransfer.cc of ARTIS reads."""
+def write_chargetransfer_files(entries: list[CTEntry], outdir: Path) -> None:
+    """Write the fits file and the estimates file in the format that chargetransfer.cc of ARTIS reads."""
+    fitted = [e for e in entries if not e.comment.startswith("Estimate")]
+    estimates = [e for e in entries if e.comment.startswith("Estimate")]
+    # the estimates file carries no coefficients, so its header must state the values of the entries
+    assert all((e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax) == ESTIMATE_COEFFS for e in estimates)
+
     # each comment starts with the tag of its source, so the header counts come from the entries
-    source_counts = Counter(e.comment.split(";", 1)[0] for e in entries)
-    with outpath.open("w", encoding="utf-8") as fout:
-        fout.write(format_header(source_counts))
-        fout.write(f"{len(entries)}\n")
-        fout.write(f"#{COLUMN_NAMES}\n")
-        for e in entries:
+    source_counts = Counter(e.comment.split(";", 1)[0] for e in fitted)
+    fitspath = outdir / "chargetransfer.txt"
+    with fitspath.open("w", encoding="utf-8") as fout:
+        fout.write(format_fits_header(source_counts))
+        fout.write(f"{len(fitted)}\n")
+        fout.write(f"#{ION_COLUMNS} {FIT_COLUMNS} autoreverse\n")
+        for e in fitted:
             cols = (e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don)
             coeffs = (e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax)
             fout.write(
                 " ".join([*(str(x) for x in cols), *(fnum(x) for x in coeffs), str(e.autoreverse)])
                 + f" # {e.comment}\n"
             )
-    print(f"wrote {len(entries)} reactions to {outpath}")
+    print(f"wrote {len(fitted)} fitted reactions to {fitspath}")
+
+    estimatespath = outdir / "chargetransfer_estimates.txt"
+    with estimatespath.open("w", encoding="utf-8") as fout:
+        fout.write(format_estimates_header(len(estimates)))
+        fout.write(f"{len(estimates)}\n")
+        fout.write(f"#{ION_COLUMNS} autoreverse\n")
+        for e in estimates:
+            fout.write(f"{e.z_acc} {e.ionstage_acc} {e.z_don} {e.ionstage_don} {e.autoreverse}\n")
+    print(f"wrote {len(estimates)} estimates to {estimatespath}")
 
 
 def main() -> None:
-    """Read the sources of the charge transfer rates and write chargetransfer.txt for ARTIS."""
+    """Read the sources of the charge transfer rates and write the two files for ARTIS."""
     parser = argparse.ArgumentParser(description=__doc__)
-    defaultoutpath = Path(__file__).parent.parent.absolute() / "artis_files" / "data" / "chargetransfer.txt"
+    defaultoutdir = Path(__file__).parent.parent.absolute() / "artis_files" / "data"
     defaultsourcedir = Path(__file__).parent.parent.absolute() / "atomic-data-chargetransfer"
-    parser.add_argument("-outputfile", default=defaultoutpath, type=Path, help="path of the output file")
+    parser.add_argument("-output_folder", default=defaultoutdir, type=Path, help="folder of the output files")
     parser.add_argument(
         "-sourcedir",
         default=defaultsourcedir,
@@ -692,9 +741,9 @@ def main() -> None:
         print(f"  {line}")
     print()
 
-    args.outputfile.parent.mkdir(parents=True, exist_ok=True)
+    args.output_folder.mkdir(parents=True, exist_ok=True)
     entries = set_autoreverse_flags(published_entries + metal_entries)
-    write_chargetransfer_file(entries, args.outputfile)
+    write_chargetransfer_files(entries, args.output_folder)
 
 
 if __name__ == "__main__":

--- a/artisatomic/makechargetransferfile.py
+++ b/artisatomic/makechargetransferfile.py
@@ -260,8 +260,8 @@ def format_header(source_counts: Counter[str]) -> str:
         "  which consist mostly of heavy elements, and any ion with a hydrogen atom or a proton with any neutral",
         "  atom. No publication gives these rates. Each exothermic reaction with a small energy defect, which no",
         "  other source of this file covers, gets the near-resonant rate of Melius (1974), J. Phys. B, 7, 1692.",
-        "  The comment of a line gives the energy defect only. The defect comes from the ground-state",
-        "  ionization energies of the NIST table that artisatomic ships (nist_ionization.txt.zst):",
+        "  The energy defect comes from the ground-state ionization energies of the NIST table that",
+        "  artisatomic ships (nist_ionization.txt.zst):",
         *[f"    {line}" for line in get_nist_ionization_provenance()],
         f"  With a neutral heavy atom, the elements are {elsymbols[METAL_METAL_ZMIN]} to {elsymbols[ESTIMATE_ZMAX]} (Z = {METAL_METAL_ZMIN} to {ESTIMATE_ZMAX}). With hydrogen,",
         f"  the elements are He to {elsymbols[ESTIMATE_ZMAX]}.",
@@ -441,7 +441,7 @@ def get_estimate_entries(covered: AbstractSet[tuple[int, int, int, int]] = froze
         """Add the capture by (z_acc, charge_acc) from the neutral atom z_don when the defect is small."""
         if (z_acc, charge_acc + 1, z_don, 1) in covered or not 0.0 < deltae_ev <= METAL_METAL_MAX_DEFECT_EV:
             return
-        comment = f"Estimate; deltaE={deltae_ev:.3g} eV"
+        comment = "Estimate"
         entries.append(
             CTEntry(
                 z_acc,

--- a/artisatomic/makechargetransferfile.py
+++ b/artisatomic/makechargetransferfile.py
@@ -215,6 +215,9 @@ ESTIMATE_ZMAX = 103
 METAL_METAL_TMIN = 1000
 METAL_METAL_TMAX = 40000
 
+# the columns of a reaction line, in their order
+COLUMN_NAMES = "Z_acc ionstage_acc Z_don ionstage_don a b c d eexp tmin tmax autoreverse"
+
 # the n-capture elements that SS11 cover
 SS11_ZNUM = {elsymbol: elsymbols.index(elsymbol) for elsymbol in ("Ge", "Se", "Br", "Kr", "Rb", "Xe")}
 
@@ -227,8 +230,7 @@ def format_header(source_counts: Counter[str]) -> str:
         "",
         "FORMAT",
         "The first non-comment line gives the number of reactions. Each reaction line holds 12 columns",
-        "that one or more spaces separate:",
-        "  Z_acc ionstage_acc Z_don ionstage_don a b c d eexp tmin tmax autoreverse",
+        "that one or more spaces separate. The comment line above the first reaction names the columns.",
         "The acceptor ion (Z_acc, ionstage_acc) captures an electron from the donor ion (Z_don, ionstage_don).",
         "The rate coefficient is k = a * 1e-9 * t4^b * (1 + c * exp(d * t4)) * exp(-eexp/T) [cm3/s].",
         "t4 is T/1e4 K with T clamped into [tmin, tmax]; the factor exp(-eexp/T) uses the true T, and eexp is in K.",
@@ -645,6 +647,7 @@ def write_chargetransfer_file(entries: list[CTEntry], outpath: Path) -> None:
     with outpath.open("w", encoding="utf-8") as fout:
         fout.write(format_header(source_counts))
         fout.write(f"{len(entries)}\n")
+        fout.write(f"# {COLUMN_NAMES}\n")
         for e in entries:
             cols = (e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don)
             coeffs = (e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax)

--- a/artisatomic/makechargetransferfile.py
+++ b/artisatomic/makechargetransferfile.py
@@ -187,7 +187,6 @@ SS11_USABLE_MIN = 1.2e-14  # a tabulated total above this value is a usable fit 
 SS11_MIN_POINTS = 4  # a curve with fewer usable points gets a flat value instead of a fit
 SS11_FLAT_TEMP = 20000  # the entry that supplies the flat value [K]
 
-# the columns of a reaction line, in their order
 COLUMN_NAMES = "Z_acc ionstage_acc Z_don ionstage_don a b c d eexp tmin tmax autoreverse"
 
 # the n-capture elements that SS11 cover

--- a/artisatomic/makechargetransferfile.py
+++ b/artisatomic/makechargetransferfile.py
@@ -647,7 +647,7 @@ def write_chargetransfer_file(entries: list[CTEntry], outpath: Path) -> None:
     with outpath.open("w", encoding="utf-8") as fout:
         fout.write(format_header(source_counts))
         fout.write(f"{len(entries)}\n")
-        fout.write(f"# {COLUMN_NAMES}\n")
+        fout.write(f"#{COLUMN_NAMES}\n")
         for e in entries:
             cols = (e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don)
             coeffs = (e.a, e.b, e.c, e.d, e.eexp, e.tmin, e.tmax)

--- a/artisatomic/test_chargetransfer.py
+++ b/artisatomic/test_chargetransfer.py
@@ -256,15 +256,16 @@ def test_read_source_reads_the_compressed_file(tmp_path):
 
 
 def test_chargetransfer_output_matches_the_checksum(tmp_path, monkeypatch):
-    """main() writes the file that tests/chargetransfer/checksums.txt records, byte for byte.
+    """main() writes the files that tests/chargetransfer/checksums.txt records, byte for byte.
 
-    The CI job 'test chargetransfer' checks the same file with md5sum. Regenerate the checksum
+    The CI job 'test chargetransfer' checks the same files with md5sum. Regenerate the checksums
     after a deliberate change of the output; tests/README.md gives the commands.
     """
-    outpath = tmp_path / "chargetransfer.txt"
-    monkeypatch.setattr(sys, "argv", ["makechargetransferfile", "-outputfile", str(outpath)])
+    monkeypatch.setattr(sys, "argv", ["makechargetransferfile", "-output_folder", str(tmp_path)])
     makechargetransferfile.main()
 
     checksumfile = Path(makechargetransferfile.__file__).parent.parent / "tests" / "chargetransfer" / "checksums.txt"
     expected = {name: digest for digest, name in (line.split() for line in checksumfile.read_text().splitlines())}
-    assert hashlib.md5(outpath.read_bytes(), usedforsecurity=False).hexdigest() == expected["chargetransfer.txt"]
+    assert set(expected) == {"chargetransfer.txt", "chargetransfer_estimates.txt"}
+    for name, digest in expected.items():
+        assert hashlib.md5((tmp_path / name).read_bytes(), usedforsecurity=False).hexdigest() == digest, name

--- a/artisatomic/test_chargetransfer.py
+++ b/artisatomic/test_chargetransfer.py
@@ -195,17 +195,14 @@ def test_makechargetransferfile_estimates(monkeypatch):
 
     # Fe+1 + La0 -> Fe0 + La+1 releases 7.9 - 5.58 = 2.32 eV, which is inside the window
     assert (26, 2, 57, 1) in reactions
-    assert "deltaE=2.32 eV" in reactions[26, 2, 57, 1].comment
     assert reactions[26, 2, 57, 1].a == makechargetransferfile.METAL_METAL_RATE
     # Fe+2 + Fe0 -> Fe+1 + Fe+1 releases 10.0 - 7.9 = 2.1 eV, and I+1 + Fe0 releases 2.55 eV
     assert (26, 3, 26, 1) in reactions
     assert (53, 2, 26, 1) in reactions
     # Fe+3 + H0 -> Fe+2 + H+ releases 16.2 - 13.6 = 2.6 eV
     assert (26, 4, 1, 1) in reactions
-    assert "deltaE=2.6 eV" in reactions[26, 4, 1, 1].comment
     # H+ + I0 -> H0 + I+1 releases 13.6 - 10.45 = 3.15 eV
     assert (1, 2, 53, 1) in reactions
-    assert "deltaE=3.15 eV" in reactions[1, 2, 53, 1].comment
     # the excluded reactions:
     #   La+1 + Fe0 and Fe+1 + H0 are endothermic;
     #   Fe+2 + La0 releases 4.42 eV and H+ + Fe0 releases 5.7 eV, which are above the window;

--- a/artisatomic/test_chargetransfer.py
+++ b/artisatomic/test_chargetransfer.py
@@ -175,7 +175,6 @@ def test_makechargetransferfile_ar85_helium_entries(patch_sources, tmp_path):
 
     # the product O+2 holds the six electrons of the file, so O+3 is the ion that captures one
     assert (entry.z_acc, entry.ionstage_acc, entry.z_don, entry.ionstage_don) == (8, 4, 2, 1)
-    assert "O+3 + He0 -> O+2 + He+" in entry.comment
     assert (entry.a, entry.b, entry.c, entry.d) == (1.0, 0.0, 1.25, -5.8)
     assert (entry.tmin, entry.tmax) == (1000.0, 30000.0)
     # the file holds no fit for He+ + O+2, so the code must add that reverse reaction
@@ -203,10 +202,10 @@ def test_makechargetransferfile_estimates(monkeypatch):
     assert (53, 2, 26, 1) in reactions
     # Fe+3 + H0 -> Fe+2 + H+ releases 16.2 - 13.6 = 2.6 eV
     assert (26, 4, 1, 1) in reactions
-    assert "Fe+3 + H0 -> Fe+2 + H+" in reactions[26, 4, 1, 1].comment
+    assert "deltaE=2.6 eV" in reactions[26, 4, 1, 1].comment
     # H+ + I0 -> H0 + I+1 releases 13.6 - 10.45 = 3.15 eV
     assert (1, 2, 53, 1) in reactions
-    assert "H+1 + I0 -> H0 + I+1" in reactions[1, 2, 53, 1].comment
+    assert "deltaE=3.15 eV" in reactions[1, 2, 53, 1].comment
     # the excluded reactions:
     #   La+1 + Fe0 and Fe+1 + H0 are endothermic;
     #   Fe+2 + La0 releases 4.42 eV and H+ + Fe0 releases 5.7 eV, which are above the window;

--- a/artisatomic/test_chargetransfer.py
+++ b/artisatomic/test_chargetransfer.py
@@ -181,43 +181,6 @@ def test_makechargetransferfile_ar85_helium_entries(patch_sources, tmp_path):
     assert entry.autoreverse == 1
 
 
-def test_makechargetransferfile_estimates(monkeypatch):
-    """The estimates keep the exothermic reactions with a small energy defect, with a heavy atom or hydrogen."""
-    # the NIST table keys by ion stage
-    monkeypatch.setattr(
-        makechargetransferfile,
-        "get_nist_ionization_energies_ev",
-        lambda: {(1, 1): 13.6, (26, 1): 7.9, (26, 2): 10.0, (26, 3): 16.2, (53, 1): 10.45, (57, 1): 5.58},
-    )
-
-    entries = makechargetransferfile.get_estimate_entries()
-    reactions = {(e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don): e for e in entries}
-
-    # Fe+1 + La0 -> Fe0 + La+1 releases 7.9 - 5.58 = 2.32 eV, which is inside the window
-    assert (26, 2, 57, 1) in reactions
-    assert reactions[26, 2, 57, 1].a == makechargetransferfile.METAL_METAL_RATE
-    # Fe+2 + Fe0 -> Fe+1 + Fe+1 releases 10.0 - 7.9 = 2.1 eV, and I+1 + Fe0 releases 2.55 eV
-    assert (26, 3, 26, 1) in reactions
-    assert (53, 2, 26, 1) in reactions
-    # Fe+3 + H0 -> Fe+2 + H+ releases 16.2 - 13.6 = 2.6 eV
-    assert (26, 4, 1, 1) in reactions
-    # H+ + I0 -> H0 + I+1 releases 13.6 - 10.45 = 3.15 eV
-    assert (1, 2, 53, 1) in reactions
-    # the excluded reactions:
-    #   La+1 + Fe0 and Fe+1 + H0 are endothermic;
-    #   Fe+2 + La0 releases 4.42 eV and H+ + Fe0 releases 5.7 eV, which are above the window;
-    #   Fe+1 + Fe0 changes nothing
-    assert set(reactions) == {(26, 2, 57, 1), (26, 3, 26, 1), (53, 2, 26, 1), (26, 4, 1, 1), (1, 2, 53, 1)}
-
-    # a reaction that another source covers gets no estimate
-    remaining = makechargetransferfile.get_estimate_entries(covered={(26, 2, 57, 1), (1, 2, 53, 1)})
-    assert {(e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don) for e in remaining} == {
-        (26, 3, 26, 1),
-        (53, 2, 26, 1),
-        (26, 4, 1, 1),
-    }
-
-
 def test_set_autoreverse_flags_rejects_a_duplicate_reaction():
     """The assembled list must hold each reaction once, because the reader takes the first fit."""
     entry = makechargetransferfile.CTEntry(26, 2, 1, 1, 1.0, 0.0, 0.0, 0.0, 0.0, 1e3, 4e4, "Test; Fe+1 + H0")
@@ -235,13 +198,9 @@ def test_committed_source_files_build_the_expected_entries():
     kf96_entries, _ = makechargetransferfile.get_kf96_h_entries(sourcedir)
     he_entries = makechargetransferfile.get_he_entries(sourcedir)
     ss11_entries, _ = makechargetransferfile.get_ss11_entries(sourcedir)
-    published = kf96_entries + he_entries + ss11_entries
-    covered = {(e.z_acc, e.ionstage_acc, e.z_don, e.ionstage_don) for e in published}
-    metal_entries = makechargetransferfile.get_estimate_entries(covered)
-
-    assert (len(kf96_entries), len(he_entries), len(ss11_entries), len(metal_entries)) == (100, 21, 36, 3913)
-    entries = makechargetransferfile.set_autoreverse_flags(published + metal_entries)
-    assert all(e.comment.split(";", 1)[0] in {"Cloudy", "AR85", "SS11", "Estimate"} for e in entries)
+    assert (len(kf96_entries), len(he_entries), len(ss11_entries)) == (100, 21, 36)
+    entries = makechargetransferfile.set_autoreverse_flags(kf96_entries + he_entries + ss11_entries)
+    assert all(e.comment.split(";", 1)[0] in {"Cloudy", "AR85", "SS11"} for e in entries)
 
 
 def test_read_source_reads_the_compressed_file(tmp_path):
@@ -256,9 +215,9 @@ def test_read_source_reads_the_compressed_file(tmp_path):
 
 
 def test_chargetransfer_output_matches_the_checksum(tmp_path, monkeypatch):
-    """main() writes the files that tests/chargetransfer/checksums.txt records, byte for byte.
+    """main() writes the file that tests/chargetransfer/checksums.txt records, byte for byte.
 
-    The CI job 'test chargetransfer' checks the same files with md5sum. Regenerate the checksums
+    The CI job 'test chargetransfer' checks the same file with md5sum. Regenerate the checksum
     after a deliberate change of the output; tests/README.md gives the commands.
     """
     monkeypatch.setattr(sys, "argv", ["makechargetransferfile", "-output_folder", str(tmp_path)])
@@ -266,6 +225,6 @@ def test_chargetransfer_output_matches_the_checksum(tmp_path, monkeypatch):
 
     checksumfile = Path(makechargetransferfile.__file__).parent.parent / "tests" / "chargetransfer" / "checksums.txt"
     expected = {name: digest for digest, name in (line.split() for line in checksumfile.read_text().splitlines())}
-    assert set(expected) == {"chargetransfer.txt", "chargetransfer_estimates.txt"}
+    assert set(expected) == {"chargetransfer.txt"}
     for name, digest in expected.items():
         assert hashlib.md5((tmp_path / name).read_bytes(), usedforsecurity=False).hexdigest() == digest, name

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,12 +52,12 @@ parallel, so a new set is free in wall clock, while extending a set churns its f
 ## The charge transfer set
 
 `chargetransfer/` is not a matrix entry: the `chargetransfer` job of the workflow runs
-`python -m artisatomic.makechargetransferfile` and checks `chargetransfer.txt` against
-`checksums.txt`. The source files are tracked in `atomic-data-chargetransfer`, so the job downloads
+`python -m artisatomic.makechargetransferfile` and checks `chargetransfer.txt` and
+`chargetransfer_estimates.txt` against `checksums.txt`. The source files are tracked in `atomic-data-chargetransfer`, so the job downloads
 nothing. The test `test_chargetransfer_output_matches_the_checksum` checks the same checksum under
-pytest. Regenerate the checksum with:
+pytest. Regenerate the checksums with:
 
 ```bash
-PYTHONPATH="$PWD" uv run makechargetransferfile -outputfile tests/chargetransfer/output/chargetransfer.txt
-(cd tests/chargetransfer/output && md5sum chargetransfer.txt > ../checksums.txt)
+PYTHONPATH="$PWD" uv run makechargetransferfile -output_folder tests/chargetransfer/output
+(cd tests/chargetransfer/output && md5sum *.txt > ../checksums.txt)
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,10 +52,10 @@ parallel, so a new set is free in wall clock, while extending a set churns its f
 ## The charge transfer set
 
 `chargetransfer/` is not a matrix entry: the `chargetransfer` job of the workflow runs
-`python -m artisatomic.makechargetransferfile` and checks `chargetransfer.txt` and
-`chargetransfer_estimates.txt` against `checksums.txt`. The source files are tracked in `atomic-data-chargetransfer`, so the job downloads
+`python -m artisatomic.makechargetransferfile` and checks `chargetransfer.txt` against
+`checksums.txt`. The source files are tracked in `atomic-data-chargetransfer`, so the job downloads
 nothing. The test `test_chargetransfer_output_matches_the_checksum` checks the same checksum under
-pytest. Regenerate the checksums with:
+pytest. Regenerate the checksum with:
 
 ```bash
 PYTHONPATH="$PWD" uv run makechargetransferfile -output_folder tests/chargetransfer/output

--- a/tests/chargetransfer/checksums.txt
+++ b/tests/chargetransfer/checksums.txt
@@ -1,1 +1,1 @@
-db34038eb6c9b1661ed0bd5a8eb3ef61  chargetransfer.txt
+fadb8cc898788141c2fa97afac8779c8  chargetransfer.txt

--- a/tests/chargetransfer/checksums.txt
+++ b/tests/chargetransfer/checksums.txt
@@ -1,1 +1,1 @@
-ba39301955a3dfc25f880e73855cb964  chargetransfer.txt
+8a473b70f85deb1452eb13f9c1e5eb1c  chargetransfer.txt

--- a/tests/chargetransfer/checksums.txt
+++ b/tests/chargetransfer/checksums.txt
@@ -1,1 +1,1 @@
-8a473b70f85deb1452eb13f9c1e5eb1c  chargetransfer.txt
+af936fe66b3a795df95493d50e7fbba0  chargetransfer.txt

--- a/tests/chargetransfer/checksums.txt
+++ b/tests/chargetransfer/checksums.txt
@@ -1,1 +1,1 @@
-27f4377739f0d83cea4770e4eeecd117  chargetransfer.txt
+ba39301955a3dfc25f880e73855cb964  chargetransfer.txt

--- a/tests/chargetransfer/checksums.txt
+++ b/tests/chargetransfer/checksums.txt
@@ -1,1 +1,2 @@
-a60979459a5f2f9f5eceaf4f3e6636d1  chargetransfer.txt
+a69a8d67455d44a81b00bcaff995249d  chargetransfer.txt
+a82eda276df2abdbb9d442c7d3c69df5  chargetransfer_estimates.txt

--- a/tests/chargetransfer/checksums.txt
+++ b/tests/chargetransfer/checksums.txt
@@ -1,1 +1,1 @@
-fadb8cc898788141c2fa97afac8779c8  chargetransfer.txt
+a60979459a5f2f9f5eceaf4f3e6636d1  chargetransfer.txt

--- a/tests/chargetransfer/checksums.txt
+++ b/tests/chargetransfer/checksums.txt
@@ -1,1 +1,1 @@
-71d757277ec1d72b4ec1a675d82a677d  chargetransfer.txt
+db34038eb6c9b1661ed0bd5a8eb3ef61  chargetransfer.txt

--- a/tests/chargetransfer/checksums.txt
+++ b/tests/chargetransfer/checksums.txt
@@ -1,2 +1,1 @@
-a69a8d67455d44a81b00bcaff995249d  chargetransfer.txt
-a82eda276df2abdbb9d442c7d3c69df5  chargetransfer_estimates.txt
+6dede763b555afc54a16f966d4bf98d3  chargetransfer.txt

--- a/tests/chargetransfer/checksums.txt
+++ b/tests/chargetransfer/checksums.txt
@@ -1,1 +1,1 @@
-af936fe66b3a795df95493d50e7fbba0  chargetransfer.txt
+71d757277ec1d72b4ec1a675d82a677d  chargetransfer.txt


### PR DESCRIPTION
The output file `chargetransfer.txt` was 755 kB, which made it by far the largest file in `artis_files/data/`. The next largest is `gamma_nd151.txt` at 6.6 kB. This branch makes it 18 kB, a decrease of 98%. The file keeps one table with 12 columns on every line.

## The estimates are gone

3913 of the 4070 lines were near-resonant estimates: a flat rate of 1e-9 cm3/s for an exothermic reaction with an energy defect in (0, 4] eV, an acceptor charge of 1 to 3, and a neutral donor. A line of that kind holds no information. It is the output of a four-parameter rule on the ground-state ionization energies. ARTIS holds the ionization energies of its ions (`get_ionpot`) and enumerates the acceptor and donor pairs for the Landau-Zener rates, so it applies the rule itself: artis commit `aa8ac3d5` on `claude/charge-transfer-feasibility-7565f3` adds `is_near_resonant` and the flat reaction to `generate_estimated_reactions`, with unit tests. The script now writes the 157 published fits of Cloudy, AR85, and SS11 only. The estimate generator, the NIST lookup, and their tests are gone from the module.

## The format changes

1. Space-separated columns in place of fixed column widths.
2. No reaction label in a comment: the four ion columns identify the reaction, so the helper `ionlabel` is gone.
3. A comment line directly above the table names the columns.

```
157
#Z_acc ionstage_acc Z_don ionstage_don a b c d eexp tmin tmax autoreverse
2 2 1 1 1.87e-06 2.06 9.93 -3.89 0 6000 100000 1 # Cloudy; Cloudy deltaE=10.99 eV; Cloudy update; KF96 published a=7.47e-06 b=2.06 c=9.93 d=-3.89
```

The values of the 157 fitted reactions do not change. Each line gives the same tokens as before.

## Script and tests

- `makechargetransferfile` takes `-output_folder` (default `artis_files/data`) in place of `-outputfile`, as `makeartisatomicfiles` does. The CI job and `tests/README.md` use it.
- `tests/chargetransfer/checksums.txt` holds the new checksum. The pytest test fails on a stale line.
- Two tests asserted the reaction label of a comment. The tests already assert the four ion columns, which identify the reaction, so those assertions are unnecessary.
- Tests, ruff, pyrefly, and ty pass.

## ARTIS

The reader of `chargetransfer.txt` needs no change for the format: `read_reaction_file` reads the fields with a stream and skips the comment lines. The artis commit above makes the estimates in the code and ships this 18 kB data file. The ARTIS estimates use the `adata.txt` ionization energies in place of the NIST values, so a few pairs at the edges of the 0 and 4 eV window can differ from the old file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)