### PR TITLE
Read the atomic data files with polars

### DIFF
--- a/artisatomic/base.py
+++ b/artisatomic/base.py
@@ -219,8 +219,8 @@ def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO[t.Any]:
 def scan_file_lines(filename: str | Path, skip_lines: int = 0) -> pl.LazyFrame:
     """Read a text file into a lazy frame that holds one line in each row of a "line" column.
 
-    A fixed-width or a space-aligned file is much faster to cut into columns with str.slice() or
-    str.split() than to parse with pandas read_fwf(), or read_csv() with a regular expression
+    polars cuts the columns out of every line at once, with str.slice() or str.extract_all().
+    That is much faster than pandas read_fwf(), or read_csv() with a regular expression
     separator. Neither of those has a C parser, so each reads one line at a time in Python.
 
     The caller names the plain file, as for xopen_check_extension(). polars reads a plain, a

--- a/artisatomic/base.py
+++ b/artisatomic/base.py
@@ -199,6 +199,17 @@ def find_file_check_extension(filename: str | Path) -> Path | None:
     return next((path for ext in compression_extensions if (path := Path(f"{filename}{ext}")).is_file()), None)
 
 
+def find_file_check_extension_or_raise(filename: str | Path) -> Path:
+    """Find a data file by its plain name, and raise if no form of the name exists."""
+    filepath = find_file_check_extension(filename)
+    if filepath is None:
+        filepaths = [f"{filename}{ext}" for ext in compression_extensions]
+        msg = f"Could not find any of the following files:\n  {'\n  '.join(filepaths)}."
+        raise FileNotFoundError(msg)
+
+    return filepath
+
+
 def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO[t.Any]:
     """Open a data file, trying the compressed variants of the name if it does not exist.
 
@@ -207,13 +218,7 @@ def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO[t.Any]:
     """
     from xopen import xopen
 
-    filepath = find_file_check_extension(filename)
-    if filepath is None:
-        filepaths = [f"{filename}{ext}" for ext in compression_extensions]
-        msg = f"Could not find any of the following files:\n  {'\n  '.join(filepaths)}."
-        raise FileNotFoundError(msg)
-
-    return xopen(filepath, **kwargs)
+    return xopen(find_file_check_extension_or_raise(filename), **kwargs)
 
 
 def scan_file_lines(filename: str | Path, skip_lines: int = 0) -> pl.LazyFrame:
@@ -227,11 +232,7 @@ def scan_file_lines(filename: str | Path, skip_lines: int = 0) -> pl.LazyFrame:
     gzip, or a zstd file itself. It cannot read the xz form, which xopen decompresses into
     memory instead.
     """
-    filepath = find_file_check_extension(filename)
-    if filepath is None:
-        filepaths = [f"{filename}{ext}" for ext in compression_extensions]
-        msg = f"Could not find any of the following files:\n  {'\n  '.join(filepaths)}."
-        raise FileNotFoundError(msg)
+    filepath = find_file_check_extension_or_raise(filename)
 
     csv_options: dict[str, t.Any] = {
         # a separator that the data files cannot contain keeps each whole line in one column

--- a/artisatomic/base.py
+++ b/artisatomic/base.py
@@ -216,6 +216,42 @@ def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO[t.Any]:
     return xopen(filepath, **kwargs)
 
 
+def scan_file_lines(filename: str | Path, skip_lines: int = 0) -> pl.LazyFrame:
+    """Read a text file into a lazy frame that holds one line in each row of a "line" column.
+
+    A fixed-width or a space-aligned file is much faster to cut into columns with str.slice() or
+    str.split() than to parse with pandas read_fwf(), or read_csv() with a regular expression
+    separator. Neither of those has a C parser, so each reads one line at a time in Python.
+
+    The caller names the plain file, as for xopen_check_extension(). polars reads a plain, a
+    gzip, or a zstd file itself. It cannot read the xz form, which xopen decompresses into
+    memory instead.
+    """
+    filepath = find_file_check_extension(filename)
+    if filepath is None:
+        filepaths = [f"{filename}{ext}" for ext in compression_extensions]
+        msg = f"Could not find any of the following files:\n  {'\n  '.join(filepaths)}."
+        raise FileNotFoundError(msg)
+
+    csv_options: dict[str, t.Any] = {
+        # a separator that the data files cannot contain keeps each whole line in one column
+        "separator": "\x1f",
+        "has_header": False,
+        "new_columns": ["line"],
+        "quote_char": None,
+        "infer_schema_length": 0,
+        "skip_lines": skip_lines,
+    }
+
+    if filepath.suffix == ".xz":
+        from xopen import xopen
+
+        with xopen(filepath, "rb") as fin:
+            return pl.read_csv(io.BytesIO(fin.read()), **csv_options).lazy()
+
+    return pl.scan_csv(filepath, **csv_options)
+
+
 NIST_IONIZATION_PATH = PYDIR / "nist_ionization.txt.zst"
 
 

--- a/artisatomic/base.py
+++ b/artisatomic/base.py
@@ -221,26 +221,29 @@ def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO[t.Any]:
     return xopen(find_file_check_extension_or_raise(filename), **kwargs)
 
 
-def read_lines_check_encoding(filename: str | Path) -> list[str]:
-    """Read a text data file into its lines, and rewrite the file as utf-8 if it is not utf-8.
+def rewrite_file_as_utf8(filename: str | Path) -> bool:
+    """Rewrite a data file as utf-8 if it is not utf-8, and say whether it was rewritten.
 
     CMFGEN writes an author's name with an accent, which leaves a few of its files in
-    iso-8859-1. Such a file is converted once, in place, so that every later read gets utf-8
-    and no reader needs to know which files those are.
+    iso-8859-1. Neither Python nor polars reads such a file, so a reader that meets one
+    converts it once, in place, and reads it again.
     """
     from xopen import xopen
 
     filepath = find_file_check_extension_or_raise(filename)
-    try:
-        with xopen(filepath, encoding="utf-8") as fin:
-            return fin.readlines()
-    except UnicodeDecodeError:
-        print(f"{filepath} is not utf-8. Rewriting it as utf-8, from iso-8859-1.")
-
     with xopen(filepath, "rb") as fin:
-        # every byte is a character in iso-8859-1, so this decode cannot fail
-        text = fin.read().decode("iso-8859-1")
+        filebytes = fin.read()
 
+    try:
+        filebytes.decode("utf-8")
+    except UnicodeDecodeError:
+        pass
+    else:
+        return False
+
+    print(f"{filepath} is not utf-8. Rewriting it as utf-8, from iso-8859-1.")
+    # every byte is a character in iso-8859-1, so this decode cannot fail
+    text = filebytes.decode("iso-8859-1")
     try:
         with xopen(filepath, "wt", encoding="utf-8") as fout:
             fout.write(text)
@@ -252,10 +255,7 @@ def read_lines_check_encoding(filename: str | Path) -> list[str]:
         )
         raise RuntimeError(msg) from exc
 
-    # read the file again rather than split the text here: str.splitlines() breaks a line at a
-    # form feed as well, which one CMFGEN file holds, and readlines() does not
-    with xopen(filepath, encoding="utf-8") as fin:
-        return fin.readlines()
+    return True
 
 
 def scan_file_lines(filename: str | Path, skip_lines: int = 0) -> pl.LazyFrame:

--- a/artisatomic/base.py
+++ b/artisatomic/base.py
@@ -221,6 +221,43 @@ def xopen_check_extension(filename: str | Path, **kwargs: t.Any) -> t.IO[t.Any]:
     return xopen(find_file_check_extension_or_raise(filename), **kwargs)
 
 
+def read_lines_check_encoding(filename: str | Path) -> list[str]:
+    """Read a text data file into its lines, and rewrite the file as utf-8 if it is not utf-8.
+
+    CMFGEN writes an author's name with an accent, which leaves a few of its files in
+    iso-8859-1. Such a file is converted once, in place, so that every later read gets utf-8
+    and no reader needs to know which files those are.
+    """
+    from xopen import xopen
+
+    filepath = find_file_check_extension_or_raise(filename)
+    try:
+        with xopen(filepath, encoding="utf-8") as fin:
+            return fin.readlines()
+    except UnicodeDecodeError:
+        print(f"{filepath} is not utf-8. Rewriting it as utf-8, from iso-8859-1.")
+
+    with xopen(filepath, "rb") as fin:
+        # every byte is a character in iso-8859-1, so this decode cannot fail
+        text = fin.read().decode("iso-8859-1")
+
+    try:
+        with xopen(filepath, "wt", encoding="utf-8") as fout:
+            fout.write(text)
+    except OSError as exc:
+        msg = (
+            f"Could not rewrite {filepath} as utf-8: {exc}\n"
+            f"Convert the file by hand, then run this again:\n"
+            f"  iconv -f iso-8859-1 -t utf-8 '{filepath}' > tmp && mv tmp '{filepath}'"
+        )
+        raise RuntimeError(msg) from exc
+
+    # read the file again rather than split the text here: str.splitlines() breaks a line at a
+    # form feed as well, which one CMFGEN file holds, and readlines() does not
+    with xopen(filepath, encoding="utf-8") as fin:
+        return fin.readlines()
+
+
 def scan_file_lines(filename: str | Path, skip_lines: int = 0) -> pl.LazyFrame:
     """Read a text file into a lazy frame that holds one line in each row of a "line" column.
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -18,8 +18,9 @@ import artisatomic
 from artisatomic.base import elsymbols
 from artisatomic.base import h_in_ev_seconds
 from artisatomic.base import hc_in_ev_angstrom
-from artisatomic.base import read_lines_check_encoding
+from artisatomic.base import rewrite_file_as_utf8
 from artisatomic.base import ryd_to_ev
+from artisatomic.base import scan_file_lines
 from artisatomic.levelnames import lchars
 
 # need to also include collision strengths from e.g., o2col.dat
@@ -343,7 +344,7 @@ def get_term_as_tuple(config: str) -> tuple[int, int, int]:
     return (twosplusone, l, parity)
 
 
-def parse_transition_lines(translines: list[str], filename: Path) -> pl.DataFrame:
+def parse_transition_lines(dflines: pl.LazyFrame, filename: Path) -> pl.DataFrame:
     """Read the oscillator strengths table of a CMFGEN file into a transition frame.
 
     A transition line names its two levels, and a level name can hold a dash. The line is
@@ -354,9 +355,6 @@ def parse_transition_lines(translines: list[str], filename: Path) -> pl.DataFram
     The file marks no end of the table. A line that is not a transition, e.g. a title, gives
     parts that fit neither layout below, and the filter drops it.
     """
-    # an empty list gives a null column, which no string operation below accepts
-    dflines = pl.LazyFrame({"line": translines}, schema={"line": pl.String})
-
     # only the first table is read, and a spelling mistake in a title must not hide the second one
     tablestart = (
         dflines.with_row_index()
@@ -433,6 +431,34 @@ def parse_transition_lines(translines: list[str], filename: Path) -> pl.DataFram
 def read_levels_and_transitions(
     atomic_number: int, ion_stage: int, flog
 ) -> tuple[float, pl.DataFrame, pl.DataFrame, defaultdict[str, int]]:
+    """Read one ion, and rewrite its file as utf-8 first if CMFGEN wrote it in iso-8859-1.
+
+    Python raises a UnicodeDecodeError for such a file and polars raises a ComputeError, so
+    both reads of read_levels_and_transitions_from_file() are covered here. The file is
+    converted once, so the second call reads it.
+    """
+    try:
+        return read_levels_and_transitions_from_file(atomic_number, ion_stage, flog)
+    except (UnicodeDecodeError, pl.exceptions.ComputeError):
+        # a failure that the encoding does not explain belongs to the caller
+        if not rewrite_file_as_utf8(hillier_osc_filename(atomic_number, ion_stage)):
+            raise
+
+    return read_levels_and_transitions_from_file(atomic_number, ion_stage, flog)
+
+
+def hillier_osc_filename(atomic_number: int, ion_stage: int) -> Path:
+    """Path of one ion's CMFGEN oscillator file, which holds its levels and its transitions."""
+    return Path(
+        hillier_ion_folder(atomic_number, ion_stage),
+        ions_data[atomic_number, ion_stage].folder,
+        ions_data[atomic_number, ion_stage].levelstransitionsfilename,
+    )
+
+
+def read_levels_and_transitions_from_file(
+    atomic_number: int, ion_stage: int, flog
+) -> tuple[float, pl.DataFrame, pl.DataFrame, defaultdict[str, int]]:
     """Read one ion's levels and bound-bound transitions from its CMFGEN oscillator file.
 
     Returns the ionization energy in eV, a level frame, a transition frame, and the number of
@@ -469,11 +495,7 @@ def read_levels_and_transitions(
             transition_count_of_level_name,
         )
 
-    filename = Path(
-        hillier_ion_folder(atomic_number, ion_stage),
-        ions_data[atomic_number, ion_stage].folder,
-        ions_data[atomic_number, ion_stage].levelstransitionsfilename,
-    )
+    filename = hillier_osc_filename(atomic_number, ion_stage)
 
     artisatomic.log_and_print(flog, f"Reading {artisatomic.path_for_log(filename)}")
 
@@ -481,12 +503,18 @@ def read_levels_and_transitions(
     levels_without_parity: list[str] = []
 
     prev_line = ""
-    fhillierosc = iter(read_lines_check_encoding(filename))
+    # threads=0 decompresses in this process. The default starts a process that writes into a
+    # pipe, which reports a broken pipe when the reader stops at the end of the level table.
+    fhillierosc = artisatomic.xopen_check_extension(filename, threads=0)
+    # the two loops below read the header and the levels. polars reads the transitions, and
+    # starts at the line after the last line that they read.
+    linesread = 0
     expected_energy_levels = -1
     expected_transitions = -1
     row_format_energy_level = None
     format_date = "NOT_SPECIFIED"
     for line in fhillierosc:
+        linesread += 1
         row = line.split()
         if (
             re.match(r"x*\*{5,}", line) and prev_line
@@ -548,6 +576,7 @@ def read_levels_and_transitions(
         raise ValueError(msg)
 
     for line in fhillierosc:
+        linesread += 1
         row = line.split()
         # check for right number of columns and that are all numbers except first column
         if len(row) == levelcolcount and all(map(artisatomic.isfloat, row[1:])):
@@ -612,11 +641,11 @@ def read_levels_and_transitions(
         msg = f"{filename} declares {expected_energy_levels} levels but {len(levelrows)} were read"
         raise ValueError(msg)
 
-    # the rest of the file holds the transitions, which are parsed as a frame rather than
-    # line by line: one ion carries half a million of them
-    translines = list(fhillierosc)
+    fhillierosc.close()
 
-    dftransitions = parse_transition_lines(translines, filename)
+    # the rest of the file holds the transitions, which polars reads rather than Python: one ion
+    # carries half a million of them
+    dftransitions = parse_transition_lines(scan_file_lines(filename, skip_lines=linesread), filename)
 
     for namecolumn in ("namefrom", "nameto"):
         for levelname, count in dftransitions[namecolumn].value_counts().iter_rows():

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -18,6 +18,7 @@ import artisatomic
 from artisatomic.base import elsymbols
 from artisatomic.base import h_in_ev_seconds
 from artisatomic.base import hc_in_ev_angstrom
+from artisatomic.base import read_lines_check_encoding
 from artisatomic.base import ryd_to_ev
 from artisatomic.levelnames import lchars
 
@@ -480,141 +481,140 @@ def read_levels_and_transitions(
     levels_without_parity: list[str] = []
 
     prev_line = ""
-    # TODO: Would be nice to have a way of dealing with different encodings automatically, but this seems to be the only case so probably not worth it
-    with artisatomic.xopen_check_extension(
-        filename, encoding="iso-8859-1" if atomic_number == 12 and ion_stage == 8 else "utf-8"
-    ) as fhillierosc:
-        expected_energy_levels = -1
-        expected_transitions = -1
-        row_format_energy_level = None
-        format_date = "NOT_SPECIFIED"
-        for line in fhillierosc:
-            row = line.split()
-            if (
-                re.match(r"x*\*{5,}", line) and prev_line
-            ):  # The x is not a mistake, one of the lines of stars somewhere starts with an x and breaks otherwise
-                if atomic_number == 26 and ion_stage == 8:  # Fe VIII has its own bespoke header...
-                    print("Fe VIII has a bespoke header")
-                    row_format_energy_level = "levelname g energyabovegsinpercm thresholdenergyev freqtentothe15hz lambdaangstrom hillierlevelid"
-                else:
-                    headerline = prev_line
-                    headerline = headerline.replace("ID", "hillierlevelid")
-                    headerline = headerline.replace("E(cm^-1)", "energyabovegsinpercm")
-                    headerline = headerline.replace("10^15 Hz", "freqtentothe15hz")
-                    headerline = headerline.replace("eV", "thresholdenergyev")
-                    headerline = headerline.replace("Lam(A)", "lambdaangstrom")
-                    headerline = headerline.replace("ARAD", "arad")
-                    row_format_energy_level = "levelname " + " ".join(headerline.lower().split())
-
-                print("File contains columns:")
-                print(f"  {row_format_energy_level}")
-            elif line.rstrip().endswith("!Number of energy levels"):
-                expected_energy_levels = int(row[0])
-                artisatomic.log_and_print(flog, f"File specifies {expected_energy_levels:d} levels")
-            elif line.rstrip().endswith("!Number of transitions"):
-                expected_transitions = int(row[0])
-                artisatomic.log_and_print(flog, f"File specifies {expected_transitions:d} transitions")
-            elif len(row) == 3 and row[1] == "!Format" and row[2] == "date":
-                format_date = row[0]
-                print(f"Format date: {format_date}")
-
-            if expected_energy_levels >= 0 and not row:
-                break
-            prev_line = line.strip()
-
-        if not row_format_energy_level:
-            # the files that predate the header also predate the format date line
-            if format_date != "NOT_SPECIFIED":
-                msg = f"{filename} gives a format date of {format_date} but carries no column header"
-                raise ValueError(msg)
-            row_format_energy_level = hillier_rowformat_noheader
-            print("File has no column header, assuming columns:")
-            print(f"  {row_format_energy_level}")
-
-        # the file columns vary by ion, so find where the ones we keep sit in each row
-        headercolumns = row_format_energy_level.split()
-        colindex = {colname: index for index, colname in enumerate(headercolumns)}
-        levelcolcount = len(headercolumns)
-        if len(colindex) != levelcolcount:
-            # a repeated header token would silently shadow an earlier column's position
-            msg = f"Level table header of {filename} contains duplicate column names: {row_format_energy_level}"
-            raise ValueError(msg)
-        missingcolumns = [colname for colname in hillier_required_filecolumns if colname not in colindex]
-        if missingcolumns:
-            msg = (
-                f"Level table of {filename} is missing the {', '.join(missingcolumns)} column(s):"
-                f" it has {row_format_energy_level}"
-            )
-            raise ValueError(msg)
-
-        for line in fhillierosc:
-            row = line.split()
-            # check for right number of columns and that are all numbers except first column
-            if len(row) == levelcolcount and all(map(artisatomic.isfloat, row[1:])):
-                hillierlevelid = int(row[colindex["hillierlevelid"]].lstrip("-"))
-                levelname = row[colindex["levelname"]]
-                energyabovegsinpercm = float(row[colindex["energyabovegsinpercm"]].replace("D", "E"))
-                lambdaangstrom = float(row[colindex["lambdaangstrom"]].replace("D", "E"))
-                (twosplusone, _l, parity) = get_term_as_tuple(levelname)
-                ismerged = parity < 0
-                isjjcoupled = "{" in levelname and "}" in levelname
-
-                if ismerged:
-                    # No definite parity: a merged level, which is normal CMFGEN, or a name we
-                    # could not read. Null rather than a number, so that add_level_ids_forbidden()
-                    # cannot match it against another level's absent parity.
-                    parity = None
-                    levels_without_parity.append(levelname)
-
-                levelrows.append(
-                    HillierEnergyLevel(
-                        levelname=levelname,
-                        g=float(row[colindex["g"]]),
-                        energyabovegsinpercm=energyabovegsinpercm,
-                        lambdaangstrom=lambdaangstrom,
-                        hillierlevelid=hillierlevelid,
-                        parity=parity,
-                        j=get_level_j(levelname, g=float(row[colindex["g"]])),
-                    )
+    fhillierosc = iter(read_lines_check_encoding(filename))
+    expected_energy_levels = -1
+    expected_transitions = -1
+    row_format_energy_level = None
+    format_date = "NOT_SPECIFIED"
+    for line in fhillierosc:
+        row = line.split()
+        if (
+            re.match(r"x*\*{5,}", line) and prev_line
+        ):  # The x is not a mistake, one of the lines of stars somewhere starts with an x and breaks otherwise
+            if atomic_number == 26 and ion_stage == 8:  # Fe VIII has its own bespoke header...
+                print("Fe VIII has a bespoke header")
+                row_format_energy_level = (
+                    "levelname g energyabovegsinpercm thresholdenergyev freqtentothe15hz lambdaangstrom hillierlevelid"
                 )
+            else:
+                headerline = prev_line
+                headerline = headerline.replace("ID", "hillierlevelid")
+                headerline = headerline.replace("E(cm^-1)", "energyabovegsinpercm")
+                headerline = headerline.replace("10^15 Hz", "freqtentothe15hz")
+                headerline = headerline.replace("eV", "thresholdenergyev")
+                headerline = headerline.replace("Lam(A)", "lambdaangstrom")
+                headerline = headerline.replace("ARAD", "arad")
+                row_format_energy_level = "levelname " + " ".join(headerline.lower().split())
 
-                # -1 indicates that the term could not be interpreted. JJ-coupled names have no
-                # LS term by construction and merged levels are summarised once below, so neither
-                # is worth a line here; what is left is a name we expected to read and could not.
-                if twosplusone == -1 and atomic_number > 1 and not isjjcoupled and not ismerged:
-                    artisatomic.log_and_print(flog, f"Can't find LS term in Hillier level name '{levelname}'")
+            print("File contains columns:")
+            print(f"  {row_format_energy_level}")
+        elif line.rstrip().endswith("!Number of energy levels"):
+            expected_energy_levels = int(row[0])
+            artisatomic.log_and_print(flog, f"File specifies {expected_energy_levels:d} levels")
+        elif line.rstrip().endswith("!Number of transitions"):
+            expected_transitions = int(row[0])
+            artisatomic.log_and_print(flog, f"File specifies {expected_transitions:d} transitions")
+        elif len(row) == 3 and row[1] == "!Format" and row[2] == "date":
+            format_date = row[0]
+            print(f"Format date: {format_date}")
 
-                # if this is the ground state
-                if energyabovegsinpercm < 1.0:
-                    hillier_ionization_energy_ev = hc_in_ev_angstrom / lambdaangstrom
+        if expected_energy_levels >= 0 and not row:
+            break
+        prev_line = line.strip()
 
-                if hillierlevelid != len(levelrows):
-                    artisatomic.log_and_print(
-                        flog,
-                        f"Hillier levels mismatch: id {len(levelrows):d} found at entry number {hillierlevelid:d}",
-                    )
-                    sys.exit(1)
-
-            if re.match(r"^\s*Osci(l|ll)ator strengths", line) and len(levelrows) > 0:
-                break
-
-        artisatomic.log_and_print(flog, f"Read {len(levelrows):d} levels")
-        if levels_without_parity:
-            # Normal for ions with merged levels, so this is a count and a sample rather than a
-            # warning per level: H I and He II are merged all the way down.
-            artisatomic.log_and_print(
-                flog,
-                f"{len(levels_without_parity):d} of {len(levelrows):d} levels have no definite parity"
-                f" (every transition touching one is treated as permitted), e.g."
-                f" {', '.join(levels_without_parity[:5])}",
-            )
-        if len(levelrows) != expected_energy_levels:
-            msg = f"{filename} declares {expected_energy_levels} levels but {len(levelrows)} were read"
+    if not row_format_energy_level:
+        # the files that predate the header also predate the format date line
+        if format_date != "NOT_SPECIFIED":
+            msg = f"{filename} gives a format date of {format_date} but carries no column header"
             raise ValueError(msg)
+        row_format_energy_level = hillier_rowformat_noheader
+        print("File has no column header, assuming columns:")
+        print(f"  {row_format_energy_level}")
 
-        # the rest of the file holds the transitions, which are parsed as a frame rather than
-        # line by line: one ion carries half a million of them
-        translines = fhillierosc.readlines()
+    # the file columns vary by ion, so find where the ones we keep sit in each row
+    headercolumns = row_format_energy_level.split()
+    colindex = {colname: index for index, colname in enumerate(headercolumns)}
+    levelcolcount = len(headercolumns)
+    if len(colindex) != levelcolcount:
+        # a repeated header token would silently shadow an earlier column's position
+        msg = f"Level table header of {filename} contains duplicate column names: {row_format_energy_level}"
+        raise ValueError(msg)
+    missingcolumns = [colname for colname in hillier_required_filecolumns if colname not in colindex]
+    if missingcolumns:
+        msg = (
+            f"Level table of {filename} is missing the {', '.join(missingcolumns)} column(s):"
+            f" it has {row_format_energy_level}"
+        )
+        raise ValueError(msg)
+
+    for line in fhillierosc:
+        row = line.split()
+        # check for right number of columns and that are all numbers except first column
+        if len(row) == levelcolcount and all(map(artisatomic.isfloat, row[1:])):
+            hillierlevelid = int(row[colindex["hillierlevelid"]].lstrip("-"))
+            levelname = row[colindex["levelname"]]
+            energyabovegsinpercm = float(row[colindex["energyabovegsinpercm"]].replace("D", "E"))
+            lambdaangstrom = float(row[colindex["lambdaangstrom"]].replace("D", "E"))
+            (twosplusone, _l, parity) = get_term_as_tuple(levelname)
+            ismerged = parity < 0
+            isjjcoupled = "{" in levelname and "}" in levelname
+
+            if ismerged:
+                # No definite parity: a merged level, which is normal CMFGEN, or a name we
+                # could not read. Null rather than a number, so that add_level_ids_forbidden()
+                # cannot match it against another level's absent parity.
+                parity = None
+                levels_without_parity.append(levelname)
+
+            levelrows.append(
+                HillierEnergyLevel(
+                    levelname=levelname,
+                    g=float(row[colindex["g"]]),
+                    energyabovegsinpercm=energyabovegsinpercm,
+                    lambdaangstrom=lambdaangstrom,
+                    hillierlevelid=hillierlevelid,
+                    parity=parity,
+                    j=get_level_j(levelname, g=float(row[colindex["g"]])),
+                )
+            )
+
+            # -1 indicates that the term could not be interpreted. JJ-coupled names have no
+            # LS term by construction and merged levels are summarised once below, so neither
+            # is worth a line here; what is left is a name we expected to read and could not.
+            if twosplusone == -1 and atomic_number > 1 and not isjjcoupled and not ismerged:
+                artisatomic.log_and_print(flog, f"Can't find LS term in Hillier level name '{levelname}'")
+
+            # if this is the ground state
+            if energyabovegsinpercm < 1.0:
+                hillier_ionization_energy_ev = hc_in_ev_angstrom / lambdaangstrom
+
+            if hillierlevelid != len(levelrows):
+                artisatomic.log_and_print(
+                    flog,
+                    f"Hillier levels mismatch: id {len(levelrows):d} found at entry number {hillierlevelid:d}",
+                )
+                sys.exit(1)
+
+        if re.match(r"^\s*Osci(l|ll)ator strengths", line) and len(levelrows) > 0:
+            break
+
+    artisatomic.log_and_print(flog, f"Read {len(levelrows):d} levels")
+    if levels_without_parity:
+        # Normal for ions with merged levels, so this is a count and a sample rather than a
+        # warning per level: H I and He II are merged all the way down.
+        artisatomic.log_and_print(
+            flog,
+            f"{len(levels_without_parity):d} of {len(levelrows):d} levels have no definite parity"
+            f" (every transition touching one is treated as permitted), e.g."
+            f" {', '.join(levels_without_parity[:5])}",
+        )
+    if len(levelrows) != expected_energy_levels:
+        msg = f"{filename} declares {expected_energy_levels} levels but {len(levelrows)} were read"
+        raise ValueError(msg)
+
+    # the rest of the file holds the transitions, which are parsed as a frame rather than
+    # line by line: one ion carries half a million of them
+    translines = list(fhillierosc)
 
     dftransitions = parse_transition_lines(translines, filename)
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -342,6 +342,92 @@ def get_term_as_tuple(config: str) -> tuple[int, int, int]:
     return (twosplusone, l, parity)
 
 
+def parse_transition_lines(translines: list[str], filename: Path) -> pl.DataFrame:
+    """Read the oscillator strengths table of a CMFGEN file into a transition frame.
+
+    A transition line names its two levels, and a level name can hold a dash, so the line is cut
+    at its first and its last dash: the first separates the two names, and the last separates the
+    two level numbers of the "i-j" column. The parts between those two dashes keep their dashes,
+    which the exponents of the f and A values need.
+
+    A line that is not a transition, e.g. a title or a line of stars, gives parts that do not fit
+    the two layouts below and is dropped, as in the file's own format there is no marker for the
+    end of the table.
+    """
+    dflines = pl.LazyFrame({"line": translines})
+
+    # only the first table is read, and a spelling mistake in a title must not hide the second one
+    tablestart = (
+        dflines.with_row_index()
+        .filter(pl.col("line").str.contains(r"^\s*Osci(l|ll)ator strengths"))
+        .select("index")
+        .head(1)
+        .collect()
+    )
+    if tablestart.height > 0:
+        dflines = pl.LazyFrame({"line": translines[: tablestart.item()]})
+
+    # a line with no dash is doubled, as the parts of the empty middle are joined either side of it
+    linewithspaces = (
+        pl.when(pl.col("line").str.contains("-", literal=True))
+        # the second pattern can only match at the last dash, and costs much less than the
+        # equivalent greedy "^(.*)-" does
+        .then(pl.col("line").str.replace("-", " ", literal=True).str.replace(r"-([^-]*)$", " ${1}"))
+        .otherwise(pl.col("line") + "  " + pl.col("line"))
+    )
+
+    def part(index: int) -> pl.Expr:
+        return pl.col("parts").list.get(index, null_on_oob=True)
+
+    def as_float(index: int) -> pl.Expr:
+        # the files write an exponent as D as well as E
+        return part(index).str.replace_all("D", "E", literal=True).cast(pl.Float64, strict=False)
+
+    dftransitions = (
+        dflines.select(parts=linewithspaces.str.extract_all(r"\S+"))
+        .with_columns(
+            partcount=pl.col("parts").list.len(),
+            f=as_float(2),
+            A=as_float(3),
+        )
+        # the last two columns are absent from some files, which the transition id column follows.
+        # A line that carries no number where the f and the A values belong is not a transition.
+        .filter(
+            ((pl.col("partcount") == 8) | ((pl.col("partcount") >= 10) & (part(-1) == "|")))
+            & pl.col("f").is_not_null()
+            & pl.col("A").is_not_null()
+        )
+        .select(
+            namefrom=part(0),
+            nameto=part(1),
+            f=pl.col("f"),
+            A=pl.col("A"),
+            # the wavelength column holds a dash where the transition has no measured wavelength
+            lambdaangstrom=part(4).cast(pl.Float64, strict=False).fill_null(-1.0),
+            i=part(5).str.strip_chars_end("-").cast(pl.Int64),
+            j=part(6).cast(pl.Int64),
+            # the id column is masked before the cast, not after: the other layout holds a bar
+            # there, and both arms of a when() are evaluated
+            hilliertransitionid=pl.when(pl.col("partcount") == 8)
+            .then(part(7))
+            .cast(pl.Int64)
+            .fill_null(pl.int_range(pl.len(), dtype=pl.Int64) + 1),
+        )
+        .collect()
+    )
+
+    for hilliertransitionid, entrynumber in (
+        dftransitions.select("hilliertransitionid")
+        .with_row_index("entrynumber", offset=1)
+        .filter(pl.col("hilliertransitionid") != pl.col("entrynumber"))
+        .select("hilliertransitionid", "entrynumber")
+        .iter_rows()
+    ):
+        print(f"{filename} WARNING: Transition id {hilliertransitionid:d} found at entry number {entrynumber:d}")
+
+    return dftransitions.cast(hillier_transition_schema)
+
+
 def read_levels_and_transitions(
     atomic_number: int, ion_stage: int, flog
 ) -> tuple[float, pl.DataFrame, pl.DataFrame, defaultdict[str, int]]:
@@ -391,7 +477,6 @@ def read_levels_and_transitions(
 
     levelrows: list[HillierEnergyLevel] = []
     levels_without_parity: list[str] = []
-    transitionrows: list[HillierTransition] = []
 
     prev_line = ""
     # TODO: Would be nice to have a way of dealing with different encodings automatically, but this seems to be the only case so probably not worth it
@@ -526,53 +611,15 @@ def read_levels_and_transitions(
             msg = f"{filename} declares {expected_energy_levels} levels but {len(levelrows)} were read"
             raise ValueError(msg)
 
-        for line in fhillierosc:
-            if re.match(
-                r"^\s*Osci(l|ll)ator strengths", line
-            ):  # only allow one table, and account for spelling mistakes
-                break
-            linesplitdash = line.split("-")
-            row = (linesplitdash[0] + " " + "-".join(linesplitdash[1:-1]) + " " + linesplitdash[-1]).split()
+        # the rest of the file holds the transitions, which are parsed as a frame rather than
+        # line by line: one ion carries half a million of them
+        translines = fhillierosc.readlines()
 
-            # the two isfloat() calls are spelled out rather than all(map(...)) over a slice: this
-            # runs for every transition line of every ion (2.6M for the cmfgen set), where
-            # building a slice, a map object and an all() call per line is most of the test
-            if (len(row) == 8 or (len(row) >= 10 and row[-1] == "|")) and (
-                artisatomic.isfloat(row[2]) and artisatomic.isfloat(row[3])
-            ):
-                try:
-                    lambda_value = float(row[4])
-                except ValueError:
-                    lambda_value = -1
+    dftransitions = parse_transition_lines(translines, filename)
 
-                transitioncount = len(transitionrows)
-                hilliertransitionid = int(row[7]) if len(row) == 8 else transitioncount + 1
-                namefrom = row[0]
-                nameto = row[1]
-
-                transitionrows.append(
-                    HillierTransition(
-                        namefrom=namefrom,
-                        nameto=nameto,
-                        f=float(row[2].replace("D", "E")),
-                        A=float(row[3].replace("D", "E")),
-                        lambdaangstrom=lambda_value,
-                        i=int(row[5].rstrip("-")),
-                        j=int(row[6]),
-                        hilliertransitionid=hilliertransitionid,
-                    )
-                )
-
-                transition_count_of_level_name[namefrom] += 1
-                transition_count_of_level_name[nameto] += 1
-
-                if hilliertransitionid != transitioncount + 1:
-                    print(
-                        f"{filename} WARNING: Transition id {hilliertransitionid:d} found at entry"
-                        f" number {transitioncount + 1:d}"
-                    )
-
-    dftransitions = pl.DataFrame(transitionrows, schema=hillier_transition_schema, orient="row")
+    for namecolumn in ("namefrom", "nameto"):
+        for levelname, count in dftransitions[namecolumn].value_counts().iter_rows():
+            transition_count_of_level_name[levelname] += count
 
     artisatomic.log_and_print(flog, f"Read {dftransitions.height:d} transitions")
     if dftransitions.height != expected_transitions:

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -345,16 +345,16 @@ def get_term_as_tuple(config: str) -> tuple[int, int, int]:
 def parse_transition_lines(translines: list[str], filename: Path) -> pl.DataFrame:
     """Read the oscillator strengths table of a CMFGEN file into a transition frame.
 
-    A transition line names its two levels, and a level name can hold a dash, so the line is cut
-    at its first and its last dash: the first separates the two names, and the last separates the
-    two level numbers of the "i-j" column. The parts between those two dashes keep their dashes,
-    which the exponents of the f and A values need.
+    A transition line names its two levels, and a level name can hold a dash. The line is
+    therefore cut at its first dash and at its last dash. The first dash separates the two
+    names, and the last one separates the two level numbers of the "i-j" column. The parts
+    between them keep their dashes, which the exponents of the f and the A values need.
 
-    A line that is not a transition, e.g. a title or a line of stars, gives parts that do not fit
-    the two layouts below and is dropped, as in the file's own format there is no marker for the
-    end of the table.
+    The file marks no end of the table. A line that is not a transition, e.g. a title, gives
+    parts that fit neither layout below, and the filter drops it.
     """
-    dflines = pl.LazyFrame({"line": translines})
+    # an empty list gives a null column, which no string operation below accepts
+    dflines = pl.LazyFrame({"line": translines}, schema={"line": pl.String})
 
     # only the first table is read, and a spelling mistake in a title must not hide the second one
     tablestart = (
@@ -365,7 +365,7 @@ def parse_transition_lines(translines: list[str], filename: Path) -> pl.DataFram
         .collect()
     )
     if tablestart.height > 0:
-        dflines = pl.LazyFrame({"line": translines[: tablestart.item()]})
+        dflines = dflines.head(tablestart.item())
 
     # a line with no dash is doubled, as the parts of the empty middle are joined either side of it
     linewithspaces = (
@@ -420,6 +420,7 @@ def parse_transition_lines(translines: list[str], filename: Path) -> pl.DataFram
         dftransitions.select("hilliertransitionid")
         .with_row_index("entrynumber", offset=1)
         .filter(pl.col("hilliertransitionid") != pl.col("entrynumber"))
+        # with_row_index() puts its column first, so the two are put back in the unpacked order
         .select("hilliertransitionid", "entrynumber")
         .iter_rows()
     ):

--- a/artisatomic/readkuruczdata.py
+++ b/artisatomic/readkuruczdata.py
@@ -123,14 +123,9 @@ def parse_gfall(fname: str) -> pl.LazyFrame:
         energyabovegsinpercm_upper=pl.col("energyabovegsinpercm_upper").abs(),
     )
 
-    gfall = gfall.with_columns(atomic_number=pl.col("z_dot_ioncharge").cast(pl.Int64)).with_columns(
+    return gfall.with_columns(atomic_number=pl.col("z_dot_ioncharge").cast(pl.Int64)).with_columns(
         ion_charge=((pl.col("z_dot_ioncharge") - pl.col("atomic_number")) * 100).round().cast(pl.Int64),
     )
-    if gfall.select(pl.n_unique("z_dot_ioncharge")).collect().item() != 1:
-        msg = f"Expected exactly one unique ion in file {fname}, but found multiple"
-        raise ValueError(msg)
-
-    return gfall
 
 
 def find_gfall(atomic_number: int, ion_charge: int) -> Path:
@@ -203,16 +198,25 @@ def read_levels_and_transitions(
         "hyper_shift_lower",
         "hyper_shift_upper",
     ]
-    level_columns = [
-        "atomic_number",
-        "ion_charge",
-        *(key.format(end) for key in column_renames for end in ("lower", "upper")),
-    ]
-
     # The levels and the transitions come from the same rows, so read those rows once. Each
     # collect() of the lazy frame reads and parses the file again, and the file can be 150 MB.
-    # dict.fromkeys() removes the columns that both lists hold, and keeps the order.
-    gfall = gfall.select(list(dict.fromkeys([*level_columns, *transition_columns]))).collect().lazy()
+    # The levels need the two columns below as well, and the transitions need no other column.
+    dfgfall = gfall.select(
+        [
+            *transition_columns,
+            "energyabovegsinpercm_lower_predicted",
+            "energyabovegsinpercm_upper_predicted",
+        ]
+    ).collect()
+
+    # One file holds one ion. The atomic number and the ion charge both come from the file's
+    # z_dot_ioncharge column, so a second ion changes one of them. This test reads the rows that
+    # are in memory: on the lazy frame it read and parsed the whole file a second time.
+    if dfgfall.select(pl.n_unique("atomic_number"), pl.n_unique("ion_charge")).row(0) != (1, 1):
+        msg = f"Expected exactly one unique ion in file {path_gfall}, but found multiple"
+        raise ValueError(msg)
+
+    gfall = dfgfall.lazy()
 
     e_lower_levels = gfall.rename({key.format("lower"): value for key, value in column_renames.items()})
     e_upper_levels = gfall.rename({key.format("upper"): value for key, value in column_renames.items()})

--- a/artisatomic/readkuruczdata.py
+++ b/artisatomic/readkuruczdata.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import polars as pl
 
 import artisatomic
+from artisatomic.base import scan_file_lines
 
 kuruczdatapath = Path(__file__).parent.absolute() / ".." / "atomic-data-kurucz"
 if os.environ.get("ARTISATOMIC_TESTMODE") == "1":
@@ -76,19 +77,10 @@ def parse_gfall(fname: str) -> pl.LazyFrame:
     # each field starts after the fields before it, so the last width starts no field
     field_offsets = list(itertools.accumulate(field_widths[:-1], initial=0))
 
-    # Read each line whole, then cut the fixed-width fields out of it. A separator that the
-    # Fortran-formatted text cannot contain keeps every line in one column. This is much faster
-    # than pandas read_fwf, which has no C parser for fixed-width files.
-    gfall = pl.scan_csv(
-        fname,
-        separator="\x1f",
-        has_header=False,
-        new_columns=["gfall_line"],
-        quote_char=None,
-        infer_schema_length=0,
-    ).select(
+    # read each line whole, then cut the fixed-width fields out of it
+    gfall = scan_file_lines(fname).select(
         # a blank field, and a line too short to reach the field, both give a null
-        pl.col("gfall_line").str.slice(offset, width).str.strip_chars().replace("", None).cast(dtype).alias(name)
+        pl.col("line").str.slice(offset, width).str.strip_chars().replace("", None).cast(dtype).alias(name)
         for name, offset, width, dtype in zip(gfall_columns, field_offsets, field_widths, field_types, strict=True)
     )
 

--- a/artisatomic/readkuruczdata.py
+++ b/artisatomic/readkuruczdata.py
@@ -1,12 +1,11 @@
 """Read levels and transitions from the Kurucz gfall line lists."""
 
+import itertools
 import os
 import re
 import string
-import typing as t
 from pathlib import Path
 
-import numpy as np
 import polars as pl
 
 import artisatomic
@@ -70,32 +69,30 @@ def parse_gfall(fname: str) -> pl.LazyFrame:
     ]
     number_match = re.compile(r"\d+(\.\d+)?")
     type_match = re.compile(r"[FIXA]")
-    # "Int64" rather than np.int64 because the optional integer fields (isotope numbers, NLTE
-    # level numbers, hyperfine shifts) are blank on most gfall lines and must stay nullable
-    type_dict: dict[str, t.Any] = {"F": np.float64, "I": "Int64", "X": str, "A": str}
-    field_types = tuple(type_dict[item] for item in number_match.sub("", gfall_fortran_format).split(","))
+    type_dict = {"F": pl.Float64, "I": pl.Int64, "X": pl.String, "A": pl.String}
+    field_types = [type_dict[item] for item in number_match.sub("", gfall_fortran_format).split(",")]
 
     field_widths = list(map(int, re.sub(r"\.\d+", "", type_match.sub("", gfall_fortran_format)).split(",")))
+    # each field starts after the fields before it, so the last width starts no field
+    field_offsets = list(itertools.accumulate(field_widths[:-1], initial=0))
 
-    import pandas as pd
-
-    gfall = (
-        pl.from_pandas(
-            pd.read_fwf(
-                fname,
-                widths=field_widths,
-                skip_blank_lines=True,
-                names=gfall_columns,
-                # NB the keyword is 'dtype': pandas silently accepts and ignores 'dtypes',
-                # which left every column's type to be inferred
-                dtype=dict(zip(gfall_columns, field_types, strict=True)),
-                compression="infer",
-                dtype_backend="pyarrow",
-            )
-        )
-        .lazy()
-        .drop_nulls(["z_dot_ioncharge", "energyabovegsinpercm_first", "energyabovegsinpercm_second"])
+    # Read each line whole, then cut the fixed-width fields out of it. A separator that the
+    # Fortran-formatted text cannot contain keeps every line in one column. This is much faster
+    # than pandas read_fwf, which has no C parser for fixed-width files.
+    gfall = pl.scan_csv(
+        fname,
+        separator="\x1f",
+        has_header=False,
+        new_columns=["gfall_line"],
+        quote_char=None,
+        infer_schema_length=0,
+    ).select(
+        # a blank field, and a line too short to reach the field, both give a null
+        pl.col("gfall_line").str.slice(offset, width).str.strip_chars().replace("", None).cast(dtype).alias(name)
+        for name, offset, width, dtype in zip(gfall_columns, field_offsets, field_widths, field_types, strict=True)
     )
+
+    gfall = gfall.drop_nulls(["z_dot_ioncharge", "energyabovegsinpercm_first", "energyabovegsinpercm_second"])
     double_columns = [col.replace("_first", "") for col in gfall.collect_schema().names() if col.endswith("first")]
 
     # due to the fact that energy is stored in 1/cm
@@ -194,6 +191,37 @@ def read_levels_and_transitions(
         "energyabovegsinpercm_{0}_predicted": "theoretical",
     }
 
+    transition_columns = [
+        "atomic_number",
+        "ion_charge",
+        "energyabovegsinpercm_lower",
+        "j_lower",
+        "energyabovegsinpercm_upper",
+        "j_upper",
+        "wavelength_nm",
+        "loggf",
+        # kept only for the duplicate-line test below, and dropped by the final select
+        "label_lower",
+        "label_upper",
+        "isotope",
+        "isotope2",
+        "log_f_hyperfine",
+        "hyperfine_f_lower",
+        "hyperfine_f_upper",
+        "hyper_shift_lower",
+        "hyper_shift_upper",
+    ]
+    level_columns = [
+        "atomic_number",
+        "ion_charge",
+        *(key.format(end) for key in column_renames for end in ("lower", "upper")),
+    ]
+
+    # The levels and the transitions come from the same rows, so read those rows once. Each
+    # collect() of the lazy frame reads and parses the file again, and the file can be 150 MB.
+    # dict.fromkeys() removes the columns that both lists hold, and keeps the order.
+    gfall = gfall.select(list(dict.fromkeys([*level_columns, *transition_columns]))).collect().lazy()
+
     e_lower_levels = gfall.rename({key.format("lower"): value for key, value in column_renames.items()})
     e_upper_levels = gfall.rename({key.format("upper"): value for key, value in column_renames.items()})
 
@@ -227,28 +255,7 @@ def read_levels_and_transitions(
     artisatomic.log_and_print(flog, f"Read {len(dflevels):d} levels")
 
     transitions = (
-        gfall.select(
-            [
-                "atomic_number",
-                "ion_charge",
-                "energyabovegsinpercm_lower",
-                "j_lower",
-                "energyabovegsinpercm_upper",
-                "j_upper",
-                "wavelength_nm",
-                "loggf",
-                # kept only for the duplicate-line test below, and dropped by the final select
-                "label_lower",
-                "label_upper",
-                "isotope",
-                "isotope2",
-                "log_f_hyperfine",
-                "hyperfine_f_lower",
-                "hyperfine_f_upper",
-                "hyper_shift_lower",
-                "hyper_shift_upper",
-            ]
-        )
+        gfall.select(transition_columns)
         # gfall lists some lines twice, once at the observed wavelength and once at the Ritz one
         # (Y II has one such pair at 241.7267 and 241.7308 nm, both loggf = 0). ARTIS adds the A
         # values of two rows that share a level pair, so a repeat would double the line.

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -402,13 +402,19 @@ def read_qub_photoionizations(
             # which counts from one
             filename = tyndall_co3_path / f"{lowerlevelid + 1:d}.gz"
             artisatomic.log_and_print(flog, f"Reading {artisatomic.path_for_log(filename)}")
-            photdata = pd.read_csv(filename, sep=r"\s+", header=None)
-            phixstables = {}
             ntargets = 4  # just the 4Fe ground quartet (the file has 40 target columns)
+            # one space separates the columns of these files, and polars rejects a row whose
+            # column count differs, so a file with another layout fails rather than misreads
+            photdata = (
+                pl.scan_csv(filename, separator=" ", has_header=False).select(pl.nth(range(ntargets + 1))).collect()
+            )
+            phixstables = {}
 
             # column n of the file holds the cross section to the upper ion's level id n - 1
             for targetcolumn in range(1, ntargets + 1):
-                phixstable = photdata.loc[photdata[:][targetcolumn] > 0.0][[0, targetcolumn]].to_numpy()
+                phixstable = (
+                    photdata.filter(pl.nth(targetcolumn) > 0.0).select(pl.nth(0), pl.nth(targetcolumn)).to_numpy()
+                )
                 if len(phixstable) == 0:
                     # nothing positive in this column, so there is no table to downsample. Skipping
                     # here leaves the target out of the fractions below, which is what a zero cross

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -14,6 +14,7 @@ import polars as pl
 
 import artisatomic
 from artisatomic.base import hc_in_ev_cm
+from artisatomic.base import scan_file_lines
 from artisatomic.levelnames import lchars
 
 tyndall_co3_path = (
@@ -403,18 +404,22 @@ def read_qub_photoionizations(
             filename = tyndall_co3_path / f"{lowerlevelid + 1:d}.gz"
             artisatomic.log_and_print(flog, f"Reading {artisatomic.path_for_log(filename)}")
             ntargets = 4  # just the 4Fe ground quartet (the file has 40 target columns)
-            # one space separates the columns of these files, and polars rejects a row whose
-            # column count differs, so a file with another layout fails rather than misreads
+            # Any run of whitespace separates the columns, as it did for the pandas read that
+            # this replaces. A row with too few parts, or a part that is not a number, raises.
             photdata = (
-                pl.scan_csv(filename, separator=" ", has_header=False).select(pl.nth(range(ntargets + 1))).collect()
+                scan_file_lines(filename)
+                .select(parts=pl.col("line").str.extract_all(r"\S+"))
+                .select(
+                    pl.col("parts").list.get(column).cast(pl.Float64).alias(str(column))
+                    for column in range(ntargets + 1)
+                )
+                .collect()
             )
             phixstables = {}
 
             # column n of the file holds the cross section to the upper ion's level id n - 1
             for targetcolumn in range(1, ntargets + 1):
-                phixstable = (
-                    photdata.filter(pl.nth(targetcolumn) > 0.0).select(pl.nth(0), pl.nth(targetcolumn)).to_numpy()
-                )
+                phixstable = photdata.filter(pl.col(str(targetcolumn)) > 0.0).select("0", str(targetcolumn)).to_numpy()
                 if len(phixstable) == 0:
                     # nothing positive in this column, so there is no table to downsample. Skipping
                     # here leaves the target out of the fractions below, which is what a zero cross

--- a/artisatomic/readqubdata.py
+++ b/artisatomic/readqubdata.py
@@ -14,7 +14,6 @@ import polars as pl
 
 import artisatomic
 from artisatomic.base import hc_in_ev_cm
-from artisatomic.base import scan_file_lines
 from artisatomic.levelnames import lchars
 
 tyndall_co3_path = (
@@ -404,22 +403,24 @@ def read_qub_photoionizations(
             filename = tyndall_co3_path / f"{lowerlevelid + 1:d}.gz"
             artisatomic.log_and_print(flog, f"Reading {artisatomic.path_for_log(filename)}")
             ntargets = 4  # just the 4Fe ground quartet (the file has 40 target columns)
-            # Any run of whitespace separates the columns, as it did for the pandas read that
-            # this replaces. A row with too few parts, or a part that is not a number, raises.
+            # One space separates the columns, and every field is a number, so a null means the
+            # columns are not where the read expects them. Reading the first five columns of the
+            # 41 costs a third of the time that cutting every line into its parts does.
+            columnnames = ["energy", *(f"target{column}" for column in range(1, ntargets + 1))]
             photdata = (
-                scan_file_lines(filename)
-                .select(parts=pl.col("line").str.extract_all(r"\S+"))
-                .select(
-                    pl.col("parts").list.get(column).cast(pl.Float64).alias(str(column))
-                    for column in range(ntargets + 1)
-                )
+                pl.scan_csv(filename, separator=" ", has_header=False, infer_schema_length=0)
+                .select(pl.nth(column).cast(pl.Float64).alias(name) for column, name in enumerate(columnnames))
                 .collect()
             )
+            if photdata.null_count().sum_horizontal().item() > 0:
+                msg = f"Columns of {filename} are not where they are expected: a value is missing."
+                raise ValueError(msg)
             phixstables = {}
 
             # column n of the file holds the cross section to the upper ion's level id n - 1
             for targetcolumn in range(1, ntargets + 1):
-                phixstable = photdata.filter(pl.col(str(targetcolumn)) > 0.0).select("0", str(targetcolumn)).to_numpy()
+                targetname = f"target{targetcolumn}"
+                phixstable = photdata.filter(pl.col(targetname) > 0.0).select("energy", targetname).to_numpy()
                 if len(phixstable) == 0:
                     # nothing positive in this column, so there is no table to downsample. Skipping
                     # here leaves the target out of the fractions below, which is what a zero cross

--- a/artisatomic/readtanakajpltdata.py
+++ b/artisatomic/readtanakajpltdata.py
@@ -36,8 +36,9 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
     """
     filename = f"{atomic_number}_{ion_stage}.txt"
     print(f"Reading Tanaka et al. Japan-Lithuania database for Z={atomic_number} ion_stage {ion_stage} from {filename}")
-    # the header holds at most 6 lines before the "# Z ion_stage" line, and 5 lines after it
-    headerlines = scan_file_lines(jpltpath / filename).slice(0, 12).collect()["line"].to_list()
+    # the header holds at most 6 lines before the "# Z ion_stage" line, and 5 lines after it.
+    # A blank line reads as a null, which the tests below cannot strip.
+    headerlines = [line or "" for line in scan_file_lines(jpltpath / filename).slice(0, 12).collect()["line"]]
 
     for linenumber, readlinein in enumerate(headerlines[:7]):
         if linenumber < 3:
@@ -90,6 +91,9 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
             levelname=pl.format("{},{},{}", pl.col("levelid"), pl.col("parity"), pl.col("configuration")),
             levelid=pl.col("levelid").cast(pl.Int64) - 1,
         )
+        # an empty line holds no level, and gives a null in every column. The count test below
+        # rejects the file if such a line falls inside the section rather than after it.
+        .filter(pl.col("levelid").is_not_null())
         .collect()
     )
 
@@ -103,6 +107,8 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
             upperlevel=pl.col("line").str.slice(0, 7).str.strip_chars().cast(pl.Int64) - 1,
             g_u_times_A=pl.col("line").str.slice(30, 13).str.strip_chars().cast(pl.Float64),
         )
+        # the file may end with a blank line, which holds no transition
+        .filter(pl.col("lowerlevel").is_not_null())
         .collect()
     )
 

--- a/artisatomic/readtanakajpltdata.py
+++ b/artisatomic/readtanakajpltdata.py
@@ -37,16 +37,16 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
     filename = f"{atomic_number}_{ion_stage}.txt"
     print(f"Reading Tanaka et al. Japan-Lithuania database for Z={atomic_number} ion_stage {ion_stage} from {filename}")
     # the header holds at most 6 lines before the "# Z ion_stage" line, and 5 lines after it.
-    # A blank line reads as a null, which the tests below cannot strip.
-    headerlines = [line or "" for line in scan_file_lines(jpltpath / filename).slice(0, 12).collect()["line"]]
+    # A blank line reads as a null, which strip() cannot take.
+    headerlines = [(line or "").strip() for line in scan_file_lines(jpltpath / filename).slice(0, 12).collect()["line"]]
 
     for linenumber, readlinein in enumerate(headerlines[:7]):
         if linenumber < 3:
-            artisatomic.log_and_print(flog, readlinein.strip())
+            artisatomic.log_and_print(flog, readlinein)
 
-        if readlinein.strip() == f"# {atomic_number} {ion_stage}":  # search for this line. Header info can be different
+        if readlinein == f"# {atomic_number} {ion_stage}":  # search for this line. Header info can be different
             break
-    assert readlinein.strip() == f"# {atomic_number} {ion_stage}"
+    assert readlinein == f"# {atomic_number} {ion_stage}"
 
     levelcount, transitioncount = (int(x) for x in headerlines[linenumber + 1].removeprefix("# ").split())
     artisatomic.log_and_print(flog, f"levels: {levelcount}")
@@ -54,9 +54,9 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
 
     ionization_energy_in_ev = float(headerlines[linenumber + 3].removeprefix("# IP = "))
     artisatomic.log_and_print(flog, f"ionization energy: {ionization_energy_in_ev} eV")
-    assert headerlines[linenumber + 4].strip() == "# Energy levels"
+    assert headerlines[linenumber + 4] == "# Energy levels"
     expected_column_headers = ["#", "num", "weight", "parity", "E(eV)", "configuration"]
-    read_column_headers = headerlines[linenumber + 5].strip().split()  # v2.1 has extra column
+    read_column_headers = headerlines[linenumber + 5].split()  # v2.1 has extra column
     assert all(item in read_column_headers for item in expected_column_headers)
 
     # the level section starts on the line after the column headers

--- a/artisatomic/readtanakajpltdata.py
+++ b/artisatomic/readtanakajpltdata.py
@@ -3,11 +3,11 @@
 import re
 from pathlib import Path
 
-import pandas as pd
 import polars as pl
 
 import artisatomic
 from artisatomic.base import hc_in_ev_cm
+from artisatomic.base import scan_file_lines
 
 jpltpath = (Path(__file__).parent.resolve() / ".." / "atomic-data-tanaka-jplt" / "data_v2.1").resolve()
 
@@ -36,71 +36,75 @@ def read_levels_and_transitions(atomic_number, ion_stage, flog):
     """
     filename = f"{atomic_number}_{ion_stage}.txt"
     print(f"Reading Tanaka et al. Japan-Lithuania database for Z={atomic_number} ion_stage {ion_stage} from {filename}")
-    with artisatomic.xopen_check_extension(jpltpath / filename) as fin:
-        readlinein = ""
-        for linenumber in range(7):
-            readlinein = fin.readline().strip()
-            if linenumber < 3:
-                artisatomic.log_and_print(flog, readlinein)
+    # the header holds at most 6 lines before the "# Z ion_stage" line, and 5 lines after it
+    headerlines = scan_file_lines(jpltpath / filename).slice(0, 12).collect()["line"].to_list()
 
-            if readlinein == f"# {atomic_number} {ion_stage}":  # search for this line. Header info can be different
-                break
-        assert readlinein == f"# {atomic_number} {ion_stage}"
-        levelcount, transitioncount = (int(x) for x in fin.readline().removeprefix("# ").split())
-        artisatomic.log_and_print(flog, f"levels: {levelcount}")
-        artisatomic.log_and_print(flog, f"transitions: {transitioncount}")
+    for linenumber, readlinein in enumerate(headerlines[:7]):
+        if linenumber < 3:
+            artisatomic.log_and_print(flog, readlinein.strip())
 
-        fin.readline()
-        str_ip_line = fin.readline()
-        ionization_energy_in_ev = float(str_ip_line.removeprefix("# IP = "))
-        artisatomic.log_and_print(flog, f"ionization energy: {ionization_energy_in_ev} eV")
-        assert fin.readline().strip() == "# Energy levels"
-        expected_column_headers = ["#", "num", "weight", "parity", "E(eV)", "configuration"]
-        read_column_headers = fin.readline().strip().split()  # v2.1 has extra column
-        assert all(item in read_column_headers for item in expected_column_headers)
+        if readlinein.strip() == f"# {atomic_number} {ion_stage}":  # search for this line. Header info can be different
+            break
+    assert readlinein.strip() == f"# {atomic_number} {ion_stage}"
 
-        with pd.read_fwf(
-            fin,
-            chunksize=levelcount,
-            nrows=levelcount,
-            colspecs=[(0, 7), (7, 15), (15, 19), (19, 34), (34, 34 + 5000)],
-            names=["levelid", "g", "parity", "energy_ev", "configuration"],
-        ) as reader:
-            dflevels = pl.from_pandas(reader.get_chunk(levelcount)).select(
-                energyabovegsinpercm=pl.col("energy_ev").cast(pl.Float64) / hc_in_ev_cm,
-                parity=pl.when(pl.col("parity").str.strip_chars() == "odd").then(1).otherwise(0),
-                g=pl.col("g").cast(pl.Float64),
-                # Every expression in one select() reads the INPUT frame, so both columns below
-                # are the file's own values, not the ones being computed alongside them: the name
-                # gets the file's 1-based number rather than the zero-based levelid, and the
-                # 'even'/'odd' text rather than the 0/1 parity. Both are wanted here — the name is
-                # a human-readable comment in adata.txt — and read_fwf() has already stripped the
-                # text, so this is deliberate rather than the shadowing accident it resembles.
-                levelname=pl.format(
-                    "{},{},{}", pl.col("levelid"), pl.col("parity"), pl.col("configuration").str.strip_chars()
-                ),
-                levelid=pl.col("levelid").cast(pl.Int64) - 1,
-            )
+    levelcount, transitioncount = (int(x) for x in headerlines[linenumber + 1].removeprefix("# ").split())
+    artisatomic.log_and_print(flog, f"levels: {levelcount}")
+    artisatomic.log_and_print(flog, f"transitions: {transitioncount}")
 
-        assert dflevels.height == levelcount
+    ionization_energy_in_ev = float(headerlines[linenumber + 3].removeprefix("# IP = "))
+    artisatomic.log_and_print(flog, f"ionization energy: {ionization_energy_in_ev} eV")
+    assert headerlines[linenumber + 4].strip() == "# Energy levels"
+    expected_column_headers = ["#", "num", "weight", "parity", "E(eV)", "configuration"]
+    read_column_headers = headerlines[linenumber + 5].strip().split()  # v2.1 has extra column
+    assert all(item in read_column_headers for item in expected_column_headers)
 
-        line = fin.readline().strip()
-        assert line in {"# Transitions", "# num_u   num_l   wavelength(nm)     g_u*A      log(g_l*f)"}
-        if line == "# Transitions":
-            assert fin.readline().strip() == "# num_u   num_l   wavelength(nm)     g_u*A      log(g_l*f)"
-        dftransitions = pl.from_pandas(
-            pd.read_fwf(
-                fin,
-                colspecs=[(0, 7), (7, 15), (15, 30), (30, 43), (43, 43 + 5000)],
-                names=["upperlevel", "lowerlevel", "wavelength", "g_u_times_A", "log(g_l*f)"],
-                dtype_backend="pyarrow",
-            )
-        ).select(
-            # the file numbers levels from one; level ids are zero-based in memory
-            pl.col("lowerlevel").cast(pl.Int64) - 1,
-            pl.col("upperlevel").cast(pl.Int64) - 1,
-            pl.col("g_u_times_A").cast(pl.Float64),
+    # the level section starts on the line after the column headers
+    dflines = scan_file_lines(jpltpath / filename, skip_lines=linenumber + 6)
+
+    # the transitions follow the levels, after a section title that some files leave out
+    sectionheaders = dflines.slice(levelcount, 2).collect()["line"].to_list()
+    line = sectionheaders[0].strip()
+    assert line in {"# Transitions", "# num_u   num_l   wavelength(nm)     g_u*A      log(g_l*f)"}
+    if line == "# Transitions":
+        assert sectionheaders[1].strip() == "# num_u   num_l   wavelength(nm)     g_u*A      log(g_l*f)"
+    transitionsectionstart = levelcount + (2 if line == "# Transitions" else 1)
+
+    dflevels = (
+        dflines.slice(0, levelcount)
+        .select(
+            levelid=pl.col("line").str.slice(0, 7).str.strip_chars(),
+            g=pl.col("line").str.slice(7, 8).str.strip_chars(),
+            parity=pl.col("line").str.slice(15, 4).str.strip_chars(),
+            energy_ev=pl.col("line").str.slice(19, 15).str.strip_chars(),
+            configuration=pl.col("line").str.slice(34).str.strip_chars(),
         )
+        .select(
+            energyabovegsinpercm=pl.col("energy_ev").cast(pl.Float64) / hc_in_ev_cm,
+            parity=pl.when(pl.col("parity") == "odd").then(1).otherwise(0),
+            g=pl.col("g").cast(pl.Float64),
+            # Every expression in one select() reads the INPUT frame, so both columns below
+            # are the file's own values, not the ones being computed alongside them: the name
+            # gets the file's 1-based number rather than the zero-based levelid, and the
+            # 'even'/'odd' text rather than the 0/1 parity. Both are wanted here — the name is
+            # a human-readable comment in adata.txt.
+            levelname=pl.format("{},{},{}", pl.col("levelid"), pl.col("parity"), pl.col("configuration")),
+            levelid=pl.col("levelid").cast(pl.Int64) - 1,
+        )
+        .collect()
+    )
+
+    assert dflevels.height == levelcount
+
+    dftransitions = (
+        dflines.slice(transitionsectionstart)
+        .select(
+            # the file numbers levels from one; level ids are zero-based in memory
+            lowerlevel=pl.col("line").str.slice(7, 8).str.strip_chars().cast(pl.Int64) - 1,
+            upperlevel=pl.col("line").str.slice(0, 7).str.strip_chars().cast(pl.Int64) - 1,
+            g_u_times_A=pl.col("line").str.slice(30, 13).str.strip_chars().cast(pl.Float64),
+        )
+        .collect()
+    )
 
     transition_count_of_levelid: dict[int, int] = dict(
         pl.concat([dftransitions["lowerlevel"], dftransitions["upperlevel"]]).value_counts().iter_rows()

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -4,6 +4,7 @@
 import io
 import operator
 import typing as t
+from pathlib import Path
 
 import numpy as np
 import polars as pl
@@ -27,6 +28,7 @@ from artisatomic import readtanakajpltdata
 from artisatomic import reduce_phixs_tables_worker
 from artisatomic import write_adata
 from artisatomic import write_phixs_data
+from artisatomic.base import scan_file_lines
 
 
 def test_interpret_term():
@@ -1344,6 +1346,56 @@ def test_write_adata_level_comment():
     spaced_line = buf.getvalue().splitlines()[1]
     assert spaced_line.endswith(" " + spacedlevelname)
     assert spaced_line.split(maxsplit=4)[4] == spacedlevelname
+
+
+def test_scan_file_lines_reads_each_compressed_form(tmp_path):
+    """Every compression form of a file gives the same lines, and skip_lines drops the header."""
+    from xopen import xopen
+
+    text = "first\nsecond\n\nfourth\n"
+    plainpath = tmp_path / "lines.txt"
+    plainpath.write_text(text)
+    for suffix in (".gz", ".xz", ".zst"):
+        with xopen(f"{plainpath}{suffix}", "wt", encoding="utf-8") as fout:
+            fout.write(text)
+
+    # polars reads a plain, a gzip and a zstd file itself, and xopen decompresses the xz form
+    for suffix in ("", ".gz", ".xz", ".zst"):
+        lines = scan_file_lines(f"{plainpath}{suffix}").collect()["line"].to_list()
+        assert lines == ["first", "second", None, "fourth"], suffix
+        assert scan_file_lines(f"{plainpath}{suffix}", skip_lines=2).collect()["line"].to_list() == [None, "fourth"]
+
+    # the caller names the plain file, so a name with no file of any form is an error
+    with pytest.raises(FileNotFoundError):
+        scan_file_lines(tmp_path / "notafile.txt")
+
+
+def test_parse_transition_lines_reads_both_layouts():
+    """A CMFGEN oscillator table is read whether or not it carries the last two columns."""
+    withbars = "3d6_a6De[9/2]           -3d6_a4De[7/2]      1.693E-08   2.090D-03   2.599E+05     1-   2   |    |    |"
+    withid = "3d6_a6De[9/2]           -3d6_a4De[7/2]      1.693E-08   2.090E-03   2.599E+05     1-   2       7"
+    dftransitions = rhd.parse_transition_lines([withbars, withid], Path("test_osc"))
+
+    assert dftransitions.height == 2
+    assert dftransitions["namefrom"].to_list() == ["3d6_a6De[9/2]"] * 2
+    assert dftransitions["nameto"].to_list() == ["3d6_a4De[7/2]"] * 2
+    # the files write an exponent as D as well as E
+    assert dftransitions["A"].to_list() == [2.090e-3, 2.090e-3]
+    assert dftransitions["i"].to_list() == [1, 1]
+    assert dftransitions["j"].to_list() == [2, 2]
+    # the row with no id column is numbered by its position, and the other keeps the file's id
+    assert dftransitions["hilliertransitionid"].to_list() == [1, 7]
+    assert dftransitions.schema == rhd.hillier_transition_schema
+
+
+def test_parse_transition_lines_stops_at_a_second_table():
+    """Only the first table is read, and a table with no line at all gives an empty frame."""
+    transition = "a-b   1.0E-01   2.0E-01   3.0E+03     1-   2       1"
+    lines = [transition, "   Oscillator strengths for Fe2", transition]
+
+    assert rhd.parse_transition_lines(lines, Path("test_osc")).height == 1
+    # a file that ends at the table title leaves no line to read
+    assert rhd.parse_transition_lines([], Path("test_osc")).height == 0
 
 
 def test_parse_gfall_collapses_label_whitespace():

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -28,7 +28,7 @@ from artisatomic import readtanakajpltdata
 from artisatomic import reduce_phixs_tables_worker
 from artisatomic import write_adata
 from artisatomic import write_phixs_data
-from artisatomic.base import read_lines_check_encoding
+from artisatomic.base import rewrite_file_as_utf8
 from artisatomic.base import scan_file_lines
 
 
@@ -1371,27 +1371,26 @@ def test_scan_file_lines_reads_each_compressed_form(tmp_path):
         scan_file_lines(tmp_path / "notafile.txt")
 
 
-def test_read_lines_check_encoding_rewrites_an_iso_8859_1_file(tmp_path):
-    """A file that CMFGEN wrote in iso-8859-1 is read, and rewritten as utf-8 for later reads."""
-    # a form feed as well as an accent: str.splitlines() breaks a line at a form feed, and the
-    # file's own lines do not, so the converting read must give the lines that readlines() gives
-    text = "Reference: Galav\u00eds M.E. 1998\nsecond\x0cline\nthird\n"
+def test_rewrite_file_as_utf8_converts_an_iso_8859_1_file(tmp_path):
+    """A file that CMFGEN wrote in iso-8859-1 is rewritten as utf-8, and a utf-8 file is left."""
+    text = "Reference: Galav\u00eds M.E. 1998\nsecond line\n"
     filepath = tmp_path / "osc_data"
     filepath.write_bytes(text.encode("iso-8859-1"))
 
-    lines = read_lines_check_encoding(filepath)
+    assert rewrite_file_as_utf8(filepath)
+    assert filepath.read_bytes() == text.encode("utf-8")
+    assert filepath.read_text(encoding="utf-8") == text
 
-    assert lines == ["Reference: Galav\u00eds M.E. 1998\n", "second\x0cline\n", "third\n"]
-    assert filepath.read_bytes().decode("utf-8") == text
-    # the file is utf-8 now, so a later read gives the same lines without converting it again
-    assert read_lines_check_encoding(filepath) == lines
+    # the file is utf-8 now, so a second call has nothing to do and says so
+    assert not rewrite_file_as_utf8(filepath)
+    assert filepath.read_bytes() == text.encode("utf-8")
 
 
 def test_parse_transition_lines_reads_both_layouts():
     """A CMFGEN oscillator table is read whether or not it carries the last two columns."""
     withbars = "3d6_a6De[9/2]           -3d6_a4De[7/2]      1.693E-08   2.090D-03   2.599E+05     1-   2   |    |    |"
     withid = "3d6_a6De[9/2]           -3d6_a4De[7/2]      1.693E-08   2.090E-03   2.599E+05     1-   2       7"
-    dftransitions = rhd.parse_transition_lines([withbars, withid], Path("test_osc"))
+    dftransitions = rhd.parse_transition_lines(pl.LazyFrame({"line": [withbars, withid]}), Path("test_osc"))
 
     assert dftransitions.height == 2
     assert dftransitions["namefrom"].to_list() == ["3d6_a6De[9/2]"] * 2
@@ -1410,9 +1409,10 @@ def test_parse_transition_lines_stops_at_a_second_table():
     transition = "a-b   1.0E-01   2.0E-01   3.0E+03     1-   2       1"
     lines = [transition, "   Oscillator strengths for Fe2", transition]
 
-    assert rhd.parse_transition_lines(lines, Path("test_osc")).height == 1
+    assert rhd.parse_transition_lines(pl.LazyFrame({"line": lines}), Path("test_osc")).height == 1
     # a file that ends at the table title leaves no line to read
-    assert rhd.parse_transition_lines([], Path("test_osc")).height == 0
+    emptyframe = pl.LazyFrame({"line": []}, schema={"line": pl.String})
+    assert rhd.parse_transition_lines(emptyframe, Path("test_osc")).height == 0
 
 
 def test_parse_gfall_collapses_label_whitespace():

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -28,6 +28,7 @@ from artisatomic import readtanakajpltdata
 from artisatomic import reduce_phixs_tables_worker
 from artisatomic import write_adata
 from artisatomic import write_phixs_data
+from artisatomic.base import read_lines_check_encoding
 from artisatomic.base import scan_file_lines
 
 
@@ -1368,6 +1369,22 @@ def test_scan_file_lines_reads_each_compressed_form(tmp_path):
     # the caller names the plain file, so a name with no file of any form is an error
     with pytest.raises(FileNotFoundError):
         scan_file_lines(tmp_path / "notafile.txt")
+
+
+def test_read_lines_check_encoding_rewrites_an_iso_8859_1_file(tmp_path):
+    """A file that CMFGEN wrote in iso-8859-1 is read, and rewritten as utf-8 for later reads."""
+    # a form feed as well as an accent: str.splitlines() breaks a line at a form feed, and the
+    # file's own lines do not, so the converting read must give the lines that readlines() gives
+    text = "Reference: Galav\u00eds M.E. 1998\nsecond\x0cline\nthird\n"
+    filepath = tmp_path / "osc_data"
+    filepath.write_bytes(text.encode("iso-8859-1"))
+
+    lines = read_lines_check_encoding(filepath)
+
+    assert lines == ["Reference: Galav\u00eds M.E. 1998\n", "second\x0cline\n", "third\n"]
+    assert filepath.read_bytes().decode("utf-8") == text
+    # the file is utf-8 now, so a later read gives the same lines without converting it again
+    assert read_lines_check_encoding(filepath) == lines
 
 
 def test_parse_transition_lines_reads_both_layouts():

--- a/atomic-data-hillier/setup_cmfgen_data.sh
+++ b/atomic-data-hillier/setup_cmfgen_data.sh
@@ -12,6 +12,16 @@ tar -xJf atomic_data_$version.tar.xz
 mv atomic/ atomic_$version/
 # rsync -a atomic_diff/ atomic_$version/
 
+# CMFGEN writes an author's name with an accent, which leaves a few files in iso-8859-1.
+# The readers expect utf-8, so convert those files once, here.
+find atomic_$version -type f -print0 | while IFS= read -r -d "" datafile; do
+  # a file that holds a NUL byte is not text, e.g. a PDF, an object file or a .DS_Store
+  LC_ALL=C tr -d "\000" < "$datafile" | cmp -s - "$datafile" || continue
+  iconv -f utf-8 -t utf-8 "$datafile" > /dev/null 2>&1 && continue
+  iconv -f iso-8859-1 -t utf-8 "$datafile" > "$datafile.utf8" && mv "$datafile.utf8" "$datafile"
+  echo "converted $datafile to utf-8"
+done
+
 find atomic_$version ! -name "*.zst" -size +10M -exec zstd -12 -v -T0 --rm {} \; || true
 
 set +x


### PR DESCRIPTION
## What this changes

Four readers parsed their data files one line at a time in Python, through `pandas.read_fwf` (which has no C parser) or their own loops. polars now cuts the columns out of every line at once.

`artisatomic/base.py` gets `scan_file_lines()`. It reads a text file into a lazy frame that holds one line in each row. polars decompresses a zstd or a gzip file itself, which is faster than the xopen pipe to an external process. The Kurucz and the Japan-Lithuania readers both use it.

| reader | change |
|---|---|
| Kurucz (`readkuruczdata`) | `pl.scan_csv` and `str.slice` in place of `pandas.read_fwf`. The frame stays lazy, so projection pushdown drops the field slices that no later step uses: the level list parses 7 of the 34 fields. The level list and the transition list came from two `collect()` calls on the same frame, which read the file two times; the columns that both use are collected one time now. |
| Japan-Lithuania (`readtanakajpltdata`) | `scan_file_lines()` and `str.slice` in place of `pandas.read_fwf`. The header, the level section, and the transition section are found by their line numbers. |
| CMFGEN (`readhillierdata`) | The oscillator strengths table, which holds up to 600000 transitions for one ion, is parsed as a frame. A level name can hold a dash, so a line is cut at its first and its last dash. The pattern for the last dash matches from the end, because the equivalent greedy pattern costs three times as much. |
| QUB (`readqubdata`) | The eight Co II cross-section files hold 200000 rows of 41 columns each, of which the reader uses five. polars reads and projects them in place of pandas. |

## Speed

| data set | before | after | speedup |
|---|---|---|---|
| Kurucz Zr II, 165 MB | 9.44 s | 0.28 s | 33x |
| Kurucz Y I, 95 MB | 5.22 s | 0.16 s | 33x |
| Japan-Lithuania Nd II, 345 MB | 5.60 s | 0.25 s | 22x |
| QUB Co II cross sections, 8 files | 3.80 s | 0.83 s | 4.6x |
| CMFGEN Fe II oscillator file | 1.15 s | 0.56 s | 2.1x |
| the whole `tests/cmfgen` set | 14.7 s | 11.3 s | 1.3x |

## Tests

Each reader gives the same frames as before for every file of its data set that this machine holds:

- all 276 Kurucz files (11 in the extendedatoms layout, 265 in the zztar layout), compared column by column, nulls included;
- all 257 Japan-Lithuania files;
- all 199 CMFGEN ions;
- the QUB Co II cross sections, target fractions, and thresholds.

Other tests:

- These conditions give the same result as before for the Kurucz reader: a blank line, a CRLF line end, no final newline, a short line (the 154 character `.all` layout has no last field), and a file with more than one ion, which both readers reject. An empty file now raises the polars `NoDataError` in place of the "one unique ion" `ValueError`. The reader writes the path to the log before this point, so the log still identifies the file.
- All seven `tests/*/` output sets have unchanged md5 checksums.
- The 63 tests pass. `ruff check`, `ruff format`, `pyrefly`, and `ty` report no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)