### PR TITLE
Reject a duplicated photoionisation target level

### DIFF
--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -1,6 +1,7 @@
 """Write the ARTIS output files: adata.txt, transitiondata.txt, phixsdata_v2.txt, compositiondata.txt."""
 
 import argparse
+from collections import Counter
 from pathlib import Path
 
 import numpy as np
@@ -569,6 +570,24 @@ def write_phixs_data(
         msg = f"Z={atomic_number} ion_stage={ion_stage} ground state has zero photoionization cross section"
         log_and_print(flog, f"ERROR: {msg}")
         raise ValueError(msg)
+
+    # ARTIS gives each entry of a target list its own target level and fraction (input.cc), so a
+    # repeated target level would get two fractions of the same recombination. Checked over every
+    # level before the first write, so a bad level fails before part of the ion goes out.
+    # Not an assert: this guards written output and must survive python -O.
+    for lowerlevelid in levelids_to_write:
+        targetlist = photoionization_targetfractions[lowerlevelid]
+        duplicates = [
+            upperionlevelid
+            for upperionlevelid, count in Counter(upperionlevelid for upperionlevelid, _ in targetlist).items()
+            if count > 1
+        ]
+        if duplicates:
+            msg = (
+                f"Z={atomic_number} ion_stage={ion_stage} level id {lowerlevelid}: phixs target level ids"
+                f" {sorted(duplicates)} occur more than one time ({targetlist})"
+            )
+            raise ValueError(msg)
 
     # level ids (of this ion and of the upper ion's photoionisation targets) are zero-based in
     # memory, but the output format numbers them from one

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -1,7 +1,6 @@
 """Write the ARTIS output files: adata.txt, transitiondata.txt, phixsdata_v2.txt, compositiondata.txt."""
 
 import argparse
-from collections import Counter
 from pathlib import Path
 
 import numpy as np
@@ -577,15 +576,18 @@ def write_phixs_data(
     # Not an assert: this guards written output and must survive python -O.
     for lowerlevelid in levelids_to_write:
         targetlist = photoionization_targetfractions[lowerlevelid]
-        duplicates = [
-            upperionlevelid
-            for upperionlevelid, count in Counter(upperionlevelid for upperionlevelid, _ in targetlist).items()
-            if count > 1
-        ]
-        if duplicates:
+        upperionlevelids = [upperionlevelid for upperionlevelid, _ in targetlist]
+        if len(upperionlevelids) != len(set(upperionlevelids)):
+            duplicates = sorted(
+                {
+                    upperionlevelid
+                    for index, upperionlevelid in enumerate(upperionlevelids)
+                    if upperionlevelid in upperionlevelids[:index]
+                }
+            )
             msg = (
                 f"Z={atomic_number} ion_stage={ion_stage} level id {lowerlevelid}: phixs target level ids"
-                f" {sorted(duplicates)} occur more than one time ({targetlist})"
+                f" {duplicates} occur more than one time ({targetlist})"
             )
             raise ValueError(msg)
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1631,10 +1631,12 @@ def get_photoiontargetfractions(
 ) -> list[list[tuple[int, float]]]:
     """Resolve each level's photoionisation targets from configuration names to upper-ion ids.
 
-    Returns, per zero-based level id, a list of (upper ion level id, fraction) pairs. A target
-    configuration that names several J-split levels of the upper ion is shared over them in
-    proportion to their statistical weights. Levels with no cross-section data (None) and levels
-    whose targets could not be matched both fall back to the upper ion's ground state.
+    Returns, per zero-based level id, a list of (upper ion level id, fraction) pairs. Each upper
+    ion level occurs one time only: two target configurations that come to the same level get one
+    entry with the summed fraction. A target configuration that names several J-split levels of
+    the upper ion is shared over them in proportion to their statistical weights. Levels with no
+    cross-section data (None) and levels whose targets could not be matched both fall back to the
+    upper ion's ground state.
     """
     targetlist: list[list[tuple[int, float]]] = [[] for _ in range(dfenergy_levels.height)]
     targetlist_of_targetconfig: defaultdict[str, list[tuple[int, float]]] = defaultdict(list)
@@ -1646,6 +1648,12 @@ def get_photoiontargetfractions(
         targetconfig_fractions = hillier_photoion_targetconfigs[lowerlevelid]
         if targetconfig_fractions is None:
             continue  # photoionisation flagged as not available
+
+        # keyed by upper ion level id because two target configurations can come to the same
+        # level, and ARTIS gives each entry of the list its own target. F II is the case here:
+        # its routes '2s2_2p3(2Do)' and '2s2_2p3(2Po)' match no F III level name
+        # ('2s2_2p3_2Do[5/2]'), so both fall back to the ground state.
+        fraction_of_upperlevelid: dict[int, float] = {}
 
         for targetconfig, targetconfig_fraction in targetconfig_fractions:
             if targetconfig not in targetlist_of_targetconfig:
@@ -1669,10 +1677,12 @@ def get_photoiontargetfractions(
                     targetlist_of_targetconfig[targetconfig].append((upperionlevelid, statweight_fraction))
 
             for upperlevelid, statweight_fraction in targetlist_of_targetconfig[targetconfig]:
-                targetlist[lowerlevelid].append((upperlevelid, targetconfig_fraction * statweight_fraction))
+                fraction_of_upperlevelid[upperlevelid] = (
+                    fraction_of_upperlevelid.get(upperlevelid, 0.0) + targetconfig_fraction * statweight_fraction
+                )
 
-        if len(targetlist[lowerlevelid]) == 0:
-            targetlist[lowerlevelid].append((0, 1.0))  # the upper ion's ground state
+        # the upper ion's ground state where no target was matched at all
+        targetlist[lowerlevelid] = list(fraction_of_upperlevelid.items()) or [(0, 1.0)]
 
     return targetlist
 

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -1544,6 +1544,67 @@ def test_write_phixs_data_keeps_a_table_with_no_threshold():
     assert written.splitlines()[4:] == ["  2.00000000E+00", "  1.00000000E+00"]
 
 
+def test_get_photoiontargetfractions_merges_targets_that_match_one_level():
+    """F II names three routes, of which two match no F III level name and fall back to the ground state."""
+    from artisatomic import readhillierdata
+
+    dfenergy_levels = pl.DataFrame({"levelid": [0], "levelname": ["2s2_2p4_3Pe[2]"], "g": [5.0]})
+    dfenergy_levels_upperion = pl.DataFrame(
+        {
+            "levelid": [0, 1, 2],
+            "levelname": ["2s2_2p3_4So[3/2]", "2s2_2p3_2Do[5/2]", "2s2_2p3_2Do[3/2]"],
+            "g": [4.0, 6.0, 4.0],
+        }
+    )
+    # the second and the third route carry the parentheses that the level names do not have
+    targetconfigs: list[list[tuple[str, float]] | None] = [
+        [("2s2_2p3_4So", 0.5), ("2s2_2p3(2Do)", 0.3), ("2s2_2p3(2Po)", 0.2)]
+    ]
+
+    targetlist = readhillierdata.get_photoiontargetfractions(dfenergy_levels, dfenergy_levels_upperion, targetconfigs)
+
+    # one entry only, with the three fractions added, and not the same target three times
+    assert targetlist == [[(0, 1.0)]]
+
+
+def test_get_photoiontargetfractions_shares_a_target_over_its_j_levels():
+    """A matched configuration is still split over its J levels by statistical weight."""
+    from artisatomic import readhillierdata
+
+    dfenergy_levels = pl.DataFrame({"levelid": [0], "levelname": ["2s2_2p4_3Pe[2]"], "g": [5.0]})
+    dfenergy_levels_upperion = pl.DataFrame(
+        {
+            "levelid": [0, 1, 2],
+            "levelname": ["2s2_2p3_4So[3/2]", "2s2_2p3_2Do[5/2]", "2s2_2p3_2Do[3/2]"],
+            "g": [4.0, 6.0, 4.0],
+        }
+    )
+    targetconfigs: list[list[tuple[str, float]] | None] = [[("2s2_2p3_2Do", 1.0)]]
+
+    targetlist = readhillierdata.get_photoiontargetfractions(dfenergy_levels, dfenergy_levels_upperion, targetconfigs)
+
+    assert targetlist == [[(1, 0.6), (2, 0.4)]]
+
+
+def test_write_phixs_data_rejects_a_duplicated_target():
+    """A target level that occurs two times would give the same target two fractions in ARTIS."""
+    import argparse
+
+    from artisatomic import write_phixs_data
+
+    args = argparse.Namespace(optimaltemperature=3000, nphixspoints=2, phixsnuincrement=0.1)
+    crosssections = np.array([[1.0, 0.5]])
+    targetfractions = [[(0, 0.4), (1, 0.3), (0, 0.3)]]  # target level 0 occurs two times
+    thresholds = np.array([13.6])
+
+    out = io.StringIO()
+    with pytest.raises(ValueError, match="occur more than one time"):
+        write_phixs_data(out, 8, 1, crosssections, targetfractions, thresholds, args, io.StringIO())
+
+    # the level fails before any part of the ion goes out
+    assert not out.getvalue()
+
+
 def test_log_degenerate_transitions():
     """ARTIS drops a transition whose two levels have one energy, so artisatomic reports it."""
     from artisatomic.output import log_degenerate_transitions

--- a/tests/cmfgen_lowz/checksums.txt
+++ b/tests/cmfgen_lowz/checksums.txt
@@ -1,4 +1,4 @@
 0d5755fa720eadc8cb1ce98ece0a596c  adata.txt
 5fbbc0dc9cf13e66a15caf576650a408  compositiondata.txt
-7f19ef7c99bed70bc94a04e0b739ab30  phixsdata_v2.txt
+f9b88e11a76734bde10262fe12843362  phixsdata_v2.txt
 a4c07e3ded1f523e6f9b2e079a09340c  transitiondata.txt


### PR DESCRIPTION
A level's photoionisation target list must not hold the same upper ion level more than one time. ARTIS gives each entry of the list its own target level and fraction (`input.cc`), so a repeated level gets two fractions of the same recombination.

## The check

`write_phixs_data()` raises a `ValueError` if any level of the ion has a repeated target id. It runs over every level before the first line of the ion goes out, so a bad level fails before part of the ion is written. It is not an assert, because it guards written output and must survive `python -O`.

## What it found

F II. Its `phot_data_*` files name the routes `2s2_2p3_4So`, `2s2_2p3(2Do)`, and `2s2_2p3(2Po)`. The F III level names use an underscore, not parentheses (`2s2_2p3_2Do[5/2]`), so the last two match no level and take the ground-state fallback. Three F II levels went out with target level 1 two times at 0.5.

`get_photoiontargetfractions()` now adds the fractions of the target configurations that come to the same upper ion level, so each level occurs one time only.

## Output

Only the `phixsdata_v2.txt` checksum of the `cmfgen_lowz` set changes. The whole diff is those three F II levels, each going from a two-target block to a single-target line. The other six sets are byte-identical.

The name mismatch itself is fixed separately in artis-mcrt/artisatomic#94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)