### PR TITLE
Match a photoionisation target whose name uses other separators

### DIFF
--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -1,6 +1,7 @@
 """Write the ARTIS output files: adata.txt, transitiondata.txt, phixsdata_v2.txt, compositiondata.txt."""
 
 import argparse
+from collections import Counter
 from pathlib import Path
 
 import numpy as np
@@ -569,6 +570,24 @@ def write_phixs_data(
         msg = f"Z={atomic_number} ion_stage={ion_stage} ground state has zero photoionization cross section"
         log_and_print(flog, f"ERROR: {msg}")
         raise ValueError(msg)
+
+    # ARTIS gives each entry of a target list its own target level and fraction (input.cc), so a
+    # repeated target level would get two fractions of the same recombination. Checked over every
+    # level before the first write, so a bad level fails before part of the ion goes out.
+    # Not an assert: this guards written output and must survive python -O.
+    for lowerlevelid in levelids_to_write:
+        targetlist = photoionization_targetfractions[lowerlevelid]
+        duplicates = [
+            upperionlevelid
+            for upperionlevelid, count in Counter(upperionlevelid for upperionlevelid, _ in targetlist).items()
+            if count > 1
+        ]
+        if duplicates:
+            msg = (
+                f"Z={atomic_number} ion_stage={ion_stage} level id {lowerlevelid}: phixs target level ids"
+                f" {sorted(duplicates)} occur more than one time ({targetlist})"
+            )
+            raise ValueError(msg)
 
     # level ids (of this ion and of the upper ion's photoionisation targets) are zero-based in
     # memory, but the output format numbers them from one

--- a/artisatomic/output.py
+++ b/artisatomic/output.py
@@ -1,7 +1,6 @@
 """Write the ARTIS output files: adata.txt, transitiondata.txt, phixsdata_v2.txt, compositiondata.txt."""
 
 import argparse
-from collections import Counter
 from pathlib import Path
 
 import numpy as np
@@ -577,15 +576,18 @@ def write_phixs_data(
     # Not an assert: this guards written output and must survive python -O.
     for lowerlevelid in levelids_to_write:
         targetlist = photoionization_targetfractions[lowerlevelid]
-        duplicates = [
-            upperionlevelid
-            for upperionlevelid, count in Counter(upperionlevelid for upperionlevelid, _ in targetlist).items()
-            if count > 1
-        ]
-        if duplicates:
+        upperionlevelids = [upperionlevelid for upperionlevelid, _ in targetlist]
+        if len(upperionlevelids) != len(set(upperionlevelids)):
+            duplicates = sorted(
+                {
+                    upperionlevelid
+                    for index, upperionlevelid in enumerate(upperionlevelids)
+                    if upperionlevelid in upperionlevelids[:index]
+                }
+            )
             msg = (
                 f"Z={atomic_number} ion_stage={ion_stage} level id {lowerlevelid}: phixs target level ids"
-                f" {sorted(duplicates)} occur more than one time ({targetlist})"
+                f" {duplicates} occur more than one time ({targetlist})"
             )
             raise ValueError(msg)
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1631,7 +1631,8 @@ def strip_name_separators(levelname: str) -> str:
     the upper ion does. F II names a route '2s2_2p3(2Do)' where F III has '2s2_2p3_2Do', and O IV
     names '2s2p3Po' where O V has '2s_2p_3Po'. The underscore and the parentheses carry no other
     meaning in these names, so a comparison with them removed still matches the shells and the term
-    exactly. Over the whole CMFGEN corpus no two level names of one ion become the same string.
+    exactly. Over the whole CMFGEN corpus no two level names of one ion become the same string, and
+    get_photoiontargetfractions() rejects a match that spans more than one name.
     """
     return levelname.replace("_", "").replace("(", "").replace(")", "")
 
@@ -1690,6 +1691,18 @@ def get_photoiontargetfractions(
                     ]
                     if upperionlevelids:
                         matchednames = sorted({uppernamenoj_of_levelid[levelid] for levelid in upperionlevelids})
+                        # the fraction is shared over the matched levels by statistical weight,
+                        # which is correct only where they are the J levels of one name. Two names
+                        # that differ in their separators alone would split the route between two
+                        # different levels. No ion of the corpus has such a pair, and this keeps
+                        # that true. Not an assert: it guards written output and must survive -O.
+                        if len(matchednames) > 1:
+                            msg = (
+                                f"Photoionisation target '{targetconfig}' matched more than one level name of"
+                                f" the upper ion with the name separators removed: {matchednames}. The target"
+                                " is ambiguous, so the fraction cannot be shared over them."
+                            )
+                            raise ValueError(msg)
                         print(
                             f"Photoionisation target '{targetconfig}' matched {matchednames} of the upper ion"
                             " with the name separators removed"

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1651,6 +1651,9 @@ def get_photoiontargetfractions(
     matches no level is tried again with the separators removed, and falls back to the upper ion's
     ground state only if that fails as well. Levels with no cross-section data (None) take that
     same ground state.
+
+    The second comparison must come to one name. A match that spans more than one name is
+    ambiguous, and this raises a ValueError rather than share the fraction over the two names.
     """
     targetlist: list[list[tuple[int, float]]] = [[] for _ in range(dfenergy_levels.height)]
     targetlist_of_targetconfig: defaultdict[str, list[tuple[int, float]]] = defaultdict(list)

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1624,6 +1624,18 @@ def read_coldata(atomic_number, ion_stage, dfenergy_levels: pl.DataFrame, flog, 
     return upsilondict
 
 
+def strip_name_separators(levelname: str) -> str:
+    """Remove the characters that a phot file and an oscillator file put between the parts of a name.
+
+    A phot file does not always separate the parts of a target name the way the oscillator file of
+    the upper ion does. F II names a route '2s2_2p3(2Do)' where F III has '2s2_2p3_2Do', and O IV
+    names '2s2p3Po' where O V has '2s_2p_3Po'. The underscore and the parentheses carry no other
+    meaning in these names, so a comparison with them removed still matches the shells and the term
+    exactly. Over the whole CMFGEN corpus no two level names of one ion become the same string.
+    """
+    return levelname.replace("_", "").replace("(", "").replace(")", "")
+
+
 def get_photoiontargetfractions(
     dfenergy_levels,
     dfenergy_levels_upperion,
@@ -1634,9 +1646,10 @@ def get_photoiontargetfractions(
     Returns, per zero-based level id, a list of (upper ion level id, fraction) pairs. Each upper
     ion level occurs one time only: two target configurations that come to the same level get one
     entry with the summed fraction. A target configuration that names several J-split levels of
-    the upper ion is shared over them in proportion to their statistical weights. Levels with no
-    cross-section data (None) and levels whose targets could not be matched both fall back to the
-    upper ion's ground state.
+    the upper ion is shared over them in proportion to their statistical weights. A name that
+    matches no level is tried again with the separators removed, and falls back to the upper ion's
+    ground state only if that fails as well. Levels with no cross-section data (None) take that
+    same ground state.
     """
     targetlist: list[list[tuple[int, float]]] = [[] for _ in range(dfenergy_levels.height)]
     targetlist_of_targetconfig: defaultdict[str, list[tuple[int, float]]] = defaultdict(list)
@@ -1644,15 +1657,16 @@ def get_photoiontargetfractions(
     if hillier_photoion_targetconfigs is None:
         return targetlist
 
+    # the names are matched per target configuration, not per level, so pull them out one time
+    uppernamenoj_of_levelid = [levelname.split("[")[0] for levelname in dfenergy_levels_upperion["levelname"].to_list()]
+
     for lowerlevelid in range(dfenergy_levels.height):
         targetconfig_fractions = hillier_photoion_targetconfigs[lowerlevelid]
         if targetconfig_fractions is None:
             continue  # photoionisation flagged as not available
 
-        # keyed by upper ion level id because two target configurations can come to the same
-        # level, and ARTIS gives each entry of the list its own target. F II is the case here:
-        # its routes '2s2_2p3(2Do)' and '2s2_2p3(2Po)' match no F III level name
-        # ('2s2_2p3_2Do[5/2]'), so both fall back to the ground state.
+        # keyed by upper ion level id because two target configurations of one level can come to
+        # the same upper ion level, and ARTIS gives each entry of the list its own target
         fraction_of_upperlevelid: dict[int, float] = {}
 
         for targetconfig, targetconfig_fraction in targetconfig_fractions:
@@ -1660,12 +1674,31 @@ def get_photoiontargetfractions(
                 # sometimes the target has a slash, e.g. '3d7_4Fe/3d7_a4Fe'
                 # so split on the slash and match all parts
                 targetconfiglist = targetconfig.split("/")
-                upperionlevelids = []
-                for upperlevelid, levelname in dfenergy_levels_upperion[["levelid", "levelname"]].iter_rows():
-                    upperlevelnamenoj = levelname.split("[")[0]
-                    if upperlevelnamenoj in targetconfiglist:
-                        upperionlevelids.append(upperlevelid)
+                upperionlevelids = [
+                    upperlevelid
+                    for upperlevelid, upperlevelnamenoj in enumerate(uppernamenoj_of_levelid)
+                    if upperlevelnamenoj in targetconfiglist
+                ]
                 if not upperionlevelids:
+                    # the two files do not always separate the parts of a name the same way, so
+                    # try again with the separators removed before the ground state is assumed
+                    targetconfiglist_stripped = [strip_name_separators(part) for part in targetconfiglist]
+                    upperionlevelids = [
+                        upperlevelid
+                        for upperlevelid, upperlevelnamenoj in enumerate(uppernamenoj_of_levelid)
+                        if strip_name_separators(upperlevelnamenoj) in targetconfiglist_stripped
+                    ]
+                    if upperionlevelids:
+                        matchednames = sorted({uppernamenoj_of_levelid[levelid] for levelid in upperionlevelids})
+                        print(
+                            f"Photoionisation target '{targetconfig}' matched {matchednames} of the upper ion"
+                            " with the name separators removed"
+                        )
+                if not upperionlevelids:
+                    print(
+                        f"WARNING: photoionisation target '{targetconfig}' matched no level of the upper ion,"
+                        " so the upper ion's ground state is the target"
+                    )
                     upperionlevelids = [0]  # the upper ion's ground state
                 targetlist_of_targetconfig[targetconfig] = []
 

--- a/artisatomic/readhillierdata.py
+++ b/artisatomic/readhillierdata.py
@@ -1631,10 +1631,12 @@ def get_photoiontargetfractions(
 ) -> list[list[tuple[int, float]]]:
     """Resolve each level's photoionisation targets from configuration names to upper-ion ids.
 
-    Returns, per zero-based level id, a list of (upper ion level id, fraction) pairs. A target
-    configuration that names several J-split levels of the upper ion is shared over them in
-    proportion to their statistical weights. Levels with no cross-section data (None) and levels
-    whose targets could not be matched both fall back to the upper ion's ground state.
+    Returns, per zero-based level id, a list of (upper ion level id, fraction) pairs. Each upper
+    ion level occurs one time only: two target configurations that come to the same level get one
+    entry with the summed fraction. A target configuration that names several J-split levels of
+    the upper ion is shared over them in proportion to their statistical weights. Levels with no
+    cross-section data (None) and levels whose targets could not be matched both fall back to the
+    upper ion's ground state.
     """
     targetlist: list[list[tuple[int, float]]] = [[] for _ in range(dfenergy_levels.height)]
     targetlist_of_targetconfig: defaultdict[str, list[tuple[int, float]]] = defaultdict(list)
@@ -1646,6 +1648,12 @@ def get_photoiontargetfractions(
         targetconfig_fractions = hillier_photoion_targetconfigs[lowerlevelid]
         if targetconfig_fractions is None:
             continue  # photoionisation flagged as not available
+
+        # keyed by upper ion level id because two target configurations can come to the same
+        # level, and ARTIS gives each entry of the list its own target. F II is the case here:
+        # its routes '2s2_2p3(2Do)' and '2s2_2p3(2Po)' match no F III level name
+        # ('2s2_2p3_2Do[5/2]'), so both fall back to the ground state.
+        fraction_of_upperlevelid: dict[int, float] = {}
 
         for targetconfig, targetconfig_fraction in targetconfig_fractions:
             if targetconfig not in targetlist_of_targetconfig:
@@ -1669,10 +1677,12 @@ def get_photoiontargetfractions(
                     targetlist_of_targetconfig[targetconfig].append((upperionlevelid, statweight_fraction))
 
             for upperlevelid, statweight_fraction in targetlist_of_targetconfig[targetconfig]:
-                targetlist[lowerlevelid].append((upperlevelid, targetconfig_fraction * statweight_fraction))
+                fraction_of_upperlevelid[upperlevelid] = (
+                    fraction_of_upperlevelid.get(upperlevelid, 0.0) + targetconfig_fraction * statweight_fraction
+                )
 
-        if len(targetlist[lowerlevelid]) == 0:
-            targetlist[lowerlevelid].append((0, 1.0))  # the upper ion's ground state
+        # the upper ion's ground state where no target was matched at all
+        targetlist[lowerlevelid] = list(fraction_of_upperlevelid.items()) or [(0, 1.0)]
 
     return targetlist
 

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -1544,6 +1544,67 @@ def test_write_phixs_data_keeps_a_table_with_no_threshold():
     assert written.splitlines()[4:] == ["  2.00000000E+00", "  1.00000000E+00"]
 
 
+def test_get_photoiontargetfractions_merges_targets_that_match_one_level():
+    """F II names three routes, of which two match no F III level name and fall back to the ground state."""
+    from artisatomic import readhillierdata
+
+    dfenergy_levels = pl.DataFrame({"levelid": [0], "levelname": ["2s2_2p4_3Pe[2]"], "g": [5.0]})
+    dfenergy_levels_upperion = pl.DataFrame(
+        {
+            "levelid": [0, 1, 2],
+            "levelname": ["2s2_2p3_4So[3/2]", "2s2_2p3_2Do[5/2]", "2s2_2p3_2Do[3/2]"],
+            "g": [4.0, 6.0, 4.0],
+        }
+    )
+    # the second and the third route carry the parentheses that the level names do not have
+    targetconfigs: list[list[tuple[str, float]] | None] = [
+        [("2s2_2p3_4So", 0.5), ("2s2_2p3(2Do)", 0.3), ("2s2_2p3(2Po)", 0.2)]
+    ]
+
+    targetlist = readhillierdata.get_photoiontargetfractions(dfenergy_levels, dfenergy_levels_upperion, targetconfigs)
+
+    # one entry only, with the three fractions added, and not the same target three times
+    assert targetlist == [[(0, 1.0)]]
+
+
+def test_get_photoiontargetfractions_shares_a_target_over_its_j_levels():
+    """A matched configuration is still split over its J levels by statistical weight."""
+    from artisatomic import readhillierdata
+
+    dfenergy_levels = pl.DataFrame({"levelid": [0], "levelname": ["2s2_2p4_3Pe[2]"], "g": [5.0]})
+    dfenergy_levels_upperion = pl.DataFrame(
+        {
+            "levelid": [0, 1, 2],
+            "levelname": ["2s2_2p3_4So[3/2]", "2s2_2p3_2Do[5/2]", "2s2_2p3_2Do[3/2]"],
+            "g": [4.0, 6.0, 4.0],
+        }
+    )
+    targetconfigs: list[list[tuple[str, float]] | None] = [[("2s2_2p3_2Do", 1.0)]]
+
+    targetlist = readhillierdata.get_photoiontargetfractions(dfenergy_levels, dfenergy_levels_upperion, targetconfigs)
+
+    assert targetlist == [[(1, 0.6), (2, 0.4)]]
+
+
+def test_write_phixs_data_rejects_a_duplicated_target():
+    """A target level that occurs two times would give the same target two fractions in ARTIS."""
+    import argparse
+
+    from artisatomic import write_phixs_data
+
+    args = argparse.Namespace(optimaltemperature=3000, nphixspoints=2, phixsnuincrement=0.1)
+    crosssections = np.array([[1.0, 0.5]])
+    targetfractions = [[(0, 0.4), (1, 0.3), (0, 0.3)]]  # target level 0 occurs two times
+    thresholds = np.array([13.6])
+
+    out = io.StringIO()
+    with pytest.raises(ValueError, match="occur more than one time"):
+        write_phixs_data(out, 8, 1, crosssections, targetfractions, thresholds, args, io.StringIO())
+
+    # the level fails before any part of the ion goes out
+    assert not out.getvalue()
+
+
 def test_log_degenerate_transitions():
     """ARTIS drops a transition whose two levels have one energy, so artisatomic reports it."""
     from artisatomic.output import log_degenerate_transitions

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -1642,6 +1642,25 @@ def test_get_photoiontargetfractions_keeps_the_ground_state_for_a_different_term
     assert targetlist == [[(0, 1.0)]]
 
 
+def test_get_photoiontargetfractions_rejects_an_ambiguous_stripped_match():
+    """Two upper ion names that differ in their separators alone give no target that can be shared."""
+    from artisatomic import readhillierdata
+
+    dfenergy_levels = pl.DataFrame({"levelid": [0], "levelname": ["3d7_a4Fe[9/2]"], "g": [10.0]})
+    # the two names are different levels, but they become one string with the separators removed
+    dfenergy_levels_upperion = pl.DataFrame(
+        {
+            "levelid": [0, 1],
+            "levelname": ["3d6(5D)4s_a6De[9/2]", "3d6_5D_4s_a6De[9/2]"],
+            "g": [10.0, 10.0],
+        }
+    )
+    targetconfigs: list[list[tuple[str, float]] | None] = [[("3d6(5D)4sa6De", 1.0)]]
+
+    with pytest.raises(ValueError, match="matched more than one level name"):
+        readhillierdata.get_photoiontargetfractions(dfenergy_levels, dfenergy_levels_upperion, targetconfigs)
+
+
 def test_strip_name_separators():
     """The underscore and the parentheses go; nothing else changes."""
     from artisatomic.readhillierdata import strip_name_separators

--- a/artisatomic/test_artisatomic.py
+++ b/artisatomic/test_artisatomic.py
@@ -1545,25 +1545,23 @@ def test_write_phixs_data_keeps_a_table_with_no_threshold():
 
 
 def test_get_photoiontargetfractions_merges_targets_that_match_one_level():
-    """F II names three routes, of which two match no F III level name and fall back to the ground state."""
+    """A matched route and a route that falls back to the ground state can come to the same level."""
     from artisatomic import readhillierdata
 
-    dfenergy_levels = pl.DataFrame({"levelid": [0], "levelname": ["2s2_2p4_3Pe[2]"], "g": [5.0]})
+    dfenergy_levels = pl.DataFrame({"levelid": [0], "levelname": ["3s2_3p6_4s_2Se[1/2]"], "g": [2.0]})
     dfenergy_levels_upperion = pl.DataFrame(
         {
-            "levelid": [0, 1, 2],
-            "levelname": ["2s2_2p3_4So[3/2]", "2s2_2p3_2Do[5/2]", "2s2_2p3_2Do[3/2]"],
-            "g": [4.0, 6.0, 4.0],
+            "levelid": [0, 1],
+            "levelname": ["3s2_3p6_1Se[0]", "3s2_3p5_4s_3Po[2]"],
+            "g": [1.0, 5.0],
         }
     )
-    # the second and the third route carry the parentheses that the level names do not have
-    targetconfigs: list[list[tuple[str, float]] | None] = [
-        [("2s2_2p3_4So", 0.5), ("2s2_2p3(2Do)", 0.3), ("2s2_2p3(2Po)", 0.2)]
-    ]
+    # the first route matches the ground state, and the second matches nothing and falls back to it
+    targetconfigs: list[list[tuple[str, float]] | None] = [[("3s2_3p6_1Se", 0.7), ("3s2_3p6_1So", 0.3)]]
 
     targetlist = readhillierdata.get_photoiontargetfractions(dfenergy_levels, dfenergy_levels_upperion, targetconfigs)
 
-    # one entry only, with the three fractions added, and not the same target three times
+    # one entry only, with the two fractions added, and not the same target two times
     assert targetlist == [[(0, 1.0)]]
 
 
@@ -1584,6 +1582,76 @@ def test_get_photoiontargetfractions_shares_a_target_over_its_j_levels():
     targetlist = readhillierdata.get_photoiontargetfractions(dfenergy_levels, dfenergy_levels_upperion, targetconfigs)
 
     assert targetlist == [[(1, 0.6), (2, 0.4)]]
+
+
+def test_get_photoiontargetfractions_matches_a_parenthesised_target():
+    """F II names '2s2_2p3(2Do)' where F III has '2s2_2p3_2Do', so the separators must not decide."""
+    from artisatomic import readhillierdata
+
+    dfenergy_levels = pl.DataFrame({"levelid": [0], "levelname": ["2s2_2p4_3Pe[2]"], "g": [5.0]})
+    dfenergy_levels_upperion = pl.DataFrame(
+        {
+            "levelid": [0, 1, 2],
+            "levelname": ["2s2_2p3_4So[3/2]", "2s2_2p3_2Do[5/2]", "2s2_2p3_2Do[3/2]"],
+            "g": [4.0, 6.0, 4.0],
+        }
+    )
+    targetconfigs: list[list[tuple[str, float]] | None] = [[("2s2_2p3(2Do)", 1.0)]]
+
+    targetlist = readhillierdata.get_photoiontargetfractions(dfenergy_levels, dfenergy_levels_upperion, targetconfigs)
+
+    # the two J levels of 2Do, by statistical weight, and not the ground state fallback
+    assert targetlist == [[(1, 0.6), (2, 0.4)]]
+
+
+def test_get_photoiontargetfractions_matches_a_target_with_no_separators():
+    """O IV names '2s2p3Po' where O V has '2s_2p_3Po'."""
+    from artisatomic import readhillierdata
+
+    dfenergy_levels = pl.DataFrame({"levelid": [0], "levelname": ["2s2_2p_2Po[1/2]"], "g": [2.0]})
+    dfenergy_levels_upperion = pl.DataFrame(
+        {
+            "levelid": [0, 1],
+            "levelname": ["2s2_1Se[0]", "2s_2p_3Po[1]"],
+            "g": [1.0, 3.0],
+        }
+    )
+    targetconfigs: list[list[tuple[str, float]] | None] = [[("2s2p3Po", 1.0)]]
+
+    targetlist = readhillierdata.get_photoiontargetfractions(dfenergy_levels, dfenergy_levels_upperion, targetconfigs)
+
+    assert targetlist == [[(1, 1.0)]]
+
+
+def test_get_photoiontargetfractions_keeps_the_ground_state_for_a_different_term():
+    """K I names '3s2_3p6_1So' where K II has '3s2_3p6_1Se'. The parity differs, so it must not match."""
+    from artisatomic import readhillierdata
+
+    dfenergy_levels = pl.DataFrame({"levelid": [0], "levelname": ["3s2_3p6_4s_2Se[1/2]"], "g": [2.0]})
+    dfenergy_levels_upperion = pl.DataFrame(
+        {
+            "levelid": [0, 1],
+            "levelname": ["3s2_3p6_1Se[0]", "3s2_3p5_4s_3Po[2]"],
+            "g": [1.0, 5.0],
+        }
+    )
+    targetconfigs: list[list[tuple[str, float]] | None] = [[("3s2_3p6_1So", 1.0)]]
+
+    targetlist = readhillierdata.get_photoiontargetfractions(dfenergy_levels, dfenergy_levels_upperion, targetconfigs)
+
+    assert targetlist == [[(0, 1.0)]]
+
+
+def test_strip_name_separators():
+    """The underscore and the parentheses go; nothing else changes."""
+    from artisatomic.readhillierdata import strip_name_separators
+
+    assert strip_name_separators("2s2_2p3(2Do)") == "2s22p32Do"
+    assert strip_name_separators("2s2_2p3_2Do") == "2s22p32Do"
+    assert strip_name_separators("3d6(5D)4sa6De") == "3d65D4sa6De"
+    assert strip_name_separators("3d6(5D)4s_a6De") == "3d65D4sa6De"
+    # a different term stays different
+    assert strip_name_separators("3s2_3p6_1So") != strip_name_separators("3s2_3p6_1Se")
 
 
 def test_write_phixs_data_rejects_a_duplicated_target():

--- a/tests/cmfgen/checksums.txt
+++ b/tests/cmfgen/checksums.txt
@@ -1,4 +1,4 @@
 645670e5c562d48e9b7a2f092cd3dccf  adata.txt
 3317c6dfe823400481ca656b42fe4210  compositiondata.txt
-da34698f25687f343b316aba6005d98d  phixsdata_v2.txt
+ea76ab56eee7a0555d6a68389edfa021  phixsdata_v2.txt
 4ea8f60d9ad25a3123365bc70e24bbff  transitiondata.txt

--- a/tests/cmfgen_lowz/checksums.txt
+++ b/tests/cmfgen_lowz/checksums.txt
@@ -1,4 +1,4 @@
 0d5755fa720eadc8cb1ce98ece0a596c  adata.txt
 5fbbc0dc9cf13e66a15caf576650a408  compositiondata.txt
-f9b88e11a76734bde10262fe12843362  phixsdata_v2.txt
+73228975424107b87fdc210ec5446a87  phixsdata_v2.txt
 a4c07e3ded1f523e6f9b2e079a09340c  transitiondata.txt

--- a/tests/cmfgen_lowz/checksums.txt
+++ b/tests/cmfgen_lowz/checksums.txt
@@ -1,4 +1,4 @@
 0d5755fa720eadc8cb1ce98ece0a596c  adata.txt
 5fbbc0dc9cf13e66a15caf576650a408  compositiondata.txt
-7f19ef7c99bed70bc94a04e0b739ab30  phixsdata_v2.txt
+f9b88e11a76734bde10262fe12843362  phixsdata_v2.txt
 a4c07e3ded1f523e6f9b2e079a09340c  transitiondata.txt


### PR DESCRIPTION
Stacked on artis-mcrt/artisatomic#93. Review that one first; this PR targets its branch, so the diff here is only the second commit.

A phot file does not always separate the parts of a target name the way the oscillator file of the upper ion does. Each of these matched no level, so the ground state became the target:

| ion | the phot file names | the upper ion has |
|---|---|---|
| F II | `2s2_2p3(2Do)`, `2s2_2p3(2Po)` | `2s2_2p3_2Do`, `2s2_2p3_2Po` |
| O IV | `2s2p3Po` | `2s_2p_3Po` |
| Fe I | `3d6(5D)4sa6De` | `3d6(5D)4s_a6De` |

## The fix

A name that matches no level is compared again with the underscores and the parentheses removed. The exact comparison comes first, so a name that already matched keeps its target and nothing else moves.

I checked the rule over the whole CMFGEN corpus. Six target configurations match no level. Four of them are the table above. No two level names of one ion become the same string under the comparison, so it adds no false match.

## The two that keep the ground state

Both are correct there, so neither is forced:

- **O IV `2s2s1Se`** writes the shell count of O V's ground state `2s2_1Se` in a different way. The fallback already gives that level.
- **K I `3s2_3p6_1So`** gives an odd parity term where K II's closed shell ground state `3s2_3p6_1Se` is even. The two terms are not the same, so a match would need parity to be ignored, which would be wrong in general. The fallback gives the intended level anyway.

`get_photoiontargetfractions()` now reports both the second comparison and a target that matches nothing at all, so neither is silent.

## Output

The `phixsdata_v2.txt` checksums of the `cmfgen` and `cmfgen_lowz` sets change. `adata.txt` and `transitiondata.txt` do not, and the other five sets are byte-identical.

- **F II** gets its three routes (F III levels 1, 2 and 3 at 0.5, 0.3 and 0.2) in place of the ground state alone.
- **Fe I** gets a share over the J levels of `3d6(5D)4s_a6De` by statistical weight, in place of the lowest of them.

O IV is the top ion of the `cmfgen` set, so its fix does not reach the output there. A unit test covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)