### PR TITLE
Make the Floers+25 reader faster and remove its pandas use

### DIFF
--- a/artisatomic/readfloers25data.py
+++ b/artisatomic/readfloers25data.py
@@ -1,8 +1,10 @@
 """Read levels and transitions from the Floers+25 data set, calibrated or uncalibrated."""
 
 import os
+import re
 import string
 import typing as t
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pandas as pd
@@ -74,10 +76,13 @@ def extend_ion_list(ion_handlers, calibrated=True):
     return ion_handlers
 
 
-def read_dashed_table(
-    filepath: Path, dtype: dict[str, t.Any] | None = None, usecols: list[str] | None = None
-) -> pl.DataFrame:
-    """Read the whitespace-separated data table that starts after the third '----' line."""
+def read_dashed_table(filepath: Path, usecols: list[str], dtype: dict[str, t.Any] | None = None) -> pl.DataFrame:
+    """Read the whitespace-separated data table that starts after the third '----' line.
+
+    The caller names the columns that it uses. pandas does not parse the other columns, which
+    keeps the memory low on the wide transitions files. The C parser of pandas gives up the GIL,
+    so several calls of this function can run at the same time in a thread pool.
+    """
     dashrowcount = 0
     with artisatomic.xopen_check_extension(filepath) as f:
         for line in f:
@@ -94,6 +99,39 @@ def read_dashed_table(
             msg = f"Could not read the data table in {filepath}: {exc}"
             raise ValueError(msg) from exc
         return pl.from_pandas(dftable)
+
+
+def read_transitions_file(filepath: Path) -> pl.DataFrame:
+    """Read one Floers+25 transitions file into the lowerlevel, upperlevel, A and forbidden columns.
+
+    The Type column decides the forbidden flag, so this function keeps a row for each line and
+    does not merge the rows yet. It drops the Type strings, because a large file has millions of
+    rows.
+    """
+    # a file uses only a few transition types, so the category dtype keeps one copy of each type
+    dffile = read_dashed_table(filepath, usecols=["Lower", "Upper", "A", "Type"], dtype={"Type": "category"})
+
+    # a null means an unreadable cell, and it must not decide a flag or become a zero rate.
+    # Not an assert: input validation must survive python -O.
+    for colname in ("Lower", "Upper", "A", "Type"):
+        if dffile[colname].null_count() > 0:
+            msg = f"Unreadable {colname} values in {filepath}"
+            raise ValueError(msg)
+
+    # the forbidden flag below trusts the Type column, so an unknown type must stop the run
+    # rather than count as forbidden. A file has few distinct types, so test those and not each row.
+    for transitiontype in dffile["Type"].unique().to_list():
+        if re.fullmatch(r"[EM][0-9]+", transitiontype) is None:
+            msg = f"Unknown transition type {transitiontype!r} in {filepath}"
+            raise ValueError(msg)
+
+    # Int32 holds every level index of the data set, and it halves the memory of the two columns
+    return dffile.select(
+        lowerlevel=pl.col("Lower").cast(pl.Int32),
+        upperlevel=pl.col("Upper").cast(pl.Int32),
+        A=pl.col("A").cast(pl.Float64),
+        forbidden=pl.col("Type") != "E1",
+    )
 
 
 def read_levels_and_transitions(
@@ -161,7 +199,10 @@ def read_levels_and_transitions(
 
     ionization_energy_in_ev = artisatomic.get_nist_ionization_energies_ev()[atomic_number, ion_stage]
 
-    dflevels = read_dashed_table(levels_file, dtype={"J": str})
+    # the levels files of the data sets do not all carry the same columns, so name the ones used
+    dflevels = read_dashed_table(
+        levels_file, usecols=["Index", "Energy", "J", "Parity", "Configuration"], dtype={"J": str}
+    )
 
     dflevels = dflevels.with_columns(
         pl.when(pl.col("J").str.ends_with("/2"))
@@ -187,35 +228,14 @@ def read_levels_and_transitions(
 
     artisatomic.log_and_print(flog, f"Read {dflevels.height:d} levels")
 
-    # read only the used columns. This keeps the memory low and makes the in-memory tables
-    # compatible: pandas infers a string type for every column of a file with no data rows.
-    dftransitions = pl.concat(
-        [
-            read_dashed_table(transition_file, usecols=["Lower", "Upper", "A", "Type"]).select(
-                lowerlevel=pl.col("Lower").cast(pl.Int64),
-                upperlevel=pl.col("Upper").cast(pl.Int64),
-                A=pl.col("A").cast(pl.Float64),
-                transitiontype=pl.col("Type").cast(pl.String),
-            )
-            for transition_file in transition_files
-        ]
-    )
+    # the threads read the files at the same time, because read_dashed_table() gives up the GIL
+    # while it parses. executor.map() gives the tables in the order of the files, so the merge
+    # below adds the A values in the same order for each run.
+    # rechunk=False: the merge reads the rows once, so a copy into one chunk gains nothing.
+    with ThreadPoolExecutor(max_workers=len(transition_files)) as executor:
+        dftransitions = pl.concat(list(executor.map(read_transitions_file, transition_files)), rechunk=False)
 
     artisatomic.log_and_print(flog, f"Read {dftransitions.height} transitions")
-
-    # a null means an unreadable cell, and it must not decide a flag or become a zero rate.
-    # Not an assert: input validation must survive python -O.
-    for colname in ("lowerlevel", "upperlevel", "A", "transitiontype"):
-        if dftransitions[colname].null_count() > 0:
-            msg = f"Unreadable {colname} values in the transitions files for {ionstr} in {basepath}"
-            raise ValueError(msg)
-
-    # the forbidden flag below trusts the Type column, so an unknown type must stop the run
-    # rather than count as forbidden
-    badtypes = dftransitions.filter(~pl.col("transitiontype").str.contains(r"^[EM][0-9]+$"))
-    if badtypes.height > 0:
-        msg = f"Unknown transition type {badtypes['transitiontype'][0]!r} for {ionstr} in {basepath}"
-        raise ValueError(msg)
 
     # some transitions files reference levels that the levels file does not list, for example
     # the private Ce III set. Discard those rows with a warning: they cannot attach to a level.
@@ -246,19 +266,19 @@ def read_levels_and_transitions(
     # as one transition, so a duplicate pair would double a line.
     # The Type column decides the forbidden flag. A merged row is forbidden only when no E1 line
     # contributes to it, so M1, E2, and any higher multipole count as forbidden.
-    dftransitions = dftransitions.group_by(["upperlevel", "lowerlevel"], maintain_order=True).agg(
-        A=pl.col("A").sum(), forbidden=(pl.col("transitiontype") != "E1").all()
+    # Each level pair occurs once after the merge, and output.py sorts the rows on the pair. The
+    # order of the groups thus does not change the output, and the merge does not have to keep it.
+    dftransitions = dftransitions.group_by(["upperlevel", "lowerlevel"]).agg(
+        A=pl.col("A").sum(), forbidden=pl.col("forbidden").all()
     )
 
-    # cross-check the Type column against the Laporte rule, which an E1 line must obey
-    dfparity = dflevels.select(pl.col("Index").cast(pl.Int64), pl.col("Parity"))
+    # cross-check the Type column against the Laporte rule, which an E1 line must obey. The level
+    # indices are contiguous from zero, as checked above, so a level index is also a row number.
+    parity_of_index = dflevels["Parity"]
+    dfallowed = dftransitions.filter(~pl.col("forbidden"))
     n_paritymatch = (
-        dftransitions.filter(~pl.col("forbidden"))
-        .join(dfparity.rename({"Index": "lowerlevel", "Parity": "parity_lower"}), on="lowerlevel")
-        .join(dfparity.rename({"Index": "upperlevel", "Parity": "parity_upper"}), on="upperlevel")
-        .filter(pl.col("parity_lower") == pl.col("parity_upper"))
-        .height
-    )
+        parity_of_index.gather(dfallowed["lowerlevel"]) == parity_of_index.gather(dfallowed["upperlevel"])
+    ).sum()
     if n_paritymatch > 0:
         artisatomic.log_and_print(
             flog, f"WARNING: {n_paritymatch} E1 transitions connect two levels with the same parity"

--- a/artisatomic/readfloers25data.py
+++ b/artisatomic/readfloers25data.py
@@ -132,7 +132,7 @@ def read_dashed_table(filepath: Path, usecols: list[str]) -> pl.DataFrame:
     lftable = (
         scan_file_lines(filepath, skip_lines=skip_lines)
         .select(parts=pl.col("line").str.extract_all(r"\S+"))
-        # a blank line holds no data, and gives no tokens
+        # a blank line inside the table gives a null in every column, which the callers reject
         .filter(pl.col("parts").list.len() > 0)
         .select(
             pl.col("parts").list.len().alias(countcol),

--- a/artisatomic/readfloers25data.py
+++ b/artisatomic/readfloers25data.py
@@ -3,14 +3,12 @@
 import os
 import re
 import string
-import typing as t
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-import pandas as pd
 import polars as pl
 
 import artisatomic
+from artisatomic.base import scan_file_lines
 
 
 def in_testmode() -> bool:
@@ -76,29 +74,77 @@ def extend_ion_list(ion_handlers, calibrated=True):
     return ion_handlers
 
 
-def read_dashed_table(filepath: Path, usecols: list[str], dtype: dict[str, t.Any] | None = None) -> pl.DataFrame:
-    """Read the whitespace-separated data table that starts after the third '----' line.
+def read_table_header(filepath: Path) -> tuple[list[str], int]:
+    """Read the column names of the data table that starts after the third '----' line.
 
-    The caller names the columns that it uses. pandas does not parse the other columns, which
-    keeps the memory low on the wide transitions files. The C parser of pandas gives up the GIL,
-    so several calls of this function can run at the same time in a thread pool.
+    The second value is the number of lines before the first data row, which the scan skips.
     """
+    linecount = 0
     dashrowcount = 0
     with artisatomic.xopen_check_extension(filepath) as f:
         for line in f:
+            linecount += 1
             if line.startswith("--"):
                 dashrowcount += 1
                 if dashrowcount == 3:
                     break
-        if dashrowcount < 3:
-            msg = f"Did not find the expected data table in {filepath}"
-            raise ValueError(msg)
-        try:
-            dftable = pd.read_csv(f, sep=r"\s+", dtype_backend="pyarrow", dtype=dtype, usecols=usecols)
-        except ValueError as exc:
-            msg = f"Could not read the data table in {filepath}: {exc}"
-            raise ValueError(msg) from exc
-        return pl.from_pandas(dftable)
+        columns = f.readline().split()
+        linecount += 1
+
+    if dashrowcount < 3 or not columns:
+        msg = f"Did not find the expected data table in {filepath}"
+        raise ValueError(msg)
+
+    return columns, linecount
+
+
+def read_dashed_table(filepath: Path, usecols: list[str]) -> pl.DataFrame:
+    """Read the data table that starts after the third '----' line, and cut it into columns.
+
+    The tables look like a fixed-width format, but they are not one. A cell holds a right-aligned
+    value with a minimum width, so a value that is wider than its cell takes the space in front of
+    it and moves the rest of the line to the right. The Config_Upper value "4f2.5d1.6s1.6s2" of
+    Tb II does this. A column is therefore not at a fixed character position, and this function
+    splits each line on whitespace instead.
+
+    polars cuts the tokens out of every line at once, which is much faster than a parser that
+    reads one line at a time. The caller names the columns that it uses. The other columns stay
+    in the list of tokens and never become a column, which keeps the memory low on a wide file.
+    Every column of the result holds strings, because the tables mix text and numbers.
+    """
+    columns, skip_lines = read_table_header(filepath)
+    missing = [name for name in usecols if name not in columns]
+    # not an assert: input validation must survive python -O
+    if missing:
+        msg = f"The data table in {filepath} has no {missing} column. It has {columns}"
+        raise ValueError(msg)
+
+    dftable = (
+        scan_file_lines(filepath, skip_lines=skip_lines)
+        .select(parts=pl.col("line").str.extract_all(r"\S+"))
+        # a blank line holds no data, and gives no tokens
+        .filter(pl.col("parts").list.len() > 0)
+        .select(
+            tokencount=pl.col("parts").list.len(),
+            **{name: pl.col("parts").list.get(columns.index(name), null_on_oob=True) for name in usecols},
+        )
+        # the streaming engine keeps the peak memory of a multi-gigabyte file near half of the
+        # memory that the in-memory engine needs, and it is faster here
+        .collect(engine="streaming")
+    )
+
+    # A row with more tokens than the header moves every value into the column on its left, which
+    # no later test can find. A row with fewer tokens has an empty cell, and keeps the columns in
+    # front of that cell: the level tables leave the LS2 cell of a high-l level empty. Such a row
+    # is permitted, because the callers take no column after LS2, and because the casts of Index,
+    # Energy and Parity would fail if an earlier cell were the empty one.
+    # Not an assert: input validation must survive python -O.
+    nlongrows = dftable.filter(pl.col("tokencount") > len(columns)).height
+    if nlongrows > 0:
+        msg = f"{nlongrows} rows of the data table in {filepath} have more than {len(columns)} tokens"
+        raise ValueError(msg)
+
+    return dftable.drop("tokencount")
 
 
 def read_transitions_file(filepath: Path) -> pl.DataFrame:
@@ -108,8 +154,7 @@ def read_transitions_file(filepath: Path) -> pl.DataFrame:
     does not merge the rows yet. It drops the Type strings, because a large file has millions of
     rows.
     """
-    # a file uses only a few transition types, so the category dtype keeps one copy of each type
-    dffile = read_dashed_table(filepath, usecols=["Lower", "Upper", "A", "Type"], dtype={"Type": "category"})
+    dffile = read_dashed_table(filepath, usecols=["Lower", "Upper", "A", "Type"])
 
     # a null means an unreadable cell, and it must not decide a flag or become a zero rate.
     # Not an assert: input validation must survive python -O.
@@ -199,9 +244,19 @@ def read_levels_and_transitions(
 
     ionization_energy_in_ev = artisatomic.get_nist_ionization_energies_ev()[atomic_number, ion_stage]
 
-    # the levels files of the data sets do not all carry the same columns, so name the ones used
-    dflevels = read_dashed_table(
-        levels_file, usecols=["Index", "Energy", "J", "Parity", "Configuration"], dtype={"J": str}
+    # the levels files of the data sets do not all carry the same columns, so name the ones used.
+    # J keeps its "5/2" form as a string, which the g column below reads.
+    dflevels = read_dashed_table(levels_file, usecols=["Index", "Energy", "J", "Parity", "Configuration"])
+
+    # a null means an empty cell, and a level needs each of these values
+    # not an assert: input validation must survive python -O
+    for colname in dflevels.columns:
+        if dflevels[colname].null_count() > 0:
+            msg = f"Unreadable {colname} values in {levels_file}"
+            raise ValueError(msg)
+
+    dflevels = dflevels.with_columns(
+        pl.col("Index").cast(pl.Int64), pl.col("Energy").cast(pl.Float64), pl.col("Parity").cast(pl.Int64)
     )
 
     dflevels = dflevels.with_columns(
@@ -228,12 +283,11 @@ def read_levels_and_transitions(
 
     artisatomic.log_and_print(flog, f"Read {dflevels.height:d} levels")
 
-    # the threads read the files at the same time, because read_dashed_table() gives up the GIL
-    # while it parses. executor.map() gives the tables in the order of the files, so the merge
-    # below adds the A values in the same order for each run.
-    # rechunk=False: the merge reads the rows once, so a copy into one chunk gains nothing.
-    with ThreadPoolExecutor(max_workers=len(transition_files)) as executor:
-        dftransitions = pl.concat(list(executor.map(read_transitions_file, transition_files)), rechunk=False)
+    # the files keep their order, so the merge below adds the A values in the same order for
+    # each run. rechunk=False: the merge reads the rows once, so a copy into one chunk gains nothing
+    dftransitions = pl.concat(
+        [read_transitions_file(transition_file) for transition_file in transition_files], rechunk=False
+    )
 
     artisatomic.log_and_print(flog, f"Read {dftransitions.height} transitions")
 

--- a/artisatomic/readfloers25data.py
+++ b/artisatomic/readfloers25data.py
@@ -88,8 +88,14 @@ def read_table_header(filepath: Path) -> tuple[list[str], int]:
                 dashrowcount += 1
                 if dashrowcount == 3:
                     break
-        columns = f.readline().split()
-        linecount += 1
+        # a blank line between the rule and the names holds no column name
+        columns: list[str] = []
+        while dashrowcount == 3 and not columns:
+            line = f.readline()
+            linecount += 1
+            if not line:
+                break
+            columns = line.split()
 
     if dashrowcount < 3 or not columns:
         msg = f"Did not find the expected data table in {filepath}"
@@ -102,49 +108,61 @@ def read_dashed_table(filepath: Path, usecols: list[str]) -> pl.DataFrame:
     """Read the data table that starts after the third '----' line, and cut it into columns.
 
     The tables look like a fixed-width format, but they are not one. A cell holds a right-aligned
-    value with a minimum width, so a value that is wider than its cell takes the space in front of
-    it and moves the rest of the line to the right. The Config_Upper value "4f2.5d1.6s1.6s2" of
-    Tb II does this. A column is therefore not at a fixed character position, and this function
-    splits each line on whitespace instead.
+    value with a minimum width. A value that is wider than its cell takes the space in front of
+    it. It thus moves the rest of the line to the right.
 
-    polars cuts the tokens out of every line at once, which is much faster than a parser that
-    reads one line at a time. The caller names the columns that it uses. The other columns stay
-    in the list of tokens and never become a column, which keeps the memory low on a wide file.
-    Every column of the result holds strings, because the tables mix text and numbers.
+    The Config_Upper value "4f2.5d1.6s1.6s2" of Tb II does this. A column is therefore not at a
+    fixed character position, and this function splits each line on whitespace.
+
+    polars cuts the tokens out of every line at once. That is much faster than a parser that reads
+    one line at a time. The caller names the columns that it uses. The other columns stay in the
+    list of tokens and never become a column. This keeps the memory low on a wide file. Every
+    column of the result holds strings, because the tables mix text and numbers.
     """
     columns, skip_lines = read_table_header(filepath)
     missing = [name for name in usecols if name not in columns]
     # not an assert: input validation must survive python -O
     if missing:
-        msg = f"The data table in {filepath} has no {missing} column. It has {columns}"
+        msg = f"The data table in {filepath} has no {missing} of the columns {columns}"
         raise ValueError(msg)
 
-    dftable = (
+    # the name is not a column name of the data, so it cannot hide a column that the caller asked
+    # for. A leading space keeps it different from every name that split() can give.
+    countcol = " tokencount"
+    lftable = (
         scan_file_lines(filepath, skip_lines=skip_lines)
         .select(parts=pl.col("line").str.extract_all(r"\S+"))
         # a blank line holds no data, and gives no tokens
         .filter(pl.col("parts").list.len() > 0)
         .select(
-            tokencount=pl.col("parts").list.len(),
-            **{name: pl.col("parts").list.get(columns.index(name), null_on_oob=True) for name in usecols},
+            pl.col("parts").list.len().alias(countcol),
+            *[pl.col("parts").list.get(columns.index(name), null_on_oob=True).alias(name) for name in usecols],
         )
-        # the streaming engine keeps the peak memory of a multi-gigabyte file near half of the
-        # memory that the in-memory engine needs, and it is faster here
-        .collect(engine="streaming")
     )
 
-    # A row with more tokens than the header moves every value into the column on its left, which
-    # no later test can find. A row with fewer tokens has an empty cell, and keeps the columns in
-    # front of that cell: the level tables leave the LS2 cell of a high-l level empty. Such a row
-    # is permitted, because the callers take no column after LS2, and because the casts of Index,
-    # Energy and Parity would fail if an earlier cell were the empty one.
+    try:
+        # the streaming engine halves the peak memory of a multi-gigabyte file. It is also faster.
+        dftable = lftable.collect(engine="streaming")
+    except pl.exceptions.NoDataError:
+        # a table can hold a header and no data row, e.g. an ion with no line of one type
+        dftable = pl.DataFrame(schema={countcol: pl.UInt32} | dict.fromkeys(usecols, pl.String))
+    except pl.exceptions.PolarsError as exc:
+        # the parser names no file, so name it here: a run reads more than a hundred of them
+        msg = f"Could not read the data table in {filepath}: {exc}"
+        raise ValueError(msg) from exc
+
+    # A row with more tokens than the header moves every value into the column on its left. No
+    # later test can find that. A row with fewer tokens has an empty cell, and keeps the columns
+    # in front of that cell. The level tables leave the LS2 cell of a high-l level empty. The
+    # callers take no column after LS2, so such a row is permitted.
+    #
     # Not an assert: input validation must survive python -O.
-    nlongrows = dftable.filter(pl.col("tokencount") > len(columns)).height
+    nlongrows = dftable.select((pl.col(countcol) > len(columns)).sum()).item()
     if nlongrows > 0:
         msg = f"{nlongrows} rows of the data table in {filepath} have more than {len(columns)} tokens"
         raise ValueError(msg)
 
-    return dftable.drop("tokencount")
+    return dftable.drop(countcol)
 
 
 def read_transitions_file(filepath: Path) -> pl.DataFrame:
@@ -255,17 +273,17 @@ def read_levels_and_transitions(
             msg = f"Unreadable {colname} values in {levels_file}"
             raise ValueError(msg)
 
+    # every expression here reads the input frame, so g reads the file's own J string
     dflevels = dflevels.with_columns(
-        pl.col("Index").cast(pl.Int64), pl.col("Energy").cast(pl.Float64), pl.col("Parity").cast(pl.Int64)
-    )
-
-    dflevels = dflevels.with_columns(
+        pl.col("Index").cast(pl.Int64),
+        pl.col("Energy").cast(pl.Float64),
+        pl.col("Parity").cast(pl.Int64),
         pl.when(pl.col("J").str.ends_with("/2"))
         .then(pl.col("J").str.strip_suffix("/2").cast(pl.Int32) + 1)
         .otherwise(
             pl.col("J").str.strip_suffix("/2").cast(pl.Int32) * 2 + 1
         )  # the strip_suffix should not be needed (does not end in "/2" but prevents a polars error)
-        .alias("g")
+        .alias("g"),
     )
 
     # the levels are indexed from zero in file order and the transitions refer to those indices,

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -1831,3 +1831,47 @@ def test_readfloers25data_pertype_merge_swap_and_forbidden(monkeypatch, tmp_path
     (tmp_path / "57LaII_transitions_calib_E2.txt").write_text(transheader + " 2 0 3.0e+00 XX\n")
     with pytest.raises(ValueError, match="Unknown transition type"):
         readfloers25data.read_levels_and_transitions(57, 2, io.StringIO(), calibrated=True, withforbidden=True)
+
+
+def test_readfloers25data_ragged_rows(monkeypatch, tmp_path):
+    """A short row keeps the columns in front of its empty cell. A long row stops the run.
+
+    The Floers+25 tables right-align each value in a cell of a minimum width, so a value that is
+    wider than its cell moves the rest of the line. A column is not at a fixed character position,
+    and the reader splits each line on whitespace. The level tables leave the LS2 cell of a high-l
+    level empty, which gives a row of nine tokens against a header of ten. The reader takes no
+    column after LS2, so such a row is read. A row with an extra token moves every value into the
+    column on its left, which no later test can find, so the reader rejects it.
+    """
+    from artisatomic import readfloers25data
+
+    header = "Test table\n--\n--\n--\n"
+    levelheader = " Index       Z  Charge      Energy       J  Parity  Configuration     LS    LS2    Method\n"
+    # the second level has an empty LS2 cell, as a high-l level of the published tables does
+    levels = (
+        "     0      57       2        0.00     3/2       0            5d1     2D     2D   uncalib\n"
+        "     1      57       2   113810.70     9/2       0            5g1     2G          uncalib\n"
+    )
+    (tmp_path / "57LaII_levels_calib.txt").write_text(header + levelheader + levels)
+    transheader = header + " Lower Upper A Type\n"
+    (tmp_path / "57LaII_transitions_calib_E1.txt").write_text(transheader + " 0 1 1.0e+06 E1\n")
+
+    monkeypatch.setattr(readfloers25data, "get_basepath", lambda **_kwargs: tmp_path)
+    _, dflevels, _, _ = readfloers25data.read_levels_and_transitions(
+        57, 2, io.StringIO(), calibrated=True, withforbidden=True
+    )
+
+    # the short row keeps its Energy, J, Parity and Configuration, which all precede LS2
+    assert dflevels["levelname"].to_list() == ["5d1 J=3/2 index=0", "5g1 J=9/2 index=1"]
+    assert dflevels["energyabovegsinpercm"].to_list() == [0.0, 113810.70]
+    assert dflevels["g"].to_list() == [4, 10]
+
+    # a row with an extra token would move every value into the column on its left
+    (tmp_path / "57LaII_levels_calib.txt").write_text(
+        header
+        + levelheader
+        + levels
+        + "     2      57       2   200000.00     1/2       1  5f1  2F  2F  uncalib  EXTRA\n"
+    )
+    with pytest.raises(ValueError, match="have more than 10 tokens"):
+        readfloers25data.read_levels_and_transitions(57, 2, io.StringIO(), calibrated=True, withforbidden=True)

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -1836,12 +1836,12 @@ def test_readfloers25data_pertype_merge_swap_and_forbidden(monkeypatch, tmp_path
 def test_readfloers25data_ragged_rows(monkeypatch, tmp_path):
     """A short row keeps the columns in front of its empty cell. A long row stops the run.
 
-    The Floers+25 tables right-align each value in a cell of a minimum width, so a value that is
+    The Floers+25 tables right-align each value in a cell of a minimum width. A value that is
     wider than its cell moves the rest of the line. A column is not at a fixed character position,
     and the reader splits each line on whitespace. The level tables leave the LS2 cell of a high-l
     level empty, which gives a row of nine tokens against a header of ten. The reader takes no
     column after LS2, so such a row is read. A row with an extra token moves every value into the
-    column on its left, which no later test can find, so the reader rejects it.
+    column on its left, so the reader rejects it.
     """
     from artisatomic import readfloers25data
 
@@ -1874,4 +1874,43 @@ def test_readfloers25data_ragged_rows(monkeypatch, tmp_path):
         + "     2      57       2   200000.00     1/2       1  5f1  2F  2F  uncalib  EXTRA\n"
     )
     with pytest.raises(ValueError, match="have more than 10 tokens"):
+        readfloers25data.read_levels_and_transitions(57, 2, io.StringIO(), calibrated=True, withforbidden=True)
+
+
+def test_readfloers25data_degenerate_tables(monkeypatch, tmp_path):
+    """A table of no data row gives no transition. A broken table names its own file.
+
+    A per-type file holds the transitions of one type, so an ion with no line of that type has a
+    header and no data row. Such a file must add nothing rather than stop the run. A blank line
+    between the third rule and the column names is also permitted.
+    """
+    from artisatomic import readfloers25data
+
+    header = "Test table\n--\n--\n--\n"
+    (tmp_path / "57LaII_levels_calib.txt").write_text(
+        header + " Index Energy J Parity Configuration\n 0 0.0 0 0 5d1\n 1 100.0 1 1 5p1\n"
+    )
+    transheader = " Lower Upper A Type\n"
+    (tmp_path / "57LaII_transitions_calib_E1.txt").write_text(header + transheader + " 0 1 1.0e+06 E1\n")
+    # the M1 file holds no data row, because the ion has no M1 line
+    (tmp_path / "57LaII_transitions_calib_M1.txt").write_text(header + transheader)
+    # the E2 file has a blank line between the third rule and the column names
+    (tmp_path / "57LaII_transitions_calib_E2.txt").write_text(header + "\n" + transheader)
+
+    monkeypatch.setattr(readfloers25data, "get_basepath", lambda **_kwargs: tmp_path)
+    _, _, dftransitions, counts = readfloers25data.read_levels_and_transitions(
+        57, 2, io.StringIO(), calibrated=True, withforbidden=True
+    )
+    assert dftransitions.height == 1
+    assert not dftransitions["forbidden"][0]
+    assert counts == {"5d1 J=0 index=0": 1, "5p1 J=1 index=1": 1}
+
+    # a file that names none of the columns that the reader takes must say so
+    (tmp_path / "57LaII_transitions_calib_M1.txt").write_text(header + " Lower Upper A\n 0 1 1.0e+00\n")
+    with pytest.raises(ValueError, match=r"has no \['Type'\]"):
+        readfloers25data.read_levels_and_transitions(57, 2, io.StringIO(), calibrated=True, withforbidden=True)
+
+    # a file with no column header at all is not a data table
+    (tmp_path / "57LaII_transitions_calib_M1.txt").write_text(header)
+    with pytest.raises(ValueError, match="Did not find the expected data table"):
         readfloers25data.read_levels_and_transitions(57, 2, io.StringIO(), calibrated=True, withforbidden=True)


### PR DESCRIPTION
## What this changes

The Floers+25 reader now cuts the columns out of every line with polars, and it
no longer uses pandas. It reads 3.2 to 3.5 times faster.

The reader uses `scan_file_lines()` and `str.extract_all()`, as `readhillierdata`
does. The streaming engine keeps the peak memory low. Other changes:

- The reader takes only the columns that it uses, from the levels file as well.
- The transition type becomes a boolean flag in each file, before the tables merge.
- The level indices are Int32.
- The merge no longer keeps the group order, because `output.py` sorts the rows.
- The Laporte test reads the parity by index, and not with two joins.

## Speed and memory

Wall time and peak resident memory for one `read_levels_and_transitions()` call.
The test ran on a MacBook Pro (Mac16,8) with an Apple M4 Pro, which has 10
performance cores and 4 efficiency cores, and 48 GiB of memory. The system was
macOS 26, with Python 3.14.7 and polars 1.44.0. The files were on the internal
SSD, and the page cache was warm.

| ion and data set | before | after |
|---|---|---|
| Tb II withforbidden (3 files, 4.87 GiB) | 13.48 s / 5.45 GiB | 3.88 s / 4.78 GiB |
| Dy II withforbidden (3 files, 3.41 GiB) | 9.57 s / 3.97 GiB | 3.02 s / 3.87 GiB |
| Ce II withforbidden (3 files, 255 MiB) | 0.72 s / 0.60 GiB | 0.23 s / 0.72 GiB |
| Tb II public (1 zstd file, 107 MiB) | 2.97 s / 1.30 GiB | 0.92 s / 1.56 GiB |
| Dy II public (1 zstd file, 72 MiB) | 2.07 s / 1.07 GiB | 0.64 s / 1.30 GiB |

## The format of the tables

The tables look like a fixed-width format, but they are not one. A cell holds a
right-aligned value with a minimum width. A value that is wider than its cell
takes the space in front of it, and moves the rest of the line. The
`Config_Upper` value `4f2.5d1.6s1.6s2` of Tb II does this, so a column is not at
a fixed character position. The reader therefore splits each line on whitespace.

A cell can also be empty. The level tables leave the `LS2` cell of a high-l level
empty, which gives a row of nine tokens against a header of ten. This moves the
later tokens to the left. The reader takes no column after `LS2`, and the casts
of `Index`, `Energy` and `Parity` would fail if an earlier cell were the empty
one. A test of all 168 data files shows that no transitions file has a ragged
row, and that no levels file has fewer than nine tokens in a row.

## Two faults that this fixes

- pandas gave the first column of an over-long row to the frame index, which
  moved every value into the column on its left. No later test could find that.
  The reader now rejects such a row.
- A table can hold a header and no data row, for example a per-type file of an
  ion with no line of that type. polars raises `NoDataError` for it, so the
  reader gives an empty frame instead.

## Tests

- The four output files of all seven checksum sets match: `floers25`, `kurucz`,
  `mons`, `qub`, `cmfgen`, `cmfgen_lowz` and `jplt`.
- A direct comparison of the levels, the transitions and the counts for La III,
  Ce III, Ce II, Nd II, Dy II and Tb II of the withforbidden set gives identical
  bytes. Tb II has 21.5 million transitions.
- Two new tests hold the reader to the rules above: one for a short row and an
  over-long row, one for an empty table, an absent column and a missing header.

### The forbidden flag

The `Type` column holds `E1`, `E2` or `M1`, and no other value. That is true for
each of the 152,534,072 transition rows of the two data sets. A merged row is
forbidden only when no `E1` row contributes to it.

A rebuild of the flag in plain Python matches the reader for La III, Ce III,
Ce II and Nd III of the withforbidden set, and for Yb II, Tb II and Dy III of the
public set, over 3.1 million level pairs. Ce III has 1025 pairs that take both an
`E1` line and a forbidden line, and the reader marks each of them permitted.
`transitiondata.txt` for Ce II and Ce III holds 1,134,446 rows, and every flag
and every `coll_str` value in them agrees with the rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)